### PR TITLE
fix: use Link type instead of HashMap for HATEOAS links

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -43,10 +43,10 @@
 //! # }
 //! ```
 
+use crate::types::Link;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 // ============================================================================
 // Models
@@ -60,7 +60,7 @@ pub struct ModulesData {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -72,7 +72,7 @@ pub struct ModulesData {
 pub struct RootAccount {
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -117,7 +117,7 @@ pub struct Regions {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -147,7 +147,7 @@ pub struct PaymentMethods {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -180,7 +180,7 @@ pub struct AccountSystemLogEntries {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -196,7 +196,7 @@ pub struct SearchScalingFactorsData {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -259,7 +259,7 @@ pub struct DataPersistenceOptions {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -274,7 +274,7 @@ pub struct AccountSessionLogEntries {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -40,11 +40,10 @@
 //! # }
 //! ```
 
-use crate::types::ProcessorResponse;
+use crate::types::{Link, ProcessorResponse};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 // ============================================================================
 // Models
@@ -107,7 +106,7 @@ pub struct AccountACLUsers {
 
     /// HATEOAS links for API navigation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Only for truly unknown/future API fields
     #[serde(flatten)]
@@ -130,7 +129,7 @@ pub struct AccountACLRedisRules {
 
     /// HATEOAS links for API navigation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Only for truly unknown/future API fields
     #[serde(flatten)]
@@ -171,7 +170,7 @@ pub struct AccountACLRoles {
 
     /// HATEOAS links for API navigation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Only for truly unknown/future API fields
     #[serde(flatten)]
@@ -256,7 +255,7 @@ pub struct ACLUser {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -325,7 +324,7 @@ pub struct TaskStateUpdate {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/cloud_accounts.rs
+++ b/src/cloud_accounts.rs
@@ -53,11 +53,10 @@
 //! # }
 //! ```
 
-use crate::types::ProcessorResponse;
+use crate::types::{Link, ProcessorResponse};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 // ============================================================================
 // Models
@@ -151,7 +150,7 @@ pub struct CloudAccount {
 
     /// HATEOAS links for API navigation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Only for truly unknown/future API fields
     #[serde(flatten)]
@@ -208,7 +207,7 @@ pub struct CloudAccounts {
 
     /// HATEOAS links for API navigation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Only for truly unknown/future API fields
     #[serde(flatten)]
@@ -239,7 +238,7 @@ pub struct TaskStateUpdate {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/fixed/databases.rs
+++ b/src/fixed/databases.rs
@@ -45,7 +45,7 @@
 //! # }
 //! ```
 
-use crate::types::ProcessorResponse;
+use crate::types::{Link, ProcessorResponse};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -64,7 +64,7 @@ pub struct AccountFixedSubscriptionDatabases {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -222,7 +222,7 @@ pub struct CloudTag {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -346,7 +346,7 @@ pub struct CloudTags {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -443,7 +443,7 @@ pub struct FixedDatabase {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -458,7 +458,7 @@ pub struct DatabaseSlowLogEntries {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -489,7 +489,7 @@ pub struct TaskStateUpdate {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/fixed/subscriptions.rs
+++ b/src/fixed/subscriptions.rs
@@ -49,11 +49,10 @@
 //! # }
 //! ```
 
-use crate::types::ProcessorResponse;
+use crate::types::{Link, ProcessorResponse};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 // ============================================================================
 // Models
@@ -76,7 +75,7 @@ pub struct RedisVersions {
 pub struct FixedSubscriptionsPlans {
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -192,7 +191,7 @@ pub struct FixedSubscriptionsPlan {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -234,7 +233,7 @@ pub struct FixedSubscriptions {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -346,7 +345,7 @@ pub struct FixedSubscription {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -377,7 +376,7 @@ pub struct TaskStateUpdate {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -51,7 +51,7 @@
 //! # }
 //! ```
 
-use crate::types::ProcessorResponse;
+use crate::types::{Link, ProcessorResponse};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -78,7 +78,7 @@ pub struct AccountSubscriptionDatabases {
 
     /// HATEOAS links for API navigation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Only for truly unknown/future API fields
     #[serde(flatten)]
@@ -250,7 +250,7 @@ pub struct CloudTag {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -674,7 +674,7 @@ pub struct Database {
 
     /// HATEOAS links for API navigation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Only for truly unknown/future API fields. All documented fields should be first-class members above.
     #[serde(flatten)]
@@ -866,7 +866,7 @@ pub struct CloudTags {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -902,7 +902,7 @@ pub struct DatabaseSlowLogEntries {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -972,7 +972,7 @@ pub struct TaskStateUpdate {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -51,7 +51,7 @@
 //! # }
 //! ```
 
-use crate::types::ProcessorResponse;
+use crate::types::{Link, ProcessorResponse};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -300,7 +300,7 @@ pub struct ActiveActiveSubscriptionRegions {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]
@@ -628,7 +628,7 @@ pub struct Subscription {
 
     /// HATEOAS links for API navigation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Only for truly unknown/future API fields. All documented fields should be first-class members above.
     #[serde(flatten)]
@@ -669,7 +669,7 @@ pub struct AccountSubscriptions {
 
     /// HATEOAS links for API navigation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Only for truly unknown/future API fields
     #[serde(flatten)]
@@ -789,7 +789,7 @@ pub struct TaskStateUpdate {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -55,11 +55,10 @@
 //! # }
 //! ```
 
-use crate::types::ProcessorResponse;
+use crate::types::{Link, ProcessorResponse};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 // ============================================================================
 // Models
@@ -101,7 +100,7 @@ pub struct TaskStateUpdate {
 
     /// HATEOAS links for API navigation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Only for truly unknown/future API fields
     #[serde(flatten)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,6 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 // ============================================================================
 // Task Types (Most common - appears in 37 endpoints)
@@ -41,7 +40,7 @@ pub struct TaskStateUpdate {
 
     /// HATEOAS links for related resources
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 }
 
 /// TaskStatus enum - Part of TaskStateUpdate schema

--- a/src/users.rs
+++ b/src/users.rs
@@ -49,11 +49,10 @@
 //! # }
 //! ```
 
-use crate::types::ProcessorResponse;
+use crate::types::{Link, ProcessorResponse};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 // ============================================================================
 // Models
@@ -137,7 +136,7 @@ pub struct TaskStateUpdate {
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<HashMap<String, Value>>>,
+    pub links: Option<Vec<Link>>,
 
     /// Additional fields from the API
     #[serde(flatten)]


### PR DESCRIPTION
## Summary
- Replace all `Option<Vec<HashMap<String, Value>>>` link fields with `Option<Vec<Link>>`
- Use the existing `Link` type from `types.rs` for type-safe HATEOAS link access
- Remove unused `HashMap` imports from modules that no longer need them

## Benefits
- Type-safe access to link properties (rel, href, method, type)
- Better IDE support and documentation  
- Consistency across all response types
- Net reduction of 6 lines of code

## Files Changed
- src/acl.rs (5 link fields updated)
- src/account.rs (8 link fields updated)
- src/users.rs (1 link field updated)
- src/cloud_accounts.rs (3 link fields updated)
- src/tasks.rs (1 link field updated)
- src/types.rs (1 link field updated)
- src/fixed/databases.rs (6 link fields updated)
- src/fixed/subscriptions.rs (5 link fields updated)
- src/flexible/databases.rs (6 link fields updated)
- src/flexible/subscriptions.rs (4 link fields updated)

## Test Plan
- [x] All 206 existing tests pass
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes

Closes #22