### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/redis-developer/redis-cloud-rs/compare/v0.8.0...v0.9.0) - 2026-01-30
+
+### Added
+
+- update Python bindings with new methods and add tests ([#33](https://github.com/redis-developer/redis-cloud-rs/pull/33))
+
+### Fixed
+
+- use Link type instead of HashMap for HATEOAS links ([#28](https://github.com/redis-developer/redis-cloud-rs/pull/28))
+- address multiple bugs in client and cost_report modules ([#25](https://github.com/redis-developer/redis-cloud-rs/pull/25))
+- add README to PyPI package ([#3](https://github.com/redis-developer/redis-cloud-rs/pull/3))
+
+### Other
+
+- code cleanup and add examples ([#42](https://github.com/redis-developer/redis-cloud-rs/pull/42))
+- align Rust types with Go client (rediscloud-go-api) ([#41](https://github.com/redis-developer/redis-cloud-rs/pull/41))
+- add dependency audit and code coverage ([#34](https://github.com/redis-developer/redis-cloud-rs/pull/34))
+- reduce VPC peering duplication and add pagination helpers ([#32](https://github.com/redis-developer/redis-cloud-rs/pull/32))
+- fix README examples and add handler method documentation ([#31](https://github.com/redis-developer/redis-cloud-rs/pull/31))
+- API cleanup and ergonomic improvements ([#30](https://github.com/redis-developer/redis-cloud-rs/pull/30))
+- improve type safety for response and request types ([#29](https://github.com/redis-developer/redis-cloud-rs/pull/29))
+- consolidate duplicate ProcessorResponse and error handling ([#26](https://github.com/redis-developer/redis-cloud-rs/pull/26))
+
 ## [0.8.0](https://github.com/redis-developer/redis-cloud-rs/compare/v0.7.6...v0.8.0) - 2026-01-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)

### ⚠ `redis-cloud` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FixedDatabase.enable_default_user in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:408
  field FixedDatabase.enable_tls in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:412
  field FixedDatabase.password in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:416
  field FixedDatabase.source_ips in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:420
  field FixedDatabase.ssl_client_authentication in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:424
  field FixedDatabase.tls_client_authentication in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:428
  field FixedDatabase.replica in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:432
  field FixedDatabase.clustering_enabled in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:436
  field FixedDatabase.regex_rules in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:440
  field FixedDatabase.hashing_policy in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:444
  field FixedDatabase.modules in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:448
  field FixedDatabase.alerts in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:452
  field FixedDatabase.backup in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:456
  field FixedDatabase.enable_default_user in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:408
  field FixedDatabase.enable_tls in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:412
  field FixedDatabase.password in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:416
  field FixedDatabase.source_ips in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:420
  field FixedDatabase.ssl_client_authentication in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:424
  field FixedDatabase.tls_client_authentication in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:428
  field FixedDatabase.replica in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:432
  field FixedDatabase.clustering_enabled in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:436
  field FixedDatabase.regex_rules in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:440
  field FixedDatabase.hashing_policy in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:444
  field FixedDatabase.modules in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:448
  field FixedDatabase.alerts in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:452
  field FixedDatabase.backup in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:456
  field Database.active_active_redis in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:880
  field Database.memory_storage in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:884
  field Database.redis_version_compliance in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:888
  field Database.auto_minor_version_upgrade in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:892
  field Database.number_of_shards in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:896
  field Database.regex_rules in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:900
  field Database.ssl_client_authentication in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:904
  field Database.tls_client_authentication in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:908
  field Database.active_active_redis in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:880
  field Database.memory_storage in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:884
  field Database.redis_version_compliance in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:888
  field Database.auto_minor_version_upgrade in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:892
  field Database.number_of_shards in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:896
  field Database.regex_rules in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:900
  field Database.ssl_client_authentication in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:904
  field Database.tls_client_authentication in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/databases.rs:908
  field Module.parameters in /tmp/.tmpSrbip3/redis-cloud-rs/src/account.rs:281
  field Subscription.storage_encryption in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/subscriptions.rs:610
  field Subscription.public_endpoint_access in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/subscriptions.rs:614
  field Subscription.storage_encryption in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/subscriptions.rs:610
  field Subscription.public_endpoint_access in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/subscriptions.rs:614
  field ReplicaOfSpec.description in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:268
  field ReplicaOfSpec.description in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/databases.rs:268
  field PaymentMethods.payment_methods in /tmp/.tmpSrbip3/redis-cloud-rs/src/account.rs:223
  field ProcessorResponse.additional_info in /tmp/.tmpSrbip3/redis-cloud-rs/src/types.rs:80
  field AccountUsers.users in /tmp/.tmpSrbip3/redis-cloud-rs/src/users.rs:86
  field AccountUsers.links in /tmp/.tmpSrbip3/redis-cloud-rs/src/users.rs:90
  field AccountSystemLogEntry.resource_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/account.rs:178
  field FixedSubscriptions.subscriptions in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/subscriptions.rs:219
  field FixedSubscriptions.subscriptions in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/subscriptions.rs:219
  field SubscriptionPricing.database_name in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/subscriptions.rs:260
  field SubscriptionPricing.database_name in /tmp/.tmpSrbip3/redis-cloud-rs/src/flexible/subscriptions.rs:260
  field FixedSubscriptionsPlan.supported_alerts in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/subscriptions.rs:178
  field FixedSubscriptionsPlan.supported_alerts in /tmp/.tmpSrbip3/redis-cloud-rs/src/fixed/subscriptions.rs:178
  field VpcPeeringCreateRequest.vpc_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:21
  field VpcPeeringCreateRequest.aws_region in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:25
  field VpcPeeringCreateRequest.aws_account_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:29
  field VpcPeeringCreateRequest.vpc_cidr in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:33
  field VpcPeeringCreateRequest.vpc_cidrs in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:37
  field VpcPeeringCreateRequest.gcp_project_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:41
  field VpcPeeringCreateRequest.network_name in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:45
  field VpcPeeringCreateRequest.vpc_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:21
  field VpcPeeringCreateRequest.aws_region in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:25
  field VpcPeeringCreateRequest.aws_account_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:29
  field VpcPeeringCreateRequest.vpc_cidr in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:33
  field VpcPeeringCreateRequest.vpc_cidrs in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:37
  field VpcPeeringCreateRequest.gcp_project_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:41
  field VpcPeeringCreateRequest.network_name in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:45
  field VpcPeeringCreateRequest.vpc_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:21
  field VpcPeeringCreateRequest.aws_region in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:25
  field VpcPeeringCreateRequest.aws_account_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:29
  field VpcPeeringCreateRequest.vpc_cidr in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:33
  field VpcPeeringCreateRequest.vpc_cidrs in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:37
  field VpcPeeringCreateRequest.gcp_project_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:41
  field VpcPeeringCreateRequest.network_name in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:45
  field VpcPeeringCreateRequest.vpc_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:21
  field VpcPeeringCreateRequest.aws_region in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:25
  field VpcPeeringCreateRequest.aws_account_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:29
  field VpcPeeringCreateRequest.vpc_cidr in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:33
  field VpcPeeringCreateRequest.vpc_cidrs in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:37
  field VpcPeeringCreateRequest.gcp_project_id in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:41
  field VpcPeeringCreateRequest.network_name in /tmp/.tmpSrbip3/redis-cloud-rs/src/connectivity/vpc_peering.rs:45
  field Region.id in /tmp/.tmpSrbip3/redis-cloud-rs/src/account.rs:203
  field AccountUser.links in /tmp/.tmpSrbip3/redis-cloud-rs/src/users.rs:167
  field RootAccount.account in /tmp/.tmpSrbip3/redis-cloud-rs/src/account.rs:71

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  FixedSubscriptionHandler::create_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:560
  FixedSubscriptionHandler::get_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:571
  FixedSubscriptionHandler::update_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:581
  FixedSubscriptionHandler::delete_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:593
  FixedSubscriptionHandler::get_all_fixed_subscriptions_plans, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:601
  FixedSubscriptionHandler::get_fixed_subscriptions_plans_by_subscription_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:609
  FixedSubscriptionHandler::get_fixed_subscriptions_plan_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:620
  FixedSubscriptionHandler::get_fixed_redis_versions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:631
  FixedSubscriptionHandler::get_all_fixed_subscriptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:639
  FixedSubscriptionHandler::delete_fixed_subscription_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:647
  FixedSubscriptionHandler::get_fixed_subscription_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:658
  FixedSubscriptionHandler::create_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:560
  FixedSubscriptionHandler::get_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:571
  FixedSubscriptionHandler::update_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:581
  FixedSubscriptionHandler::delete_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:593
  FixedSubscriptionHandler::get_all_fixed_subscriptions_plans, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:601
  FixedSubscriptionHandler::get_fixed_subscriptions_plans_by_subscription_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:609
  FixedSubscriptionHandler::get_fixed_subscriptions_plan_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:620
  FixedSubscriptionHandler::get_fixed_redis_versions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:631
  FixedSubscriptionHandler::get_all_fixed_subscriptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:639
  FixedSubscriptionHandler::delete_fixed_subscription_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:647
  FixedSubscriptionHandler::get_fixed_subscription_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:658
  FixedSubscriptionHandler::create_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:560
  FixedSubscriptionHandler::get_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:571
  FixedSubscriptionHandler::update_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:581
  FixedSubscriptionHandler::delete_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:593
  FixedSubscriptionHandler::get_all_fixed_subscriptions_plans, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:601
  FixedSubscriptionHandler::get_fixed_subscriptions_plans_by_subscription_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:609
  FixedSubscriptionHandler::get_fixed_subscriptions_plan_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:620
  FixedSubscriptionHandler::get_fixed_redis_versions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:631
  FixedSubscriptionHandler::get_all_fixed_subscriptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:639
  FixedSubscriptionHandler::delete_fixed_subscription_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:647
  FixedSubscriptionHandler::get_fixed_subscription_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:658
  FixedSubscriptionHandler::create_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:560
  FixedSubscriptionHandler::get_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:571
  FixedSubscriptionHandler::update_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:581
  FixedSubscriptionHandler::delete_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:593
  FixedSubscriptionHandler::get_all_fixed_subscriptions_plans, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:601
  FixedSubscriptionHandler::get_fixed_subscriptions_plans_by_subscription_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:609
  FixedSubscriptionHandler::get_fixed_subscriptions_plan_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:620
  FixedSubscriptionHandler::get_fixed_redis_versions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:631
  FixedSubscriptionHandler::get_all_fixed_subscriptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:639
  FixedSubscriptionHandler::delete_fixed_subscription_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:647
  FixedSubscriptionHandler::get_fixed_subscription_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:658
  FixedSubscriptionHandler::create_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:560
  FixedSubscriptionHandler::get_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:571
  FixedSubscriptionHandler::update_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:581
  FixedSubscriptionHandler::delete_fixed_subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:593
  FixedSubscriptionHandler::get_all_fixed_subscriptions_plans, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:601
  FixedSubscriptionHandler::get_fixed_subscriptions_plans_by_subscription_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:609
  FixedSubscriptionHandler::get_fixed_subscriptions_plan_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:620
  FixedSubscriptionHandler::get_fixed_redis_versions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:631
  FixedSubscriptionHandler::get_all_fixed_subscriptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:639
  FixedSubscriptionHandler::delete_fixed_subscription_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:647
  FixedSubscriptionHandler::get_fixed_subscription_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:658
  FixedDatabaseHandler::create_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1054
  FixedDatabaseHandler::get_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1066
  FixedDatabaseHandler::update_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1080
  FixedDatabaseHandler::delete_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1093
  FixedDatabaseHandler::backup_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1105
  FixedDatabaseHandler::get_fixed_subscription_databases, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1118
  FixedDatabaseHandler::fixed_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1131
  FixedDatabaseHandler::get_fixed_subscription_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1143
  FixedDatabaseHandler::delete_fixed_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1155
  FixedDatabaseHandler::import_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1167
  FixedDatabaseHandler::create_fixed_database_tag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1180
  FixedDatabaseHandler::get_fixed_database_tags, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1193
  FixedDatabaseHandler::create_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1054
  FixedDatabaseHandler::get_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1066
  FixedDatabaseHandler::update_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1080
  FixedDatabaseHandler::delete_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1093
  FixedDatabaseHandler::backup_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1105
  FixedDatabaseHandler::get_fixed_subscription_databases, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1118
  FixedDatabaseHandler::fixed_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1131
  FixedDatabaseHandler::get_fixed_subscription_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1143
  FixedDatabaseHandler::delete_fixed_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1155
  FixedDatabaseHandler::import_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1167
  FixedDatabaseHandler::create_fixed_database_tag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1180
  FixedDatabaseHandler::get_fixed_database_tags, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1193
  FixedDatabaseHandler::create_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1054
  FixedDatabaseHandler::get_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1066
  FixedDatabaseHandler::update_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1080
  FixedDatabaseHandler::delete_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1093
  FixedDatabaseHandler::backup_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1105
  FixedDatabaseHandler::get_fixed_subscription_databases, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1118
  FixedDatabaseHandler::fixed_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1131
  FixedDatabaseHandler::get_fixed_subscription_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1143
  FixedDatabaseHandler::delete_fixed_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1155
  FixedDatabaseHandler::import_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1167
  FixedDatabaseHandler::create_fixed_database_tag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1180
  FixedDatabaseHandler::get_fixed_database_tags, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1193
  FixedDatabaseHandler::create_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1054
  FixedDatabaseHandler::get_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1066
  FixedDatabaseHandler::update_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1080
  FixedDatabaseHandler::delete_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1093
  FixedDatabaseHandler::backup_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1105
  FixedDatabaseHandler::get_fixed_subscription_databases, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1118
  FixedDatabaseHandler::fixed_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1131
  FixedDatabaseHandler::get_fixed_subscription_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1143
  FixedDatabaseHandler::delete_fixed_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1155
  FixedDatabaseHandler::import_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1167
  FixedDatabaseHandler::create_fixed_database_tag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1180
  FixedDatabaseHandler::get_fixed_database_tags, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1193
  FixedDatabaseHandler::create_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1054
  FixedDatabaseHandler::get_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1066
  FixedDatabaseHandler::update_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1080
  FixedDatabaseHandler::delete_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1093
  FixedDatabaseHandler::backup_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1105
  FixedDatabaseHandler::get_fixed_subscription_databases, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1118
  FixedDatabaseHandler::fixed_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1131
  FixedDatabaseHandler::get_fixed_subscription_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1143
  FixedDatabaseHandler::delete_fixed_database_by_id, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1155
  FixedDatabaseHandler::import_fixed_database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1167
  FixedDatabaseHandler::create_fixed_database_tag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1180
  FixedDatabaseHandler::get_fixed_database_tags, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:1193

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct redis_cloud::cloud_accounts::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/cloud_accounts.rs:220
  struct redis_cloud::users::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/users.rs:97
  struct redis_cloud::tasks::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/tasks.rs:72
  struct redis_cloud::fixed::databases::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:100
  struct redis_cloud::fixed_databases::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:100
  struct redis_cloud::flexible::subscriptions::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:398
  struct redis_cloud::subscriptions::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:398
  struct redis_cloud::flexible::databases::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:90
  struct redis_cloud::databases::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:90
  struct redis_cloud::acl::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:73
  struct redis_cloud::fixed::subscriptions::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:88
  struct redis_cloud::fixed_subscriptions::ProcessorResponse, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:88

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field extra of struct BdbVersionUpgradeStatus, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:301
  field extra of struct BdbVersionUpgradeStatus, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:301
  field extra of struct CloudAccounts, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/cloud_accounts.rs:214
  field extra of struct AclRoleUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:309
  field extra of struct AccountUserUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/users.rs:80
  field extra of struct AccountSessionLogEntries, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:281
  field extra of struct ActiveActiveRegionToDelete, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:788
  field extra of struct ActiveActiveRegionToDelete, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:788
  field extra of struct AccountACLRedisRules, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:160
  field extra of struct CustomerManagedKey, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:138
  field extra of struct CustomerManagedKey, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:138
  field extra of struct DatabaseTagsUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:195
  field extra of struct DatabaseTagsUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:195
  field extra of struct TasksStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/types.rs:103
  field extra of struct Module, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:172
  field extra of struct DatabaseAlertSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:718
  field extra of struct DatabaseAlertSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:718
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:519
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:519
  field extra of struct DatabaseTagUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:153
  field extra of struct DatabaseTagUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:153
  field extra of struct DataPersistenceOptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:266
  field extra of struct CustomerManagedKeyAccessDetails, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:443
  field extra of struct CustomerManagedKeyAccessDetails, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:443
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:407
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:407
  field extra of struct SubscriptionSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:122
  field extra of struct SubscriptionSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:122
  field extra of struct FixedSubscriptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:264
  field extra of struct FixedSubscriptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:264
  field extra of struct MaintenanceWindow, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:577
  field extra of struct MaintenanceWindow, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:577
  field extra of struct DatabaseTagCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:297
  field extra of struct DatabaseTagCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:297
  field extra of struct LocalThroughput, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:129
  field extra of struct LocalThroughput, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:129
  field extra of struct ModulesData, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:67
  field extra of struct AclUserUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:114
  field extra of struct FixedDatabaseUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:733
  field extra of struct FixedDatabaseUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:733
  field extra of struct AclRoleDatabaseSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:241
  field extra of struct MaintenanceWindowSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:676
  field extra of struct MaintenanceWindowSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:676
  field extra of struct DynamicEndpoints, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:156
  field extra of struct DynamicEndpoints, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:156
  field extra of struct DatabaseSlowLogEntry, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:273
  field extra of struct DatabaseSlowLogEntry, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:273
  field extra of struct Database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:704
  field extra of struct Database, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:704
  field extra of struct DataPersistenceEntry, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:250
  field extra of struct FixedSubscriptionCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:248
  field extra of struct FixedSubscriptionCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:248
  field extra of struct CrdbUpdatePropertiesRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:379
  field extra of struct CrdbUpdatePropertiesRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:379
  field extra of struct FixedSubscriptionsPlan, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:222
  field extra of struct FixedSubscriptionsPlan, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:222
  field extra of struct SubscriptionRegionNetworkingSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:538
  field extra of struct SubscriptionRegionNetworkingSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:538
  field extra of struct DatabaseTagUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:142
  field extra of struct DatabaseTagUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:142
  field extra of struct SearchScalingFactorsData, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:203
  field extra of struct AccountACLRoles, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:201
  field extra of struct AccountUsers, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/users.rs:91
  field extra of struct Region, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:138
  field extra of struct AccountSessionLogEntry, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:236
  field extra of struct FixedDatabaseImportRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:94
  field extra of struct FixedDatabaseImportRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:94
  field extra of struct AccountFixedSubscriptionDatabases, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:70
  field extra of struct AccountFixedSubscriptionDatabases, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:70
  field extra of struct RedisVersion, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:285
  field extra of struct RedisVersion, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:285
  field extra of struct AccountSystemLogEntries, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:187
  field extra of struct Subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:658
  field extra of struct Subscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:658
  field extra of struct CrdbFlushRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:189
  field extra of struct CrdbFlushRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:189
  field extra of struct Regions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:124
  field extra of struct CostReportCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/cost_report.rs:175
  field extra of struct CostReportCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/cost_report.rs:175
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/cloud_accounts.rs:269
  field extra of struct TgwUpdateCidrsRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/transit_gateway.rs:35
  field extra of struct TgwUpdateCidrsRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/transit_gateway.rs:35
  field extra of struct DatabaseModuleSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:491
  field extra of struct DatabaseModuleSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:491
  field extra of struct DatabaseModuleSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:334
  field extra of struct DatabaseModuleSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:334
  field extra of struct ActiveActiveSubscriptionRegions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:306
  field extra of struct ActiveActiveSubscriptionRegions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:306
  field extra of struct RootAccount, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:79
  field extra of struct CloudAccount, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/cloud_accounts.rs:157
  field extra of struct ACLUser, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:286
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:1002
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:1002
  field extra of struct DatabaseThroughputSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:438
  field extra of struct DatabaseThroughputSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:438
  field extra of struct CloudAccountCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/cloud_accounts.rs:191
  field extra of struct SubscriptionPricing, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:339
  field extra of struct SubscriptionPricing, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:339
  field extra of struct Cidr, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/transit_gateway.rs:19
  field extra of struct Cidr, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/transit_gateway.rs:19
  field extra of struct CloudTags, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:376
  field extra of struct CloudTags, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:376
  field extra of struct DatabaseBackupConfig, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:476
  field extra of struct DatabaseBackupConfig, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:476
  field extra of struct FixedDatabaseBackupRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:319
  field extra of struct FixedDatabaseBackupRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:319
  field extra of struct AccountACLUsers, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:137
  field extra of struct AclUserCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:262
  field extra of struct MaintenanceWindowSkipStatus, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:290
  field extra of struct MaintenanceWindowSkipStatus, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:290
  field extra of struct DatabaseSyncSourceSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:243
  field extra of struct DatabaseSyncSourceSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:243
  field extra of struct FixedDatabaseCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:628
  field extra of struct FixedDatabaseCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:628
  field extra of struct LocalRegionProperties, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:971
  field extra of struct LocalRegionProperties, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:971
  field extra of struct DatabaseTagCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:424
  field extra of struct DatabaseTagCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:424
  field extra of struct SubscriptionCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:392
  field extra of struct SubscriptionCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:392
  field extra of struct PaymentMethods, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:154
  field extra of struct CloudTags, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:896
  field extra of struct CloudTags, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:896
  field extra of struct DatabaseSlowLogEntry, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:400
  field extra of struct DatabaseSlowLogEntry, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:400
  field extra of struct DatabaseAlertSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:360
  field extra of struct DatabaseAlertSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:360
  field extra of struct SubscriptionMaintenanceWindowsSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:275
  field extra of struct SubscriptionMaintenanceWindowsSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:275
  field extra of struct RedisVersion, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:559
  field extra of struct RedisVersion, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:559
  field extra of struct AccountUserOptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/users.rs:136
  field extra of struct CloudTags, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/types.rs:124
  field extra of struct AclRedisRuleUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:222
  field extra of struct VpcPeeringUpdateAwsRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/vpc_peering.rs:52
  field extra of struct VpcPeeringUpdateAwsRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/vpc_peering.rs:52
  field extra of struct VpcPeeringUpdateAwsRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/vpc_peering.rs:52
  field extra of struct VpcPeeringUpdateAwsRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/vpc_peering.rs:52
  field extra of struct FixedSubscriptionUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:137
  field extra of struct FixedSubscriptionUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:137
  field extra of struct AccountSubscriptionDatabases, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:84
  field extra of struct AccountSubscriptionDatabases, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:84
  field extra of struct DatabaseBackupRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:529
  field extra of struct DatabaseBackupRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:529
  field extra of struct DatabaseCertificate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:202
  field extra of struct DatabaseCertificate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:202
  field extra of struct DatabaseImportRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:880
  field extra of struct DatabaseImportRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:880
  field extra of struct ActiveActiveRegionCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:741
  field extra of struct ActiveActiveRegionCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:741
  field extra of struct SubscriptionMaintenanceWindows, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:863
  field extra of struct SubscriptionMaintenanceWindows, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:863
  field extra of struct CrdbRegionSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:175
  field extra of struct CrdbRegionSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:175
  field extra of struct ReplicaOfSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:503
  field extra of struct ReplicaOfSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:503
  field extra of struct ReplicaOfSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:346
  field extra of struct ReplicaOfSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:346
  field extra of struct DatabaseCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:856
  field extra of struct DatabaseCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:856
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:355
  field extra of struct CloudAccountUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/cloud_accounts.rs:97
  field extra of struct DatabaseModuleSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:237
  field extra of struct DatabaseModuleSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:237
  field extra of struct AclRedisRuleCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:178
  field extra of struct LocalThroughput, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:159
  field extra of struct LocalThroughput, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:159
  field extra of struct DatabaseSyncSourceSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:215
  field extra of struct DatabaseSyncSourceSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:215
  field extra of struct CloudTag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:280
  field extra of struct CloudTag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:280
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:819
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:819
  field extra of struct RedisVersions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:70
  field extra of struct RedisVersions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:70
  field extra of struct DatabaseCertificateSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:255
  field extra of struct DatabaseCertificateSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:255
  field extra of struct DatabaseSlowLogEntries, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:932
  field extra of struct DatabaseSlowLogEntries, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:932
  field extra of struct DatabaseThroughputSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:222
  field extra of struct DatabaseThroughputSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:222
  field extra of struct Tag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:171
  field extra of struct Tag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:171
  field extra of struct AccountSystemLogEntry, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/account.rs:109
  field extra of struct SubscriptionDatabaseSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:513
  field extra of struct SubscriptionDatabaseSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:513
  field extra of struct SubscriptionRegionSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:842
  field extra of struct SubscriptionRegionSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:842
  field extra of struct DatabaseSlowLogEntries, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:488
  field extra of struct DatabaseSlowLogEntries, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:488
  field extra of struct Tag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:174
  field extra of struct Tag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:174
  field extra of struct DatabaseUpgradeRedisVersionRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:917
  field extra of struct DatabaseUpgradeRedisVersionRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:917
  field extra of struct ActiveActiveRegionDeleteRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:776
  field extra of struct ActiveActiveRegionDeleteRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:776
  field extra of struct FixedSubscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:376
  field extra of struct FixedSubscription, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:376
  field extra of struct SubscriptionPricings, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:208
  field extra of struct SubscriptionPricings, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:208
  field extra of struct DatabaseUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:1121
  field extra of struct DatabaseUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:1121
  field extra of struct RedisVersions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:753
  field extra of struct RedisVersions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:753
  field extra of struct AclRoleRedisRuleSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:324
  field extra of struct SubscriptionUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:102
  field extra of struct SubscriptionUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:102
  field extra of struct FixedDatabase, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:473
  field extra of struct FixedDatabase, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:473
  field extra of struct AccountSubscriptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:699
  field extra of struct AccountSubscriptions, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:699
  field extra of struct DatabaseTagsUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:223
  field extra of struct DatabaseTagsUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/databases.rs:223
  field extra of struct BaseSubscriptionUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:75
  field extra of struct BaseSubscriptionUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:75
  field extra of struct SubscriptionUpdateCMKRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:197
  field extra of struct SubscriptionUpdateCMKRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:197
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/tasks.rs:138
  field extra of struct TaskStateUpdate, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/users.rs:167
  field extra of struct CloudTag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:252
  field extra of struct CloudTag, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:252
  field extra of struct AclRoleCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/acl.rs:67
  field extra of struct VpcPeeringCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/vpc_peering.rs:22
  field extra of struct VpcPeeringCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/vpc_peering.rs:22
  field extra of struct VpcPeeringCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/vpc_peering.rs:22
  field extra of struct VpcPeeringCreateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/vpc_peering.rs:22
  field extra of struct DatabaseCertificateSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:227
  field extra of struct DatabaseCertificateSpec, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/databases.rs:227
  field extra of struct AccountUser, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/users.rs:200
  field extra of struct CidrAllowlistUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:260
  field extra of struct CidrAllowlistUpdateRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/flexible/subscriptions.rs:260
  field extra of struct FixedSubscriptionsPlans, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:82
  field extra of struct FixedSubscriptionsPlans, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/fixed/subscriptions.rs:82
  field extra of struct TgwAttachmentRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/transit_gateway.rs:56
  field extra of struct TgwAttachmentRequest, previously in file /tmp/.tmpVpmCk3/redis-cloud/src/connectivity/transit_gateway.rs:56
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/redis-developer/redis-cloud-rs/compare/v0.8.0...v0.9.0) - 2026-01-30

### Added

- update Python bindings with new methods and add tests ([#33](https://github.com/redis-developer/redis-cloud-rs/pull/33))

### Fixed

- use Link type instead of HashMap for HATEOAS links ([#28](https://github.com/redis-developer/redis-cloud-rs/pull/28))
- address multiple bugs in client and cost_report modules ([#25](https://github.com/redis-developer/redis-cloud-rs/pull/25))
- add README to PyPI package ([#3](https://github.com/redis-developer/redis-cloud-rs/pull/3))

### Other

- code cleanup and add examples ([#42](https://github.com/redis-developer/redis-cloud-rs/pull/42))
- align Rust types with Go client (rediscloud-go-api) ([#41](https://github.com/redis-developer/redis-cloud-rs/pull/41))
- add dependency audit and code coverage ([#34](https://github.com/redis-developer/redis-cloud-rs/pull/34))
- reduce VPC peering duplication and add pagination helpers ([#32](https://github.com/redis-developer/redis-cloud-rs/pull/32))
- fix README examples and add handler method documentation ([#31](https://github.com/redis-developer/redis-cloud-rs/pull/31))
- API cleanup and ergonomic improvements ([#30](https://github.com/redis-developer/redis-cloud-rs/pull/30))
- improve type safety for response and request types ([#29](https://github.com/redis-developer/redis-cloud-rs/pull/29))
- consolidate duplicate ProcessorResponse and error handling ([#26](https://github.com/redis-developer/redis-cloud-rs/pull/26))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).