### PR TITLE
docs: fix README examples and add handler method documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ A comprehensive Rust client library for the Redis Cloud REST API, with Python bi
 
 ```toml
 [dependencies]
-redis-cloud = "0.7"
+redis-cloud = "0.8"
 
 # Optional: Enable Tower service integration
-redis-cloud = { version = "0.7", features = ["tower-integration"] }
+redis-cloud = { version = "0.8", features = ["tower-integration"] }
 ```
 
 ## Quick Start
@@ -46,17 +46,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .api_secret("your-api-secret")
         .build()?;
 
-    // Get account information
-    let account = client.account().get().await?;
+    // Get account information using fluent API
+    let account = client.account().get_current_account().await?;
     println!("Account: {:?}", account);
 
     // List all subscriptions
-    let subscriptions = client.subscription().list().await?;
+    let subscriptions = client.subscriptions().get_all_subscriptions().await?;
     println!("Subscriptions: {:?}", subscriptions);
 
     // List databases in a subscription
-    let databases = client.database().list("subscription-id").await?;
+    let databases = client.databases().get_subscription_databases(123, None, None).await?;
     println!("Databases: {:?}", databases);
+
+    Ok(())
+}
+```
+
+You can also use explicit handler creation if preferred:
+
+```rust
+use redis_cloud::{CloudClient, SubscriptionHandler};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = CloudClient::builder()
+        .api_key("your-api-key")
+        .api_secret("your-api-secret")
+        .build()?;
+
+    // Explicit handler creation
+    let handler = SubscriptionHandler::new(client.clone());
+    let subscriptions = handler.get_all_subscriptions().await?;
 
     Ok(())
 }

--- a/src/account.rs
+++ b/src/account.rs
@@ -304,6 +304,23 @@ impl AccountHandler {
     /// Gets information on this account.
     ///
     /// GET /
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let account = client.account().get_current_account().await?;
+    /// println!("Account ID: {}", account.id);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn get_current_account(&self) -> Result<RootAccount> {
         self.client.get("/").await
     }

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -353,6 +353,22 @@ impl AclHandler {
     /// Gets a list of all Redis ACL rules for this account.
     ///
     /// GET /acl/redisRules
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let rules = client.acl().get_all_redis_rules().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn get_all_redis_rules(&self) -> Result<AccountACLRedisRules> {
         self.client.get("/acl/redisRules").await
     }
@@ -398,6 +414,22 @@ impl AclHandler {
     /// Gets a list of all database access roles for this account.
     ///
     /// GET /acl/roles
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let roles = client.acl().get_roles().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn get_roles(&self) -> Result<AccountACLRoles> {
         self.client.get("/acl/roles").await
     }

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -1117,9 +1117,36 @@ impl DatabaseHandler {
     }
 
     /// Get all databases in a Pro subscription
+    ///
     /// Gets a list of all databases in the specified Pro subscription.
     ///
     /// GET /subscriptions/{subscriptionId}/databases
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `offset` - Optional offset for pagination
+    /// * `limit` - Optional limit for pagination
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// // Get all databases in subscription 123
+    /// let databases = client.databases().get_subscription_databases(123, None, None).await?;
+    ///
+    /// // With pagination
+    /// let page = client.databases().get_subscription_databases(123, Some(0), Some(10)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn get_subscription_databases(
         &self,
         subscription_id: i32,
@@ -1183,9 +1210,30 @@ impl DatabaseHandler {
     }
 
     /// Get a single Pro database
+    ///
     /// Gets details and settings of a single database in a Pro subscription.
     ///
     /// GET /subscriptions/{subscriptionId}/databases/{databaseId}
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let database = client.databases().get_subscription_database_by_id(123, 456).await?;
+    ///
+    /// println!("Database: {} (status: {:?})",
+    ///     database.name.unwrap_or_default(),
+    ///     database.status);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn get_subscription_database_by_id(
         &self,
         subscription_id: i32,

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -859,9 +859,31 @@ impl SubscriptionHandler {
     }
 
     /// Get Pro subscriptions
+    ///
     /// Gets a list of all Pro subscriptions in the current account.
     ///
     /// GET /subscriptions
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let subscriptions = client.subscriptions().get_all_subscriptions().await?;
+    ///
+    /// // Access subscription data from the extra field
+    /// if let Some(subs) = subscriptions.extra.get("subscriptions") {
+    ///     println!("Found {} subscriptions", subs.as_array().map(|a| a.len()).unwrap_or(0));
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn get_all_subscriptions(&self) -> Result<AccountSubscriptions> {
         self.client.get("/subscriptions").await
     }
@@ -909,9 +931,30 @@ impl SubscriptionHandler {
     }
 
     /// Get a single Pro subscription
+    ///
     /// Gets information on the specified Pro subscription.
     ///
     /// GET /subscriptions/{subscriptionId}
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let subscription = client.subscriptions().get_subscription_by_id(123).await?;
+    ///
+    /// println!("Subscription: {} (status: {:?})",
+    ///     subscription.name.unwrap_or_default(),
+    ///     subscription.status);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn get_subscription_by_id(&self, subscription_id: i32) -> Result<Subscription> {
         self.client
             .get(&format!("/subscriptions/{}", subscription_id))

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -145,6 +145,23 @@ impl TasksHandler {
     /// Gets details and status of a single task by the Task ID.
     ///
     /// GET /tasks/{taskId}
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let task = client.tasks().get_task_by_id("task-id".to_string()).await?;
+    /// println!("Task status: {:?}", task.status);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn get_task_by_id(&self, task_id: String) -> Result<TaskStateUpdate> {
         self.client.get(&format!("/tasks/{}", task_id)).await
     }


### PR DESCRIPTION
## Summary
- Update README Quick Start examples to use correct method names (e.g., `get_current_account()` instead of `get()`)
- Update version references to 0.8 and add alternative explicit handler example
- Add doc examples to priority handler methods as specified in #20

## Handler Methods with Examples Added
- `SubscriptionHandler::get_all_subscriptions()`
- `SubscriptionHandler::get_subscription_by_id()`
- `DatabaseHandler::get_subscription_databases()`
- `DatabaseHandler::get_subscription_database_by_id()`
- `AccountHandler::get_current_account()`
- `AclHandler::get_all_redis_rules()`
- `AclHandler::get_roles()`
- `TasksHandler::get_task_by_id()`

## Test plan
- [x] All 216 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Doc examples use `no_run` attribute to avoid API calls during doc tests

Closes #6, Closes #20