### PR TITLE
refactor: improve type safety for response and request types

### DIFF
--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -26,6 +26,12 @@ pub mod vpc_peering;
 
 // Re-export handlers for convenience
 pub use private_link::PrivateLinkHandler;
+
+// Re-export PrivateLink types
+pub use private_link::{
+    PrincipalType, PrivateLinkAddPrincipalRequest, PrivateLinkCreateRequest,
+    PrivateLinkRemovePrincipalRequest,
+};
 pub use psc::PscHandler;
 pub use transit_gateway::TransitGatewayHandler;
 pub use vpc_peering::VpcPeeringHandler;

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -610,7 +610,7 @@ pub struct Database {
 
     /// Remote backup configuration
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub remote_backup: Option<Value>,
+    pub remote_backup: Option<DatabaseBackupConfig>,
 
     /// List of source IP addresses or subnet masks allowed to connect
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -622,7 +622,7 @@ pub struct Database {
 
     /// List of client TLS/SSL certificates for mTLS authentication
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_tls_certificates: Option<Vec<Value>>,
+    pub client_tls_certificates: Option<Vec<DatabaseCertificateSpec>>,
 
     /// Database password (masked in responses for security)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -638,11 +638,11 @@ pub struct Database {
 
     /// Database alert configurations
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub alerts: Option<Vec<Value>>,
+    pub alerts: Option<Vec<DatabaseAlertSpec>>,
 
     /// Redis modules/capabilities enabled on this database
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub modules: Option<Vec<Value>>,
+    pub modules: Option<Vec<DatabaseModuleSpec>>,
 
     /// Database hashing policy for clustering
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -658,7 +658,7 @@ pub struct Database {
 
     /// Replica configuration
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub replica: Option<Value>,
+    pub replica: Option<ReplicaOfSpec>,
 
     /// Whether default Redis user is enabled
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -608,7 +608,7 @@ pub struct Subscription {
 
     /// Pricing details for the subscription
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pricing: Option<Vec<Value>>,
+    pub pricing: Option<Vec<SubscriptionPricing>>,
 
     /// Redis version for databases created in this subscription (deprecated)
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

- Replace bare `serde_json::Value` with typed structs in Database and Subscription response types
- Add typed request structs for PrivateLink operations with `PrincipalType` enum
- Re-export PrivateLink types from connectivity module for ergonomic access

### Database struct type improvements
- `remote_backup`: `Option<Value>` -> `Option<DatabaseBackupConfig>`
- `client_tls_certificates`: `Option<Vec<Value>>` -> `Option<Vec<DatabaseCertificateSpec>>`
- `alerts`: `Option<Vec<Value>>` -> `Option<Vec<DatabaseAlertSpec>>`
- `modules`: `Option<Vec<Value>>` -> `Option<Vec<DatabaseModuleSpec>>`
- `replica`: `Option<Value>` -> `Option<ReplicaOfSpec>`

### Subscription struct type improvements
- `pricing`: `Option<Vec<Value>>` -> `Option<Vec<SubscriptionPricing>>`

### PrivateLink typed request structs
- `PrivateLinkCreateRequest` for creating PrivateLink configurations
- `PrivateLinkAddPrincipalRequest` for adding principals
- `PrivateLinkRemovePrincipalRequest` for removing principals
- `PrincipalType` enum for type-safe principal types (aws_account, iam_role, etc.)

## Test plan

- [x] All existing tests pass
- [x] Updated PrivateLink tests to use typed request structs
- [x] cargo fmt and clippy pass

Closes #7
Closes #14