### PR TITLE
refactor: consolidate duplicate ProcessorResponse and error handling

### DIFF
--- a/src/acl.rs
+++ b/src/acl.rs
@@ -40,6 +40,7 @@
 //! # }
 //! ```
 
+use crate::types::ProcessorResponse;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -61,30 +62,6 @@ pub struct AclRoleCreateRequest {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
-
-    /// Additional fields from the API
-    #[serde(flatten)]
-    pub extra: Value,
-}
-
-/// ProcessorResponse
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ProcessorResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource: Option<HashMap<String, Value>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_info: Option<String>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -165,6 +165,27 @@ impl CloudClient {
         format!("{}/{}", base, path)
     }
 
+    /// Convert HTTP status code and response text to appropriate error
+    ///
+    /// This is a helper to avoid duplicating the error handling pattern
+    /// across multiple methods.
+    fn status_to_error(status: reqwest::StatusCode, text: String) -> RestError {
+        match status.as_u16() {
+            400 => RestError::BadRequest { message: text },
+            401 => RestError::AuthenticationFailed { message: text },
+            403 => RestError::Forbidden { message: text },
+            404 => RestError::NotFound { message: text },
+            412 => RestError::PreconditionFailed,
+            429 => RestError::RateLimited { message: text },
+            500 => RestError::InternalServerError { message: text },
+            503 => RestError::ServiceUnavailable { message: text },
+            _ => RestError::ApiError {
+                code: status.as_u16(),
+                message: text,
+            },
+        }
+    }
+
     /// Make a GET request with API key authentication
     #[instrument(skip(self), fields(method = "GET"))]
     pub async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
@@ -258,21 +279,7 @@ impl CloudClient {
                 .text()
                 .await
                 .unwrap_or_else(|e| format!("(failed to read response body: {})", e));
-
-            match status.as_u16() {
-                400 => Err(RestError::BadRequest { message: text }),
-                401 => Err(RestError::AuthenticationFailed { message: text }),
-                403 => Err(RestError::Forbidden { message: text }),
-                404 => Err(RestError::NotFound { message: text }),
-                412 => Err(RestError::PreconditionFailed),
-                429 => Err(RestError::RateLimited { message: text }),
-                500 => Err(RestError::InternalServerError { message: text }),
-                503 => Err(RestError::ServiceUnavailable { message: text }),
-                _ => Err(RestError::ApiError {
-                    code: status.as_u16(),
-                    message: text,
-                }),
-            }
+            Err(Self::status_to_error(status, text))
         }
     }
 
@@ -312,21 +319,7 @@ impl CloudClient {
                 .text()
                 .await
                 .unwrap_or_else(|e| format!("(failed to read response body: {})", e));
-
-            match status.as_u16() {
-                400 => Err(RestError::BadRequest { message: text }),
-                401 => Err(RestError::AuthenticationFailed { message: text }),
-                403 => Err(RestError::Forbidden { message: text }),
-                404 => Err(RestError::NotFound { message: text }),
-                412 => Err(RestError::PreconditionFailed),
-                429 => Err(RestError::RateLimited { message: text }),
-                500 => Err(RestError::InternalServerError { message: text }),
-                503 => Err(RestError::ServiceUnavailable { message: text }),
-                _ => Err(RestError::ApiError {
-                    code: status.as_u16(),
-                    message: text,
-                }),
-            }
+            Err(Self::status_to_error(status, text))
         }
     }
 
@@ -395,21 +388,7 @@ impl CloudClient {
                 .text()
                 .await
                 .unwrap_or_else(|e| format!("(failed to read response body: {})", e));
-
-            match status.as_u16() {
-                400 => Err(RestError::BadRequest { message: text }),
-                401 => Err(RestError::AuthenticationFailed { message: text }),
-                403 => Err(RestError::Forbidden { message: text }),
-                404 => Err(RestError::NotFound { message: text }),
-                412 => Err(RestError::PreconditionFailed),
-                429 => Err(RestError::RateLimited { message: text }),
-                500 => Err(RestError::InternalServerError { message: text }),
-                503 => Err(RestError::ServiceUnavailable { message: text }),
-                _ => Err(RestError::ApiError {
-                    code: status.as_u16(),
-                    message: text,
-                }),
-            }
+            Err(Self::status_to_error(status, text))
         }
     }
 
@@ -464,21 +443,7 @@ impl CloudClient {
                 .text()
                 .await
                 .unwrap_or_else(|e| format!("(failed to read response body: {})", e));
-
-            match status_code {
-                400 => Err(RestError::BadRequest { message: text }),
-                401 => Err(RestError::AuthenticationFailed { message: text }),
-                403 => Err(RestError::Forbidden { message: text }),
-                404 => Err(RestError::NotFound { message: text }),
-                412 => Err(RestError::PreconditionFailed),
-                429 => Err(RestError::RateLimited { message: text }),
-                500 => Err(RestError::InternalServerError { message: text }),
-                503 => Err(RestError::ServiceUnavailable { message: text }),
-                _ => Err(RestError::ApiError {
-                    code: status_code,
-                    message: text,
-                }),
-            }
+            Err(Self::status_to_error(status, text))
         }
     }
 
