### PR TITLE
refactor: reduce VPC peering duplication and add pagination helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,9 +922,12 @@ name = "redis-cloud"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "base64",
  "chrono",
+ "futures",
+ "futures-core",
  "pretty_assertions",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ chrono = { version = "0.4", features = ["serde"] }
 url = "2.5"
 typed-builder = "0.20"
 tower = { version = "0.5", optional = true }
+async-stream = "0.3"
+futures-core = "0.3"
 
 [features]
 tower-integration = ["tower"]
@@ -39,3 +41,4 @@ pretty_assertions = "1.4"
 serial_test = "3.1"
 tower = { version = "0.5", features = ["timeout", "limit", "retry", "buffer"] }
 tower-resilience = { version = "0.3.8", features = ["retry"] }
+futures = "0.3"

--- a/src/connectivity/vpc_peering.rs
+++ b/src/connectivity/vpc_peering.rs
@@ -123,55 +123,49 @@ impl VpcPeeringHandler {
     // ========================================================================
     // Active-Active VPC Peering
     // ========================================================================
+    //
+    // Note: Active-Active VPC peering uses the same API endpoints as standard
+    // VPC peering. These methods are provided for API consistency and to match
+    // the naming convention used by other connectivity handlers.
 
     /// Get Active-Active VPC peerings
+    ///
+    /// Note: Uses the same endpoint as standard VPC peering.
     pub async fn get_active_active(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
-        self.client
-            .get(&format!("/subscriptions/{}/peerings", subscription_id))
-            .await
+        self.get(subscription_id).await
     }
 
     /// Create Active-Active VPC peering
+    ///
+    /// Note: Uses the same endpoint as standard VPC peering.
     pub async fn create_active_active(
         &self,
         subscription_id: i32,
         request: &VpcPeeringCreateRequest,
     ) -> Result<TaskStateUpdate> {
-        self.client
-            .post(
-                &format!("/subscriptions/{}/peerings", subscription_id),
-                request,
-            )
-            .await
+        self.create(subscription_id, request).await
     }
 
     /// Delete Active-Active VPC peering
+    ///
+    /// Note: Uses the same endpoint as standard VPC peering.
     pub async fn delete_active_active(
         &self,
         subscription_id: i32,
         peering_id: i32,
     ) -> Result<serde_json::Value> {
-        self.client
-            .delete(&format!(
-                "/subscriptions/{}/peerings/{}",
-                subscription_id, peering_id
-            ))
-            .await?;
-        Ok(serde_json::Value::Null)
+        self.delete(subscription_id, peering_id).await
     }
 
     /// Update Active-Active VPC peering
+    ///
+    /// Note: Uses the same endpoint as standard VPC peering.
     pub async fn update_active_active(
         &self,
         subscription_id: i32,
         peering_id: i32,
         request: &VpcPeeringCreateRequest,
     ) -> Result<TaskStateUpdate> {
-        self.client
-            .put(
-                &format!("/subscriptions/{}/peerings/{}", subscription_id, peering_id),
-                request,
-            )
-            .await
+        self.update(subscription_id, peering_id, request).await
     }
 }


### PR DESCRIPTION
## Summary
- Remove duplicated code in VPC peering Active-Active methods (they now delegate to standard methods since API endpoints are identical)
- Add async pagination/streaming helpers for databases

## Pagination Helpers (Closes #12)
New methods on `DatabaseHandler`:
- `stream_databases(subscription_id)` - Returns an async stream for iterating over databases
- `stream_databases_with_page_size(subscription_id, page_size)` - Same with custom page size
- `get_all_databases(subscription_id)` - Collects all databases into a Vec

### Usage Example
```rust
use futures::StreamExt;
use std::pin::pin;

let handler = client.databases();
let mut stream = pin!(handler.stream_databases(123));
while let Some(result) = stream.next().await {
    let database = result?;
    println!("Database: {}", database.database_id);
}

// Or collect all at once
let all_dbs = client.databases().get_all_databases(123).await?;
```

## Dependencies Added
- `async-stream` - For the `try_stream!` macro
- `futures-core` - For the `Stream` trait
- `futures` (dev) - For `StreamExt` in tests

## VPC Peering Refactor (Partially addresses #18)
The Active-Active VPC peering methods were exact copies of the standard methods. They now delegate to the standard implementations with documentation noting they use the same API endpoints.

## Test plan
- [x] All 220 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] New pagination tests cover single page, multiple pages, empty, and streaming cases

Closes #12
Partially addresses #18