@@ -511,21 +476,7 @@ impl CloudClient {
                 .text()
                 .await
                 .unwrap_or_else(|e| format!("(failed to read response body: {})", e));
-
-            match status.as_u16() {
-                400 => Err(RestError::BadRequest { message: text }),
-                401 => Err(RestError::AuthenticationFailed { message: text }),
-                403 => Err(RestError::Forbidden { message: text }),
-                404 => Err(RestError::NotFound { message: text }),
-                412 => Err(RestError::PreconditionFailed),
-                429 => Err(RestError::RateLimited { message: text }),
-                500 => Err(RestError::InternalServerError { message: text }),
-                503 => Err(RestError::ServiceUnavailable { message: text }),
-                _ => Err(RestError::ApiError {
-                    code: status.as_u16(),
-                    message: text,
-                }),
-            }
+            Err(Self::status_to_error(status, text))
         }
     }
 }

--- a/src/cloud_accounts.rs
+++ b/src/cloud_accounts.rs
@@ -53,6 +53,7 @@
 //! # }
 //! ```
 
+use crate::types::ProcessorResponse;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -210,30 +211,6 @@ pub struct CloudAccounts {
     pub links: Option<Vec<HashMap<String, Value>>>,
 
     /// Only for truly unknown/future API fields
-    #[serde(flatten)]
-    pub extra: Value,
-}
-
-/// ProcessorResponse
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ProcessorResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource: Option<HashMap<String, Value>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_info: Option<String>,
-
-    /// Additional fields from the API
     #[serde(flatten)]
     pub extra: Value,
 }

--- a/src/fixed/databases.rs
+++ b/src/fixed/databases.rs
@@ -45,6 +45,7 @@
 //! # }
 //! ```
 
+use crate::types::ProcessorResponse;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -88,30 +89,6 @@ pub struct FixedDatabaseImportRequest {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
-
-    /// Additional fields from the API
-    #[serde(flatten)]
-    pub extra: Value,
-}
-
-/// ProcessorResponse
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ProcessorResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource: Option<HashMap<String, Value>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_info: Option<String>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/fixed/subscriptions.rs
+++ b/src/fixed/subscriptions.rs
@@ -49,6 +49,7 @@
 //! # }
 //! ```
 
+use crate::types::ProcessorResponse;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -76,30 +77,6 @@ pub struct FixedSubscriptionsPlans {
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Vec<HashMap<String, Value>>>,
-
-    /// Additional fields from the API
-    #[serde(flatten)]
-    pub extra: Value,
-}
-
-/// ProcessorResponse
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ProcessorResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource: Option<HashMap<String, Value>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_info: Option<String>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -51,6 +51,7 @@
 //! # }
 //! ```
 
+use crate::types::ProcessorResponse;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -80,30 +81,6 @@ pub struct AccountSubscriptionDatabases {
     pub links: Option<Vec<HashMap<String, Value>>>,
 
     /// Only for truly unknown/future API fields
-    #[serde(flatten)]
-    pub extra: Value,
-}
-
-/// ProcessorResponse
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ProcessorResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource: Option<HashMap<String, Value>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_info: Option<String>,
-
-    /// Additional fields from the API
     #[serde(flatten)]
     pub extra: Value,
 }

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -51,6 +51,7 @@
 //! # }
 //! ```
 
+use crate::types::ProcessorResponse;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -386,30 +387,6 @@ pub struct SubscriptionCreateRequest {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
-
-    /// Additional fields from the API
-    #[serde(flatten)]
-    pub extra: Value,
-}
-
-/// ProcessorResponse
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ProcessorResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource: Option<HashMap<String, Value>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_info: Option<String>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -55,6 +55,7 @@
 //! # }
 //! ```
 
+use crate::types::ProcessorResponse;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -63,37 +64,6 @@ use std::collections::HashMap;
 // ============================================================================
 // Models
 // ============================================================================
-
-/// ProcessorResponse
-///
-/// Contains the result of an asynchronous operation
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ProcessorResponse {
-    /// ID of the created/modified resource
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource_id: Option<i32>,
-
-    /// Additional resource ID (for operations creating multiple resources)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_resource_id: Option<i32>,
-
-    /// Full resource object for the created/modified resource
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource: Option<HashMap<String, Value>>,
-
-    /// Error message if the operation failed
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-
-    /// Additional information about the operation
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_info: Option<String>,
-
-    /// Only for truly unknown/future API fields
-    #[serde(flatten)]
-    pub extra: Value,
-}
 
 /// TaskStateUpdate
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -70,11 +70,19 @@ pub struct ProcessorResponse {
 
     /// The resource object itself
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource: Option<Value>,
+    pub resource: Option<std::collections::HashMap<String, Value>>,
 
-    /// Error code if the operation failed
+    /// Error message if the operation failed
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<ProcessorError>,
+    pub error: Option<String>,
+
+    /// Additional information about the operation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_info: Option<String>,
+
+    /// Additional fields from the API
+    #[serde(flatten)]
+    pub extra: Value,
 }
 
 /// ProcessorError - Subset of massive error enum for common errors

--- a/src/users.rs
+++ b/src/users.rs
@@ -49,6 +49,7 @@
 //! # }
 //! ```
 
+use crate::types::ProcessorResponse;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -85,30 +86,6 @@ pub struct AccountUserUpdateRequest {
 pub struct AccountUsers {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account: Option<i32>,
-
-    /// Additional fields from the API
-    #[serde(flatten)]
-    pub extra: Value,
-}
-
-/// ProcessorResponse
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ProcessorResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_resource_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource: Option<HashMap<String, Value>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_info: Option<String>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/tests/types_tests.rs
+++ b/tests/types_tests.rs
@@ -45,36 +45,44 @@ fn test_processor_response_with_error() {
         resource_id: None,
         additional_resource_id: None,
         resource: None,
-        error: Some(ProcessorError::Unauthorized),
+        error: Some("UNAUTHORIZED".to_string()),
+        additional_info: None,
+        extra: serde_json::Value::Null,
     };
 
     let json_str = serde_json::to_string(&response).unwrap();
     assert!(json_str.contains("\"UNAUTHORIZED\""));
 
     let parsed: ProcessorResponse = serde_json::from_str(&json_str).unwrap();
-    assert!(matches!(parsed.error, Some(ProcessorError::Unauthorized)));
+    assert_eq!(parsed.error, Some("UNAUTHORIZED".to_string()));
 }
 
 #[test]
 fn test_processor_response_with_resource() {
-    let resource_data = json!({
-        "databaseId": 12345,
-        "name": "my-database",
-        "status": "active"
-    });
+    use std::collections::HashMap;
+
+    let mut resource_data: HashMap<String, serde_json::Value> = HashMap::new();
+    resource_data.insert("databaseId".to_string(), json!(12345));
+    resource_data.insert("name".to_string(), json!("my-database"));
+    resource_data.insert("status".to_string(), json!("active"));
 
     let response = ProcessorResponse {
         resource_id: Some(12345),
         additional_resource_id: None,
         resource: Some(resource_data.clone()),
         error: None,
+        additional_info: None,
+        extra: serde_json::Value::Null,
     };
 
     let json_str = serde_json::to_string(&response).unwrap();
     let parsed: ProcessorResponse = serde_json::from_str(&json_str).unwrap();
 
     assert_eq!(parsed.resource_id, Some(12345));
-    assert_eq!(parsed.resource, Some(resource_data));
+    assert!(parsed.resource.is_some());
+    let parsed_resource = parsed.resource.unwrap();
+    assert_eq!(parsed_resource.get("databaseId"), Some(&json!(12345)));
+    assert_eq!(parsed_resource.get("name"), Some(&json!("my-database")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR addresses two code quality issues identified during the post-split cleanup:

- **#8** Consolidate duplicate ProcessorResponse definitions (was 9 copies, now 1)
- **#9** Consolidate duplicate error handling code in client.rs (was 5 copies, now 1 helper)

## Changes

### ProcessorResponse Consolidation (#8)

Removed duplicate `ProcessorResponse` struct definitions from:
- `src/acl.rs`
- `src/users.rs`
- `src/cloud_accounts.rs`
- `src/tasks.rs`
- `src/flexible/subscriptions.rs`
- `src/flexible/databases.rs`
- `src/fixed/subscriptions.rs`
- `src/fixed/databases.rs`

All modules now import `ProcessorResponse` from `src/types.rs`.

Updated the canonical definition in `types.rs` to be the superset of all variants:
- `resource: Option<HashMap<String, Value>>` (matches common pattern)
- `error: Option<String>` (simpler than ProcessorError enum)
- `additional_info: Option<String>` (was missing from types.rs)
- `extra: Value` with `#[serde(flatten)]` (for forward compatibility)

### Error Handling Consolidation (#9)

Added `status_to_error` helper function in `client.rs` to centralize HTTP status code to error conversion:

```rust
fn status_to_error(status: reqwest::StatusCode, text: String) -> RestError {
    match status.as_u16() {
        400 => RestError::BadRequest { message: text },
        401 => RestError::AuthenticationFailed { message: text },
        // ... etc
    }
}
```

Replaced 5 duplicate match statements with calls to this helper.

## Impact

- **Net reduction of ~224 lines** of duplicated code
- Easier maintenance - changes to error handling or ProcessorResponse only need to be made in one place
- Reduced risk of schema drift between duplicate definitions

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`

All tests pass.

## Related Issues

Closes #8, Closes #9