### PR TITLE
chore: code cleanup and add examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ A comprehensive Rust client library for the Redis Cloud REST API, with Python bi
 - Comprehensive error handling
 - Optional Tower service integration for middleware composition
 - Support for all Redis Cloud features including:
-  - Subscriptions and databases
+  - Pro and Essentials subscriptions and databases
   - User and ACL management
-  - Backup and restore operations
-  - VPC peering and networking
-  - Metrics and monitoring
-  - Billing and payment management
+  - Backup, restore, and import operations
+  - VPC peering, Transit Gateway, Private Service Connect, PrivateLink
+  - Cloud account integration (AWS, GCP, Azure)
+  - Task tracking for async operations
+  - Cost reports (FOCUS format)
 
 ## Installation
 
@@ -113,6 +114,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 This enables composition with Tower middleware like circuit breakers, retry, rate limiting, and more.
 
+## Examples
+
+See the `examples/` directory for runnable examples:
+
+```bash
+# Basic usage - connect and list subscriptions
+REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example basic
+
+# Database operations
+REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example databases
+
+# Streaming with pagination
+REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example stream_databases -- SUBSCRIPTION_ID
+```
+
 ## Python Bindings
 
 This library also provides Python bindings via PyO3:
@@ -174,15 +190,24 @@ subs = client.subscriptions_sync()
 
 ## API Coverage
 
-This library provides comprehensive coverage of the Redis Cloud REST API, including:
+This library provides comprehensive coverage of the Redis Cloud REST API:
 
-- **Account Management** - Account info, users, payment methods
-- **Subscriptions** - CRUD operations, pricing, CIDR management
-- **Databases** - Full database lifecycle, backups, imports, metrics
-- **ACL Management** - Users, roles, Redis rules
-- **Networking** - VPC peering, Transit Gateway, Private Service Connect
-- **Monitoring** - Metrics, logs, alerts
-- **Billing** - Invoices, payment methods, usage
+| Handler | Description |
+|---------|-------------|
+| `account()` | Account info, payment methods, regions, logs |
+| `subscriptions()` | Pro subscription CRUD, pricing, CIDR, maintenance windows |
+| `databases()` | Pro database lifecycle, backups, imports, flush |
+| `fixed_subscriptions()` | Essentials subscription management |
+| `fixed_databases()` | Essentials database management |
+| `acl()` | ACL users, roles, Redis rules |
+| `users()` | Account user management |
+| `cloud_accounts()` | Cloud provider integration (AWS, GCP, Azure) |
+| `vpc_peering()` | VPC peering (standard and Active-Active) |
+| `transit_gateway()` | AWS Transit Gateway attachments |
+| `psc()` | GCP Private Service Connect |
+| `private_link()` | AWS PrivateLink |
+| `tasks()` | Async operation tracking |
+| `cost_reports()` | Cost reports in FOCUS format |
 
 ## Documentation
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,73 @@
+//! Basic example showing how to connect and list subscriptions
+//!
+//! Run with:
+//! ```
+//! REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example basic
+//! ```
+
+use redis_cloud::{CloudClient, CloudError};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get credentials from environment
+    let api_key = std::env::var("REDIS_CLOUD_API_KEY")
+        .expect("REDIS_CLOUD_API_KEY environment variable required");
+    let api_secret = std::env::var("REDIS_CLOUD_API_SECRET")
+        .expect("REDIS_CLOUD_API_SECRET environment variable required");
+
+    // Create client
+    let client = CloudClient::builder()
+        .api_key(api_key)
+        .api_secret(api_secret)
+        .build()?;
+
+    // Get account information
+    println!("Fetching account information...");
+    let account = client.account().get_current_account().await?;
+    if let Some(acc) = &account.account {
+        println!("Account ID: {:?}", acc.id);
+        println!("Account Name: {:?}", acc.name);
+    }
+
+    // List all Pro subscriptions
+    println!("\nFetching Pro subscriptions...");
+    match client.subscriptions().get_all_subscriptions().await {
+        Ok(response) => {
+            if let Some(subs) = response.subscriptions {
+                println!("Found {} Pro subscriptions:", subs.len());
+                for sub in subs {
+                    println!(
+                        "  - ID: {:?}, Name: {:?}, Status: {:?}",
+                        sub.id, sub.name, sub.status
+                    );
+                }
+            }
+        }
+        Err(CloudError::NotFound { .. }) => {
+            println!("No Pro subscriptions found");
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    // List all Essentials subscriptions
+    println!("\nFetching Essentials subscriptions...");
+    match client.fixed_subscriptions().list().await {
+        Ok(response) => {
+            if let Some(subs) = response.subscriptions {
+                println!("Found {} Essentials subscriptions:", subs.len());
+                for sub in subs {
+                    println!(
+                        "  - ID: {:?}, Name: {:?}, Status: {:?}",
+                        sub.id, sub.name, sub.status
+                    );
+                }
+            }
+        }
+        Err(CloudError::NotFound { .. }) => {
+            println!("No Essentials subscriptions found");
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    Ok(())
+}

--- a/examples/databases.rs
+++ b/examples/databases.rs
@@ -1,0 +1,69 @@
+//! Database operations example
+//!
+//! Run with:
+//! ```
+//! REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example databases
+//! ```
+
+use redis_cloud::CloudClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("REDIS_CLOUD_API_KEY")?;
+    let api_secret = std::env::var("REDIS_CLOUD_API_SECRET")?;
+
+    let client = CloudClient::builder()
+        .api_key(api_key)
+        .api_secret(api_secret)
+        .build()?;
+
+    // First, get the subscription ID from command line or use first available
+    let subscription_id = std::env::args().nth(1).and_then(|s| s.parse::<i32>().ok());
+
+    let subscription_id = match subscription_id {
+        Some(id) => id,
+        None => {
+            // Get first Pro subscription
+            let subs = client.subscriptions().get_all_subscriptions().await?;
+            subs.subscriptions
+                .and_then(|s| s.first().and_then(|sub| sub.id))
+                .expect("No subscriptions found. Pass subscription ID as argument.")
+        }
+    };
+
+    println!("Using subscription ID: {subscription_id}");
+
+    // List databases in subscription
+    println!("\nFetching databases...");
+    let response = client
+        .databases()
+        .get_subscription_databases(subscription_id, None, None)
+        .await?;
+
+    for sub_info in &response.subscription {
+        let dbs = &sub_info.databases;
+        println!("Found {} databases:", dbs.len());
+        for db in dbs {
+            println!(
+                "  - ID: {:?}, Name: {:?}, Status: {:?}",
+                db.database_id, db.name, db.status
+            );
+            if let Some(endpoint) = &db.public_endpoint {
+                println!("    Endpoint: {endpoint}");
+            }
+            if let Some(memory) = db.memory_limit_in_gb {
+                println!("    Memory: {memory} GB");
+            }
+        }
+    }
+
+    // Get all databases using pagination helper
+    println!("\nFetching all databases (with pagination)...");
+    let all_dbs = client
+        .databases()
+        .get_all_databases(subscription_id)
+        .await?;
+    println!("Total databases: {}", all_dbs.len());
+
+    Ok(())
+}

--- a/examples/stream_databases.rs
+++ b/examples/stream_databases.rs
@@ -1,0 +1,59 @@
+//! Streaming example - process databases one at a time without loading all into memory
+//!
+//! Run with:
+//! ```
+//! REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example stream_databases -- SUBSCRIPTION_ID
+//! ```
+
+use futures::StreamExt;
+use redis_cloud::{CloudClient, CloudError};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("REDIS_CLOUD_API_KEY")?;
+    let api_secret = std::env::var("REDIS_CLOUD_API_SECRET")?;
+
+    let subscription_id: i32 = std::env::args()
+        .nth(1)
+        .expect("Usage: stream_databases SUBSCRIPTION_ID")
+        .parse()
+        .expect("SUBSCRIPTION_ID must be an integer");
+
+    let client = CloudClient::builder()
+        .api_key(api_key)
+        .api_secret(api_secret)
+        .build()?;
+
+    println!("Streaming databases from subscription {subscription_id}...\n");
+
+    // Get the database handler
+    let db_handler = client.databases();
+
+    // Stream databases - this fetches pages as needed instead of loading all at once
+    let mut stream = std::pin::pin!(db_handler.stream_databases(subscription_id));
+
+    // Process each database as it arrives
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(db) => {
+                count += 1;
+                println!(
+                    "[{}] {:?} - {:?} ({:?})",
+                    count,
+                    db.name.as_deref().unwrap_or("unnamed"),
+                    db.status.as_deref().unwrap_or("unknown"),
+                    db.public_endpoint.as_deref().unwrap_or("no endpoint")
+                );
+            }
+            Err(CloudError::NotFound { .. }) => {
+                println!("No databases found in subscription");
+                break;
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    println!("\nProcessed {count} databases");
+    Ok(())
+}

--- a/src/account.rs
+++ b/src/account.rs
@@ -264,7 +264,7 @@ pub struct PaymentMethod {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Module {
-    /// Module name (e.g., "RedisJSON", "RediSearch")
+    /// Module name (e.g., "`RedisJSON`", "`RediSearch`")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
@@ -418,6 +418,7 @@ pub struct AccountHandler {
 
 impl AccountHandler {
     /// Create a new handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -476,17 +477,17 @@ impl AccountHandler {
     ) -> Result<AccountSystemLogEntries> {
         let mut query = Vec::new();
         if let Some(v) = offset {
-            query.push(format!("offset={}", v));
+            query.push(format!("offset={v}"));
         }
         if let Some(v) = limit {
-            query.push(format!("limit={}", v));
+            query.push(format!("limit={v}"));
         }
         let query_string = if query.is_empty() {
             String::new()
         } else {
             format!("?{}", query.join("&"))
         };
-        self.client.get(&format!("/logs{}", query_string)).await
+        self.client.get(&format!("/logs{query_string}")).await
     }
 
     /// Get payment methods
@@ -512,14 +513,14 @@ impl AccountHandler {
     pub async fn get_supported_regions(&self, provider: Option<String>) -> Result<Regions> {
         let mut query = Vec::new();
         if let Some(v) = provider {
-            query.push(format!("provider={}", v));
+            query.push(format!("provider={v}"));
         }
         let query_string = if query.is_empty() {
             String::new()
         } else {
             format!("?{}", query.join("&"))
         };
-        self.client.get(&format!("/regions{}", query_string)).await
+        self.client.get(&format!("/regions{query_string}")).await
     }
 
     /// Get session logs
@@ -533,10 +534,10 @@ impl AccountHandler {
     ) -> Result<AccountSessionLogEntries> {
         let mut query = Vec::new();
         if let Some(v) = offset {
-            query.push(format!("offset={}", v));
+            query.push(format!("offset={v}"));
         }
         if let Some(v) = limit {
-            query.push(format!("limit={}", v));
+            query.push(format!("limit={v}"));
         }
         let query_string = if query.is_empty() {
             String::new()
@@ -544,7 +545,7 @@ impl AccountHandler {
             format!("?{}", query.join("&"))
         };
         self.client
-            .get(&format!("/session-logs{}", query_string))
+            .get(&format!("/session-logs{query_string}"))
             .await
     }
 }

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -219,7 +219,7 @@ pub struct ACLRoleUser {
 
 /// Redis rule as embedded in an ACL role response
 ///
-/// This has different field names than ACLRedisRule because the API
+/// This has different field names than `ACLRedisRule` because the API
 /// uses different JSON keys when rules are embedded in role responses.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -408,6 +408,7 @@ pub struct AclHandler {
 
 impl AclHandler {
     /// Create a new handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -454,7 +455,7 @@ impl AclHandler {
     pub async fn delete_redis_rule(&self, acl_redis_rule_id: i32) -> Result<TaskStateUpdate> {
         let response = self
             .client
-            .delete_raw(&format!("/acl/redisRules/{}", acl_redis_rule_id))
+            .delete_raw(&format!("/acl/redisRules/{acl_redis_rule_id}"))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
     }
@@ -469,7 +470,7 @@ impl AclHandler {
         request: &AclRedisRuleUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .put(&format!("/acl/redisRules/{}", acl_redis_rule_id), request)
+            .put(&format!("/acl/redisRules/{acl_redis_rule_id}"), request)
             .await
     }
 
@@ -512,7 +513,7 @@ impl AclHandler {
     pub async fn delete_acl_role(&self, acl_role_id: i32) -> Result<TaskStateUpdate> {
         let response = self
             .client
-            .delete_raw(&format!("/acl/roles/{}", acl_role_id))
+            .delete_raw(&format!("/acl/roles/{acl_role_id}"))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
     }
@@ -527,7 +528,7 @@ impl AclHandler {
         request: &AclRoleUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .put(&format!("/acl/roles/{}", acl_role_id), request)
+            .put(&format!("/acl/roles/{acl_role_id}"), request)
             .await
     }
 
@@ -554,7 +555,7 @@ impl AclHandler {
     pub async fn delete_user(&self, acl_user_id: i32) -> Result<TaskStateUpdate> {
         let response = self
             .client
-            .delete_raw(&format!("/acl/users/{}", acl_user_id))
+            .delete_raw(&format!("/acl/users/{acl_user_id}"))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
     }
@@ -564,9 +565,7 @@ impl AclHandler {
     ///
     /// GET /acl/users/{aclUserId}
     pub async fn get_user_by_id(&self, acl_user_id: i32) -> Result<ACLUser> {
-        self.client
-            .get(&format!("/acl/users/{}", acl_user_id))
-            .await
+        self.client.get(&format!("/acl/users/{acl_user_id}")).await
     }
 
     /// Update access control user
@@ -579,7 +578,7 @@ impl AclHandler {
         request: &AclUserUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .put(&format!("/acl/users/{}", acl_user_id), request)
+            .put(&format!("/acl/users/{acl_user_id}"), request)
             .await
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,10 +16,10 @@ use tracing::{debug, instrument, trace};
 /// Default user agent for the Redis Cloud client
 const DEFAULT_USER_AGENT: &str = concat!("redis-cloud/", env!("CARGO_PKG_VERSION"));
 
-/// Builder for constructing a CloudClient with custom configuration
+/// Builder for constructing a `CloudClient` with custom configuration
 ///
 /// Provides a fluent interface for configuring API credentials, base URL, timeouts,
-/// and other client settings before creating the final CloudClient instance.
+/// and other client settings before creating the final `CloudClient` instance.
 ///
 /// # Examples
 ///
@@ -64,29 +64,34 @@ impl Default for CloudClientBuilder {
 
 impl CloudClientBuilder {
     /// Create a new builder
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Set the API key
+    #[must_use]
     pub fn api_key(mut self, key: impl Into<String>) -> Self {
         self.api_key = Some(key.into());
         self
     }
 
     /// Set the API secret
+    #[must_use]
     pub fn api_secret(mut self, secret: impl Into<String>) -> Self {
         self.api_secret = Some(secret.into());
         self
     }
 
     /// Set the base URL
+    #[must_use]
     pub fn base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into();
         self
     }
 
     /// Set the timeout
+    #[must_use]
     pub fn timeout(mut self, timeout: std::time::Duration) -> Self {
         self.timeout = timeout;
         self
@@ -97,6 +102,7 @@ impl CloudClientBuilder {
     /// The default user agent is `redis-cloud/{version}`.
     /// This can be overridden to identify specific clients, for example:
     /// `redisctl/1.2.3` or `my-app/1.0.0`.
+    #[must_use]
     pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
         self.user_agent = user_agent.into();
         self
@@ -115,7 +121,7 @@ impl CloudClientBuilder {
         default_headers.insert(
             USER_AGENT,
             HeaderValue::from_str(&self.user_agent)
-                .map_err(|e| RestError::ConnectionError(format!("Invalid user agent: {}", e)))?,
+                .map_err(|e| RestError::ConnectionError(format!("Invalid user agent: {e}")))?,
         );
 
         let client = Client::builder()
@@ -146,6 +152,7 @@ pub struct CloudClient {
 
 impl CloudClient {
     /// Create a new builder for the client
+    #[must_use]
     pub fn builder() -> CloudClientBuilder {
         CloudClientBuilder::new()
     }
@@ -154,6 +161,7 @@ impl CloudClient {
     ///
     /// Returns the timeout duration that was set when building the client.
     /// This timeout is applied to all HTTP requests made by this client.
+    #[must_use]
     pub fn timeout(&self) -> std::time::Duration {
         self.timeout
     }
@@ -178,6 +186,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn account(&self) -> crate::AccountHandler {
         crate::AccountHandler::new(self.clone())
     }
@@ -198,6 +207,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn subscriptions(&self) -> crate::SubscriptionHandler {
         crate::SubscriptionHandler::new(self.clone())
     }
@@ -218,6 +228,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn databases(&self) -> crate::DatabaseHandler {
         crate::DatabaseHandler::new(self.clone())
     }
@@ -238,6 +249,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn fixed_subscriptions(&self) -> crate::FixedSubscriptionHandler {
         crate::FixedSubscriptionHandler::new(self.clone())
     }
@@ -258,6 +270,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn fixed_databases(&self) -> crate::FixedDatabaseHandler {
         crate::FixedDatabaseHandler::new(self.clone())
     }
@@ -278,6 +291,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn acl(&self) -> crate::AclHandler {
         crate::AclHandler::new(self.clone())
     }
@@ -298,6 +312,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn users(&self) -> crate::UserHandler {
         crate::UserHandler::new(self.clone())
     }
@@ -318,6 +333,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn tasks(&self) -> crate::TaskHandler {
         crate::TaskHandler::new(self.clone())
     }
@@ -338,6 +354,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn cloud_accounts(&self) -> crate::CloudAccountHandler {
         crate::CloudAccountHandler::new(self.clone())
     }
@@ -358,6 +375,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn vpc_peering(&self) -> crate::VpcPeeringHandler {
         crate::VpcPeeringHandler::new(self.clone())
     }
@@ -378,6 +396,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn transit_gateway(&self) -> crate::TransitGatewayHandler {
         crate::TransitGatewayHandler::new(self.clone())
     }
@@ -398,11 +417,12 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn psc(&self) -> crate::PscHandler {
         crate::PscHandler::new(self.clone())
     }
 
-    /// Get a PrivateLink handler for AWS PrivateLink operations
+    /// Get a `PrivateLink` handler for AWS `PrivateLink` operations
     ///
     /// # Example
     ///
@@ -418,6 +438,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn private_link(&self) -> crate::PrivateLinkHandler {
         crate::PrivateLinkHandler::new(self.clone())
     }
@@ -438,6 +459,7 @@ impl CloudClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn cost_reports(&self) -> crate::CostReportHandler {
         crate::CostReportHandler::new(self.clone())
     }
@@ -446,7 +468,7 @@ impl CloudClient {
     fn normalize_url(&self, path: &str) -> String {
         let base = self.base_url.trim_end_matches('/');
         let path = path.trim_start_matches('/');
-        format!("{}/{}", base, path)
+        format!("{base}/{path}")
     }
 
     /// Convert HTTP status code and response text to appropriate error
@@ -562,7 +584,7 @@ impl CloudClient {
             let text = response
                 .text()
                 .await
-                .unwrap_or_else(|e| format!("(failed to read response body: {})", e));
+                .unwrap_or_else(|e| format!("(failed to read response body: {e})"));
             Err(Self::status_to_error(status, text))
         }
     }
@@ -597,12 +619,12 @@ impl CloudClient {
                 .bytes()
                 .await
                 .map(|b| b.to_vec())
-                .map_err(|e| RestError::ConnectionError(format!("Failed to read response: {}", e)))
+                .map_err(|e| RestError::ConnectionError(format!("Failed to read response: {e}")))
         } else {
             let text = response
                 .text()
                 .await
-                .unwrap_or_else(|e| format!("(failed to read response body: {})", e));
+                .unwrap_or_else(|e| format!("(failed to read response body: {e})"));
             Err(Self::status_to_error(status, text))
         }
     }
@@ -671,12 +693,12 @@ impl CloudClient {
             let text = response
                 .text()
                 .await
-                .unwrap_or_else(|e| format!("(failed to read response body: {})", e));
+                .unwrap_or_else(|e| format!("(failed to read response body: {e})"));
             Err(Self::status_to_error(status, text))
         }
     }
 
-    /// Execute DELETE request with JSON body (used by some endpoints like PrivateLink principals)
+    /// Execute DELETE request with JSON body (used by some endpoints like `PrivateLink` principals)
     #[instrument(skip(self, body), fields(method = "DELETE"))]
     pub async fn delete_with_body<T: serde::de::DeserializeOwned>(
         &self,
@@ -713,12 +735,13 @@ impl CloudClient {
         let status_code = status.as_u16();
 
         if status.is_success() {
-            let bytes = response.bytes().await.map_err(|e| {
-                RestError::ConnectionError(format!("Failed to read response: {}", e))
-            })?;
+            let bytes = response
+                .bytes()
+                .await
+                .map_err(|e| RestError::ConnectionError(format!("Failed to read response: {e}")))?;
 
             let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| {
-                RestError::ConnectionError(format!("Failed to parse JSON response: {}", e))
+                RestError::ConnectionError(format!("Failed to parse JSON response: {e}"))
             })?;
 
             Ok((status_code, value))
@@ -726,7 +749,7 @@ impl CloudClient {
             let text = response
                 .text()
                 .await
-                .unwrap_or_else(|e| format!("(failed to read response body: {})", e));
+                .unwrap_or_else(|e| format!("(failed to read response body: {e})"));
             Err(Self::status_to_error(status, text))
         }
     }
@@ -740,9 +763,10 @@ impl CloudClient {
 
         if status.is_success() {
             // Get the response bytes for better error reporting
-            let bytes = response.bytes().await.map_err(|e| {
-                RestError::ConnectionError(format!("Failed to read response: {}", e))
-            })?;
+            let bytes = response
+                .bytes()
+                .await
+                .map_err(|e| RestError::ConnectionError(format!("Failed to read response: {e}")))?;
 
             // Use serde_path_to_error for better deserialization error messages
             let deserializer = &mut serde_json::Deserializer::from_slice(&bytes);
@@ -759,15 +783,15 @@ impl CloudClient {
             let text = response
                 .text()
                 .await
-                .unwrap_or_else(|e| format!("(failed to read response body: {})", e));
+                .unwrap_or_else(|e| format!("(failed to read response body: {e})"));
             Err(Self::status_to_error(status, text))
         }
     }
 }
 
-/// Tower Service integration for CloudClient
+/// Tower Service integration for `CloudClient`
 ///
-/// This module provides Tower Service implementations for CloudClient, enabling
+/// This module provides Tower Service implementations for `CloudClient`, enabling
 /// middleware composition with patterns like circuit breakers, retry, and rate limiting.
 ///
 /// # Feature Flag
@@ -798,7 +822,7 @@ impl CloudClient {
 /// ```
 #[cfg(feature = "tower-integration")]
 pub mod tower_support {
-    use super::*;
+    use super::{CloudClient, RestError, Result};
     use std::future::Future;
     use std::pin::Pin;
     use std::task::{Context, Poll};
@@ -915,6 +939,7 @@ pub mod tower_support {
         /// # Ok(())
         /// # }
         /// ```
+        #[must_use]
         pub fn into_service(self) -> Self {
             self
         }

--- a/src/cloud_accounts.rs
+++ b/src/cloud_accounts.rs
@@ -241,6 +241,7 @@ pub struct CloudAccountsHandler {
 
 impl CloudAccountsHandler {
     /// Create a new handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -286,7 +287,7 @@ impl CloudAccountsHandler {
     pub async fn delete_cloud_account(&self, cloud_account_id: i32) -> Result<TaskStateUpdate> {
         let response = self
             .client
-            .delete_raw(&format!("/cloud-accounts/{}", cloud_account_id))
+            .delete_raw(&format!("/cloud-accounts/{cloud_account_id}"))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
     }
@@ -302,7 +303,7 @@ impl CloudAccountsHandler {
     /// See [OpenAPI Spec](https://redis.io/docs/latest/operate/rc/api/api-reference/openapi.json) - `getCloudAccountById`
     pub async fn get_cloud_account_by_id(&self, cloud_account_id: i32) -> Result<CloudAccount> {
         self.client
-            .get(&format!("/cloud-accounts/{}", cloud_account_id))
+            .get(&format!("/cloud-accounts/{cloud_account_id}"))
             .await
     }
 
@@ -321,7 +322,7 @@ impl CloudAccountsHandler {
         request: &CloudAccountUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .put(&format!("/cloud-accounts/{}", cloud_account_id), request)
+            .put(&format!("/cloud-accounts/{cloud_account_id}"), request)
             .await
     }
 }

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -2,14 +2,14 @@
 //!
 //! This module manages advanced networking features for Redis Cloud Pro subscriptions,
 //! including VPC peering, AWS Transit Gateway attachments, GCP Private Service Connect,
-//! AWS PrivateLink, and other cloud-native networking integrations.
+//! AWS `PrivateLink`, and other cloud-native networking integrations.
 //!
 //! # Supported Connectivity Types
 //!
 //! - **VPC Peering**: Direct peering between Redis Cloud VPC and your VPC
 //! - **Transit Gateway**: AWS Transit Gateway attachments for hub-and-spoke topologies
 //! - **Private Service Connect**: GCP Private Service Connect for private endpoints
-//! - **PrivateLink**: AWS PrivateLink for secure private connectivity
+//! - **`PrivateLink`**: AWS `PrivateLink` for secure private connectivity
 //!
 //! # Module Organization
 //!
@@ -17,7 +17,7 @@
 //! - `vpc_peering` - VPC peering operations for AWS, GCP, and Azure
 //! - `psc` - Google Cloud Private Service Connect endpoints
 //! - `transit_gateway` - AWS Transit Gateway attachments
-//! - `private_link` - AWS PrivateLink connectivity
+//! - `private_link` - AWS `PrivateLink` connectivity
 
 pub mod private_link;
 pub mod psc;
@@ -61,6 +61,7 @@ pub struct ConnectivityHandler {
 }
 
 impl ConnectivityHandler {
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self {
             vpc_peering: VpcPeeringHandler::new(client.clone()),

--- a/src/connectivity/private_link.rs
+++ b/src/connectivity/private_link.rs
@@ -1,20 +1,20 @@
-//! AWS PrivateLink connectivity operations
+//! AWS `PrivateLink` connectivity operations
 //!
-//! This module provides AWS PrivateLink connectivity functionality for Redis Cloud,
+//! This module provides AWS `PrivateLink` connectivity functionality for Redis Cloud,
 //! enabling secure, private connections from AWS VPCs to Redis Cloud databases.
 //!
 //! # Overview
 //!
-//! AWS PrivateLink allows you to connect to Redis Cloud from your AWS VPC without
+//! AWS `PrivateLink` allows you to connect to Redis Cloud from your AWS VPC without
 //! traversing the public internet. This provides enhanced security and potentially
 //! lower latency.
 //!
 //! # Features
 //!
-//! - **PrivateLink Management**: Create and retrieve PrivateLink configurations
+//! - **`PrivateLink` Management**: Create and retrieve `PrivateLink` configurations
 //! - **Principal Management**: Control which AWS principals can access the service
 //! - **Endpoint Scripts**: Get scripts to create endpoints in your AWS account
-//! - **Active-Active Support**: PrivateLink for CRDB (Active-Active) databases
+//! - **Active-Active Support**: `PrivateLink` for CRDB (Active-Active) databases
 //!
 //! # Example Usage
 //!
@@ -53,7 +53,7 @@ use serde_json::Value;
 // Request/Response Types
 // ============================================================================
 
-/// Principal type for PrivateLink access control
+/// Principal type for `PrivateLink` access control
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PrincipalType {
@@ -71,11 +71,11 @@ pub enum PrincipalType {
     ServicePrincipal,
 }
 
-/// Request to create a PrivateLink configuration
+/// Request to create a `PrivateLink` configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivateLinkCreateRequest {
-    /// Share name for the PrivateLink service (max 64 characters)
+    /// Share name for the `PrivateLink` service (max 64 characters)
     pub share_name: String,
 
     /// AWS principal (account ID, role ARN, etc.)
@@ -85,12 +85,12 @@ pub struct PrivateLinkCreateRequest {
     #[serde(rename = "type")]
     pub principal_type: PrincipalType,
 
-    /// Optional alias for the PrivateLink
+    /// Optional alias for the `PrivateLink`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
 }
 
-/// Request to add a principal to PrivateLink access list
+/// Request to add a principal to `PrivateLink` access list
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivateLinkAddPrincipalRequest {
@@ -106,7 +106,7 @@ pub struct PrivateLinkAddPrincipalRequest {
     pub alias: Option<String>,
 }
 
-/// Request to remove a principal from PrivateLink access list
+/// Request to remove a principal from `PrivateLink` access list
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivateLinkRemovePrincipalRequest {
@@ -122,11 +122,11 @@ pub struct PrivateLinkRemovePrincipalRequest {
     pub alias: Option<String>,
 }
 
-/// PrivateLink configuration response
+/// `PrivateLink` configuration response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivateLink {
-    /// PrivateLink status
+    /// `PrivateLink` status
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 
@@ -150,11 +150,11 @@ pub struct PrivateLink {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub share_name: Option<String>,
 
-    /// List of PrivateLink connections
+    /// List of `PrivateLink` connections
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connections: Option<Vec<PrivateLinkConnection>>,
 
-    /// List of databases accessible via PrivateLink
+    /// List of databases accessible via `PrivateLink`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub databases: Option<Vec<PrivateLinkDatabase>>,
 
@@ -171,7 +171,7 @@ pub struct PrivateLink {
     pub error_message: Option<String>,
 }
 
-/// PrivateLink principal information
+/// `PrivateLink` principal information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivateLinkPrincipal {
@@ -192,7 +192,7 @@ pub struct PrivateLinkPrincipal {
     pub status: Option<String>,
 }
 
-/// PrivateLink connection information
+/// `PrivateLink` connection information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivateLinkConnection {
@@ -217,7 +217,7 @@ pub struct PrivateLinkConnection {
     pub association_date: Option<String>,
 }
 
-/// Database accessible via PrivateLink
+/// Database accessible via `PrivateLink`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivateLinkDatabase {
@@ -234,7 +234,7 @@ pub struct PrivateLinkDatabase {
     pub resource_link_endpoint: Option<String>,
 }
 
-/// PrivateLink endpoint script response
+/// `PrivateLink` endpoint script response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivateLinkEndpointScript {
@@ -247,22 +247,23 @@ pub struct PrivateLinkEndpointScript {
     pub terraform_aws_script: Option<String>,
 }
 
-/// AWS PrivateLink handler
+/// AWS `PrivateLink` handler
 ///
-/// Manages AWS PrivateLink connectivity for Redis Cloud subscriptions.
+/// Manages AWS `PrivateLink` connectivity for Redis Cloud subscriptions.
 pub struct PrivateLinkHandler {
     client: CloudClient,
 }
 
 impl PrivateLinkHandler {
-    /// Create a new PrivateLink handler
+    /// Create a new `PrivateLink` handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
 
-    /// Get PrivateLink configuration
+    /// Get `PrivateLink` configuration
     ///
-    /// Gets the AWS PrivateLink configuration for a subscription.
+    /// Gets the AWS `PrivateLink` configuration for a subscription.
     ///
     /// GET /subscriptions/{subscriptionId}/private-link
     ///
@@ -272,23 +273,23 @@ impl PrivateLinkHandler {
     ///
     /// # Returns
     ///
-    /// Returns the PrivateLink configuration as JSON
+    /// Returns the `PrivateLink` configuration as JSON
     pub async fn get(&self, subscription_id: i32) -> Result<Value> {
         self.client
-            .get(&format!("/subscriptions/{}/private-link", subscription_id))
+            .get(&format!("/subscriptions/{subscription_id}/private-link"))
             .await
     }
 
-    /// Create a PrivateLink
+    /// Create a `PrivateLink`
     ///
-    /// Creates a new AWS PrivateLink configuration for a subscription.
+    /// Creates a new AWS `PrivateLink` configuration for a subscription.
     ///
     /// POST /subscriptions/{subscriptionId}/private-link
     ///
     /// # Arguments
     ///
     /// * `subscription_id` - The subscription ID
-    /// * `request` - PrivateLink creation request
+    /// * `request` - `PrivateLink` creation request
     ///
     /// # Returns
     ///
@@ -300,15 +301,15 @@ impl PrivateLinkHandler {
     ) -> Result<Value> {
         self.client
             .post(
-                &format!("/subscriptions/{}/private-link", subscription_id),
+                &format!("/subscriptions/{subscription_id}/private-link"),
                 request,
             )
             .await
     }
 
-    /// Add principals to PrivateLink
+    /// Add principals to `PrivateLink`
     ///
-    /// Adds AWS principals (accounts, IAM roles, etc.) that can access the PrivateLink.
+    /// Adds AWS principals (accounts, IAM roles, etc.) that can access the `PrivateLink`.
     ///
     /// POST /subscriptions/{subscriptionId}/private-link/principals
     ///
@@ -327,15 +328,15 @@ impl PrivateLinkHandler {
     ) -> Result<Value> {
         self.client
             .post(
-                &format!("/subscriptions/{}/private-link/principals", subscription_id),
+                &format!("/subscriptions/{subscription_id}/private-link/principals"),
                 request,
             )
             .await
     }
 
-    /// Remove principals from PrivateLink
+    /// Remove principals from `PrivateLink`
     ///
-    /// Removes AWS principals from the PrivateLink access list.
+    /// Removes AWS principals from the `PrivateLink` access list.
     ///
     /// DELETE /subscriptions/{subscriptionId}/private-link/principals
     ///
@@ -354,7 +355,7 @@ impl PrivateLinkHandler {
     ) -> Result<Value> {
         self.client
             .delete_with_body(
-                &format!("/subscriptions/{}/private-link/principals", subscription_id),
+                &format!("/subscriptions/{subscription_id}/private-link/principals"),
                 serde_json::to_value(request).unwrap_or_default(),
             )
             .await
@@ -376,15 +377,14 @@ impl PrivateLinkHandler {
     pub async fn get_endpoint_script(&self, subscription_id: i32) -> Result<Value> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/private-link/endpoint-script",
-                subscription_id
+                "/subscriptions/{subscription_id}/private-link/endpoint-script"
             ))
             .await
     }
 
-    /// Delete PrivateLink
+    /// Delete `PrivateLink`
     ///
-    /// Deletes the AWS PrivateLink configuration for a subscription.
+    /// Deletes the AWS `PrivateLink` configuration for a subscription.
     ///
     /// DELETE /subscriptions/{subscriptionId}/private-link
     ///
@@ -397,13 +397,13 @@ impl PrivateLinkHandler {
     /// Returns task information for tracking the deletion
     pub async fn delete(&self, subscription_id: i32) -> Result<Value> {
         self.client
-            .delete_raw(&format!("/subscriptions/{}/private-link", subscription_id))
+            .delete_raw(&format!("/subscriptions/{subscription_id}/private-link"))
             .await
     }
 
-    /// Get Active-Active PrivateLink configuration
+    /// Get Active-Active `PrivateLink` configuration
     ///
-    /// Gets the AWS PrivateLink configuration for an Active-Active (CRDB) subscription region.
+    /// Gets the AWS `PrivateLink` configuration for an Active-Active (CRDB) subscription region.
     ///
     /// GET /subscriptions/{subscriptionId}/regions/{regionId}/private-link
     ///
@@ -414,19 +414,18 @@ impl PrivateLinkHandler {
     ///
     /// # Returns
     ///
-    /// Returns the PrivateLink configuration for the region
+    /// Returns the `PrivateLink` configuration for the region
     pub async fn get_active_active(&self, subscription_id: i32, region_id: i32) -> Result<Value> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/regions/{}/private-link",
-                subscription_id, region_id
+                "/subscriptions/{subscription_id}/regions/{region_id}/private-link"
             ))
             .await
     }
 
-    /// Create Active-Active PrivateLink
+    /// Create Active-Active `PrivateLink`
     ///
-    /// Creates a new AWS PrivateLink for an Active-Active (CRDB) subscription region.
+    /// Creates a new AWS `PrivateLink` for an Active-Active (CRDB) subscription region.
     ///
     /// POST /subscriptions/{subscriptionId}/regions/{regionId}/private-link
     ///
@@ -434,7 +433,7 @@ impl PrivateLinkHandler {
     ///
     /// * `subscription_id` - The subscription ID
     /// * `region_id` - The region ID
-    /// * `request` - PrivateLink creation request
+    /// * `request` - `PrivateLink` creation request
     ///
     /// # Returns
     ///
@@ -447,18 +446,15 @@ impl PrivateLinkHandler {
     ) -> Result<Value> {
         self.client
             .post(
-                &format!(
-                    "/subscriptions/{}/regions/{}/private-link",
-                    subscription_id, region_id
-                ),
+                &format!("/subscriptions/{subscription_id}/regions/{region_id}/private-link"),
                 request,
             )
             .await
     }
 
-    /// Add principals to Active-Active PrivateLink
+    /// Add principals to Active-Active `PrivateLink`
     ///
-    /// Adds AWS principals to an Active-Active PrivateLink.
+    /// Adds AWS principals to an Active-Active `PrivateLink`.
     ///
     /// POST /subscriptions/{subscriptionId}/regions/{regionId}/private-link/principals
     ///
@@ -480,17 +476,16 @@ impl PrivateLinkHandler {
         self.client
             .post(
                 &format!(
-                    "/subscriptions/{}/regions/{}/private-link/principals",
-                    subscription_id, region_id
+                    "/subscriptions/{subscription_id}/regions/{region_id}/private-link/principals"
                 ),
                 request,
             )
             .await
     }
 
-    /// Remove principals from Active-Active PrivateLink
+    /// Remove principals from Active-Active `PrivateLink`
     ///
-    /// Removes AWS principals from an Active-Active PrivateLink.
+    /// Removes AWS principals from an Active-Active `PrivateLink`.
     ///
     /// DELETE /subscriptions/{subscriptionId}/regions/{regionId}/private-link/principals
     ///
@@ -512,8 +507,7 @@ impl PrivateLinkHandler {
         self.client
             .delete_with_body(
                 &format!(
-                    "/subscriptions/{}/regions/{}/private-link/principals",
-                    subscription_id, region_id
+                    "/subscriptions/{subscription_id}/regions/{region_id}/private-link/principals"
                 ),
                 serde_json::to_value(request).unwrap_or_default(),
             )
@@ -541,8 +535,7 @@ impl PrivateLinkHandler {
     ) -> Result<Value> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/regions/{}/private-link/endpoint-script",
-                subscription_id, region_id
+                "/subscriptions/{subscription_id}/regions/{region_id}/private-link/endpoint-script"
             ))
             .await
     }

--- a/src/connectivity/psc.rs
+++ b/src/connectivity/psc.rs
@@ -105,7 +105,7 @@ pub struct GcpCreationScript {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bash: Option<String>,
 
-    /// PowerShell script for endpoint creation
+    /// `PowerShell` script for endpoint creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub powershell: Option<String>,
 
@@ -152,7 +152,7 @@ pub struct GcpDeletionScript {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bash: Option<String>,
 
-    /// PowerShell script for endpoint deletion
+    /// `PowerShell` script for endpoint deletion
     #[serde(skip_serializing_if = "Option::is_none")]
     pub powershell: Option<String>,
 }
@@ -164,6 +164,7 @@ pub struct PscHandler {
 
 impl PscHandler {
     /// Create a new PSC handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -176,8 +177,7 @@ impl PscHandler {
     pub async fn delete_service(&self, subscription_id: i32) -> Result<serde_json::Value> {
         self.client
             .delete(&format!(
-                "/subscriptions/{}/private-service-connect",
-                subscription_id
+                "/subscriptions/{subscription_id}/private-service-connect"
             ))
             .await?;
         Ok(serde_json::Value::Null)
@@ -187,8 +187,7 @@ impl PscHandler {
     pub async fn get_service(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/private-service-connect",
-                subscription_id
+                "/subscriptions/{subscription_id}/private-service-connect"
             ))
             .await
     }
@@ -197,7 +196,7 @@ impl PscHandler {
     pub async fn create_service(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!("/subscriptions/{}/private-service-connect", subscription_id),
+                &format!("/subscriptions/{subscription_id}/private-service-connect"),
                 &serde_json::json!({}),
             )
             .await
@@ -207,8 +206,7 @@ impl PscHandler {
     pub async fn get_endpoints(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/private-service-connect/endpoints",
-                subscription_id
+                "/subscriptions/{subscription_id}/private-service-connect/endpoints"
             ))
             .await
     }
@@ -221,10 +219,7 @@ impl PscHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!(
-                    "/subscriptions/{}/private-service-connect/endpoints",
-                    subscription_id
-                ),
+                &format!("/subscriptions/{subscription_id}/private-service-connect/endpoints"),
                 request,
             )
             .await
@@ -238,8 +233,7 @@ impl PscHandler {
     ) -> Result<serde_json::Value> {
         self.client
             .delete(&format!(
-                "/subscriptions/{}/private-service-connect/endpoints/{}",
-                subscription_id, endpoint_id
+                "/subscriptions/{subscription_id}/private-service-connect/endpoints/{endpoint_id}"
             ))
             .await?;
         Ok(serde_json::Value::Null)
@@ -257,8 +251,7 @@ impl PscHandler {
         self.client
             .put(
                 &format!(
-                    "/subscriptions/{}/private-service-connect/{}/endpoints/{}",
-                    subscription_id, psc_service_id, endpoint_id
+                    "/subscriptions/{subscription_id}/private-service-connect/{psc_service_id}/endpoints/{endpoint_id}"
                 ),
                 request,
             )
@@ -273,8 +266,7 @@ impl PscHandler {
     ) -> Result<String> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/private-service-connect/endpoints/{}/creationScripts",
-                subscription_id, endpoint_id
+                "/subscriptions/{subscription_id}/private-service-connect/endpoints/{endpoint_id}/creationScripts"
             ))
             .await
     }
@@ -287,8 +279,7 @@ impl PscHandler {
     ) -> Result<String> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/private-service-connect/endpoints/{}/deletionScripts",
-                subscription_id, endpoint_id
+                "/subscriptions/{subscription_id}/private-service-connect/endpoints/{endpoint_id}/deletionScripts"
             ))
             .await
     }
@@ -304,8 +295,7 @@ impl PscHandler {
     ) -> Result<serde_json::Value> {
         self.client
             .delete(&format!(
-                "/subscriptions/{}/regions/private-service-connect",
-                subscription_id
+                "/subscriptions/{subscription_id}/regions/private-service-connect"
             ))
             .await?;
         Ok(serde_json::Value::Null)
@@ -315,8 +305,7 @@ impl PscHandler {
     pub async fn get_service_active_active(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/regions/private-service-connect",
-                subscription_id
+                "/subscriptions/{subscription_id}/regions/private-service-connect"
             ))
             .await
     }
@@ -328,10 +317,7 @@ impl PscHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!(
-                    "/subscriptions/{}/regions/private-service-connect",
-                    subscription_id
-                ),
+                &format!("/subscriptions/{subscription_id}/regions/private-service-connect"),
                 &serde_json::json!({}),
             )
             .await
@@ -344,8 +330,7 @@ impl PscHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/regions/private-service-connect/endpoints",
-                subscription_id
+                "/subscriptions/{subscription_id}/regions/private-service-connect/endpoints"
             ))
             .await
     }
@@ -359,8 +344,7 @@ impl PscHandler {
         self.client
             .post(
                 &format!(
-                    "/subscriptions/{}/regions/private-service-connect/endpoints",
-                    subscription_id
+                    "/subscriptions/{subscription_id}/regions/private-service-connect/endpoints"
                 ),
                 request,
             )
@@ -376,8 +360,7 @@ impl PscHandler {
     ) -> Result<serde_json::Value> {
         self.client
             .delete(&format!(
-                "/subscriptions/{}/regions/{}/private-service-connect/endpoints/{}",
-                subscription_id, region_id, endpoint_id
+                "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/endpoints/{endpoint_id}"
             ))
             .await?;
         Ok(serde_json::Value::Null)
@@ -394,8 +377,7 @@ impl PscHandler {
         self.client
             .put(
                 &format!(
-                    "/subscriptions/{}/regions/{}/private-service-connect/{}/endpoints/{}",
-                    subscription_id, region_id, subscription_id, endpoint_id
+                    "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/{subscription_id}/endpoints/{endpoint_id}"
                 ),
                 request,
             )
@@ -412,8 +394,7 @@ impl PscHandler {
     ) -> Result<String> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/regions/{}/private-service-connect/{}/endpoints/{}/creationScripts",
-                subscription_id, region_id, psc_service_id, endpoint_id
+                "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/{psc_service_id}/endpoints/{endpoint_id}/creationScripts"
             ))
             .await
     }
@@ -428,8 +409,7 @@ impl PscHandler {
     ) -> Result<String> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/regions/{}/private-service-connect/{}/endpoints/{}/deletionScripts",
-                subscription_id, region_id, psc_service_id, endpoint_id
+                "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/{psc_service_id}/endpoints/{endpoint_id}/deletionScripts"
             ))
             .await
     }

--- a/src/connectivity/transit_gateway.rs
+++ b/src/connectivity/transit_gateway.rs
@@ -128,6 +128,7 @@ pub struct TransitGatewayHandler {
 
 impl TransitGatewayHandler {
     /// Create a new Transit Gateway handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -139,10 +140,7 @@ impl TransitGatewayHandler {
     /// Get Transit Gateway attachments
     pub async fn get_attachments(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
-            .get(&format!(
-                "/subscriptions/{}/transitGateways",
-                subscription_id
-            ))
+            .get(&format!("/subscriptions/{subscription_id}/transitGateways"))
             .await
     }
 
@@ -150,8 +148,7 @@ impl TransitGatewayHandler {
     pub async fn get_shared_invitations(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/tgw/shared-invitations",
-                subscription_id
+                "/subscriptions/{subscription_id}/tgw/shared-invitations"
             ))
             .await
     }
@@ -165,8 +162,7 @@ impl TransitGatewayHandler {
         self.client
             .post(
                 &format!(
-                    "/subscriptions/{}/tgw/shared-invitations/{}/accept",
-                    subscription_id, invitation_id
+                    "/subscriptions/{subscription_id}/tgw/shared-invitations/{invitation_id}/accept"
                 ),
                 &serde_json::json!({}),
             )
@@ -182,8 +178,7 @@ impl TransitGatewayHandler {
         self.client
             .post(
                 &format!(
-                    "/subscriptions/{}/tgw/shared-invitations/{}/reject",
-                    subscription_id, invitation_id
+                    "/subscriptions/{subscription_id}/tgw/shared-invitations/{invitation_id}/reject"
                 ),
                 &serde_json::json!({}),
             )
@@ -198,14 +193,13 @@ impl TransitGatewayHandler {
     ) -> Result<serde_json::Value> {
         self.client
             .delete(&format!(
-                "/subscriptions/{}/transitGateways/{}/attachment",
-                subscription_id, attachment_id
+                "/subscriptions/{subscription_id}/transitGateways/{attachment_id}/attachment"
             ))
             .await?;
         Ok(serde_json::Value::Null)
     }
 
-    /// Create Transit Gateway attachment with tgw_id in path
+    /// Create Transit Gateway attachment with `tgw_id` in path
     pub async fn create_attachment_with_id(
         &self,
         subscription_id: i32,
@@ -219,10 +213,7 @@ impl TransitGatewayHandler {
 
         self.client
             .post(
-                &format!(
-                    "/subscriptions/{}/transitGateways/{}/attachment",
-                    subscription_id, tgw_id
-                ),
+                &format!("/subscriptions/{subscription_id}/transitGateways/{tgw_id}/attachment"),
                 &request,
             )
             .await
@@ -236,10 +227,7 @@ impl TransitGatewayHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!(
-                    "/subscriptions/{}/transitGateways/attachments",
-                    subscription_id
-                ),
+                &format!("/subscriptions/{subscription_id}/transitGateways/attachments"),
                 request,
             )
             .await
@@ -255,8 +243,7 @@ impl TransitGatewayHandler {
         self.client
             .put(
                 &format!(
-                    "/subscriptions/{}/transitGateways/{}/attachment",
-                    subscription_id, attachment_id
+                    "/subscriptions/{subscription_id}/transitGateways/{attachment_id}/attachment"
                 ),
                 request,
             )
@@ -274,8 +261,7 @@ impl TransitGatewayHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/regions/transitGateways",
-                subscription_id
+                "/subscriptions/{subscription_id}/regions/transitGateways"
             ))
             .await
     }
@@ -287,8 +273,7 @@ impl TransitGatewayHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/regions/tgw/shared-invitations",
-                subscription_id
+                "/subscriptions/{subscription_id}/regions/tgw/shared-invitations"
             ))
             .await
     }
@@ -303,8 +288,7 @@ impl TransitGatewayHandler {
         self.client
             .post(
                 &format!(
-                    "/subscriptions/{}/regions/{}/tgw/shared-invitations/{}/accept",
-                    subscription_id, region_id, invitation_id
+                    "/subscriptions/{subscription_id}/regions/{region_id}/tgw/shared-invitations/{invitation_id}/accept"
                 ),
                 &serde_json::json!({}),
             )
@@ -321,8 +305,7 @@ impl TransitGatewayHandler {
         self.client
             .post(
                 &format!(
-                    "/subscriptions/{}/regions/{}/tgw/shared-invitations/{}/reject",
-                    subscription_id, region_id, invitation_id
+                    "/subscriptions/{subscription_id}/regions/{region_id}/tgw/shared-invitations/{invitation_id}/reject"
                 ),
                 &serde_json::json!({}),
             )
@@ -338,8 +321,7 @@ impl TransitGatewayHandler {
     ) -> Result<serde_json::Value> {
         self.client
             .delete(&format!(
-                "/subscriptions/{}/regions/{}/tgw/attachments/{}",
-                subscription_id, region_id, attachment_id
+                "/subscriptions/{subscription_id}/regions/{region_id}/tgw/attachments/{attachment_id}"
             ))
             .await?;
         Ok(serde_json::Value::Null)
@@ -354,10 +336,7 @@ impl TransitGatewayHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!(
-                    "/subscriptions/{}/regions/{}/tgw/attachments",
-                    subscription_id, region_id
-                ),
+                &format!("/subscriptions/{subscription_id}/regions/{region_id}/tgw/attachments"),
                 request,
             )
             .await
@@ -374,8 +353,7 @@ impl TransitGatewayHandler {
         self.client
             .put(
                 &format!(
-                    "/subscriptions/{}/regions/{}/tgw/attachments/{}/cidrs",
-                    subscription_id, region_id, attachment_id
+                    "/subscriptions/{subscription_id}/regions/{region_id}/tgw/attachments/{attachment_id}/cidrs"
                 ),
                 request,
             )

--- a/src/connectivity/vpc_peering.rs
+++ b/src/connectivity/vpc_peering.rs
@@ -257,6 +257,7 @@ pub struct VpcPeeringHandler {
 
 impl VpcPeeringHandler {
     /// Create a new VPC peering handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -268,7 +269,7 @@ impl VpcPeeringHandler {
     /// Get VPC peering for subscription
     pub async fn get(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
-            .get(&format!("/subscriptions/{}/peerings", subscription_id))
+            .get(&format!("/subscriptions/{subscription_id}/peerings"))
             .await
     }
 
@@ -280,7 +281,7 @@ impl VpcPeeringHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!("/subscriptions/{}/peerings", subscription_id),
+                &format!("/subscriptions/{subscription_id}/peerings"),
                 request,
             )
             .await
@@ -290,8 +291,7 @@ impl VpcPeeringHandler {
     pub async fn delete(&self, subscription_id: i32, peering_id: i32) -> Result<serde_json::Value> {
         self.client
             .delete(&format!(
-                "/subscriptions/{}/peerings/{}",
-                subscription_id, peering_id
+                "/subscriptions/{subscription_id}/peerings/{peering_id}"
             ))
             .await?;
         Ok(serde_json::Value::Null)
@@ -306,7 +306,7 @@ impl VpcPeeringHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .put(
-                &format!("/subscriptions/{}/peerings/{}", subscription_id, peering_id),
+                &format!("/subscriptions/{subscription_id}/peerings/{peering_id}"),
                 request,
             )
             .await

--- a/src/cost_report.rs
+++ b/src/cost_report.rs
@@ -1,7 +1,7 @@
 //! Cost Report Generation and Retrieval
 //!
 //! This module provides functionality for generating and downloading cost reports
-//! in FOCUS format from Redis Cloud. FOCUS (FinOps Cost and Usage Specification)
+//! in FOCUS format from Redis Cloud. FOCUS (`FinOps` Cost and Usage Specification)
 //! is an open standard for cloud cost data.
 //!
 //! # Overview
@@ -60,7 +60,7 @@
 //!
 //! The cost report follows the [FOCUS specification](https://focus.finops.org/),
 //! providing standardized columns including:
-//! - BilledCost, EffectiveCost, ListCost, ContractedCost
+//! - `BilledCost`, `EffectiveCost`, `ListCost`, `ContractedCost`
 //! - Resource identifiers (subscription, database)
 //! - Service categories and SKU details
 //! - Billing period and usage information
@@ -143,7 +143,7 @@ pub struct CostReportCreateRequest {
     pub start_date: String,
 
     /// End date for the report (YYYY-MM-DD format, required)
-    /// Must be after start_date and within 40 days of start_date
+    /// Must be after `start_date` and within 40 days of `start_date`
     pub end_date: String,
 
     /// Output format (csv or json, defaults to csv)
@@ -173,6 +173,7 @@ pub struct CostReportCreateRequest {
 
 impl CostReportCreateRequest {
     /// Create a new cost report request builder
+    #[must_use]
     pub fn builder() -> CostReportCreateRequestBuilder {
         CostReportCreateRequestBuilder::default()
     }
@@ -187,7 +188,7 @@ impl CostReportCreateRequest {
     }
 }
 
-/// Builder for CostReportCreateRequest
+/// Builder for `CostReportCreateRequest`
 #[derive(Debug, Clone, Default)]
 pub struct CostReportCreateRequestBuilder {
     start_date: Option<String>,
@@ -202,54 +203,63 @@ pub struct CostReportCreateRequestBuilder {
 
 impl CostReportCreateRequestBuilder {
     /// Set the start date (required, YYYY-MM-DD format)
+    #[must_use]
     pub fn start_date(mut self, date: impl Into<String>) -> Self {
         self.start_date = Some(date.into());
         self
     }
 
     /// Set the end date (required, YYYY-MM-DD format)
+    #[must_use]
     pub fn end_date(mut self, date: impl Into<String>) -> Self {
         self.end_date = Some(date.into());
         self
     }
 
     /// Set the output format
+    #[must_use]
     pub fn format(mut self, format: CostReportFormat) -> Self {
         self.format = Some(format);
         self
     }
 
     /// Filter by subscription IDs
+    #[must_use]
     pub fn subscription_ids(mut self, ids: Vec<i32>) -> Self {
         self.subscription_ids = Some(ids);
         self
     }
 
     /// Filter by database IDs
+    #[must_use]
     pub fn database_ids(mut self, ids: Vec<i32>) -> Self {
         self.database_ids = Some(ids);
         self
     }
 
     /// Filter by subscription type
+    #[must_use]
     pub fn subscription_type(mut self, sub_type: SubscriptionType) -> Self {
         self.subscription_type = Some(sub_type);
         self
     }
 
     /// Filter by regions
+    #[must_use]
     pub fn regions(mut self, regions: Vec<String>) -> Self {
         self.regions = Some(regions);
         self
     }
 
     /// Filter by tags
+    #[must_use]
     pub fn tags(mut self, tags: Vec<Tag>) -> Self {
         self.tags = Some(tags);
         self
     }
 
     /// Add a single tag filter
+    #[must_use]
     pub fn tag(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let tag = Tag::new(key, value);
         match &mut self.tags {
@@ -300,6 +310,7 @@ pub struct CostReportHandler {
 
 impl CostReportHandler {
     /// Create a new handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -309,8 +320,8 @@ impl CostReportHandler {
     /// Generates a cost report in FOCUS format for the specified time period
     /// and filters. The maximum date range is 40 days.
     ///
-    /// This is an asynchronous operation. The returned TaskStateUpdate contains
-    /// a task_id that can be used to track progress. Once complete, the task
+    /// This is an asynchronous operation. The returned `TaskStateUpdate` contains
+    /// a `task_id` that can be used to track progress. Once complete, the task
     /// response will contain the costReportId needed to download the report.
     ///
     /// POST /cost-report
@@ -319,7 +330,7 @@ impl CostReportHandler {
     /// * `request` - The cost report generation request with date range and filters
     ///
     /// # Returns
-    /// A TaskStateUpdate with the task ID for tracking the generation
+    /// A `TaskStateUpdate` with the task ID for tracking the generation
     ///
     /// # Example
     /// ```no_run
@@ -377,7 +388,7 @@ impl CostReportHandler {
     /// ```
     pub async fn download_cost_report(&self, cost_report_id: &str) -> Result<Vec<u8>> {
         self.client
-            .get_bytes(&format!("/cost-report/{}", cost_report_id))
+            .get_bytes(&format!("/cost-report/{cost_report_id}"))
             .await
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -121,6 +121,7 @@ impl CloudError {
     /// let error = CloudError::NotFound { message: "Resource not found".to_string() };
     /// assert!(!error.is_retryable());
     /// ```
+    #[must_use]
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,

--- a/src/fixed/databases.rs
+++ b/src/fixed/databases.rs
@@ -55,7 +55,7 @@ use std::collections::HashMap;
 // Models
 // ============================================================================
 
-/// RedisLabs Account Subscription Databases information
+/// `RedisLabs` Account Subscription Databases information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountFixedSubscriptionDatabases {
@@ -107,7 +107,7 @@ pub struct DatabaseTagUpdateRequest {
     pub command_type: Option<String>,
 }
 
-/// DynamicEndpoints
+/// `DynamicEndpoints`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DynamicEndpoints {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -152,7 +152,7 @@ pub struct DatabaseTagsUpdateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseSyncSourceSpec {
-    /// Redis URI of a source database. Example format: 'redis://user:password@host:port'. If the URI provided is a Redis Cloud database, only host and port should be provided. Example: 'redis://endpoint1:6379'.
+    /// Redis URI of a source database. Example format: 'redis://user:password@host:port'. If the URI provided is a Redis Cloud database, only host and port should be provided. Example: '<redis://endpoint1:6379>'.
     pub endpoint: String,
 
     /// Defines if encryption should be used to connect to the sync source. If not set the source is a Redis Cloud database, it will automatically detect if the source uses encryption.
@@ -315,7 +315,7 @@ pub struct CloudTags {
     pub links: Option<Vec<Link>>,
 }
 
-/// FixedDatabase
+/// `FixedDatabase`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedDatabase {
@@ -460,7 +460,7 @@ pub struct FixedDatabase {
     pub links: Option<Vec<Link>>,
 }
 
-/// DatabaseSlowLogEntries
+/// `DatabaseSlowLogEntries`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatabaseSlowLogEntries {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -471,7 +471,7 @@ pub struct DatabaseSlowLogEntries {
     pub links: Option<Vec<Link>>,
 }
 
-/// TaskStateUpdate
+/// `TaskStateUpdate`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskStateUpdate {
@@ -568,7 +568,7 @@ pub struct FixedDatabaseCreateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regex_rules: Option<Vec<String>>,
 
-    /// Optional. This database will be a replica of the specified Redis databases provided as one or more URI(s). Example: 'redis://user:password@host:port'. If the URI provided is a Redis Cloud database, only host and port should be provided. Example: ['redis://endpoint1:6379', 'redis://endpoint2:6380'].
+    /// Optional. This database will be a replica of the specified Redis databases provided as one or more URI(s). Example: 'redis://user:password@host:port'. If the URI provided is a Redis Cloud database, only host and port should be provided. Example: ['<redis://endpoint1:6379>', '<redis://endpoint2:6380>'].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replica_of: Option<Vec<String>>,
 
@@ -665,7 +665,7 @@ pub struct FixedDatabaseUpdateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_ips: Option<Vec<String>>,
 
-    /// Optional. This database will be a replica of the specified Redis databases provided as one or more URI (sample format: 'redis://user:password@host:port)'. If the URI provided is Redis Cloud instance, only host and port should be provided (using the format: ['redis://endpoint1:6379', 'redis://endpoint2:6380'] ).
+    /// Optional. This database will be a replica of the specified Redis databases provided as one or more URI (sample format: 'redis://user:password@host:port)'. If the URI provided is Redis Cloud instance, only host and port should be provided (using the format: ['<redis://endpoint1:6379>', '<redis://endpoint2:6380>'] ).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replica_of: Option<Vec<String>>,
 
@@ -718,6 +718,7 @@ pub struct FixedDatabaseHandler {
 
 impl FixedDatabaseHandler {
     /// Create a new handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -734,10 +735,10 @@ impl FixedDatabaseHandler {
     ) -> Result<AccountFixedSubscriptionDatabases> {
         let mut query = Vec::new();
         if let Some(v) = offset {
-            query.push(format!("offset={}", v));
+            query.push(format!("offset={v}"));
         }
         if let Some(v) = limit {
-            query.push(format!("limit={}", v));
+            query.push(format!("limit={v}"));
         }
         let query_string = if query.is_empty() {
             String::new()
@@ -746,8 +747,7 @@ impl FixedDatabaseHandler {
         };
         self.client
             .get(&format!(
-                "/fixed/subscriptions/{}/databases{}",
-                subscription_id, query_string
+                "/fixed/subscriptions/{subscription_id}/databases{query_string}"
             ))
             .await
     }
@@ -763,7 +763,7 @@ impl FixedDatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!("/fixed/subscriptions/{}/databases", subscription_id),
+                &format!("/fixed/subscriptions/{subscription_id}/databases"),
                 request,
             )
             .await
@@ -781,8 +781,7 @@ impl FixedDatabaseHandler {
         let response = self
             .client
             .delete_raw(&format!(
-                "/fixed/subscriptions/{}/databases/{}",
-                subscription_id, database_id
+                "/fixed/subscriptions/{subscription_id}/databases/{database_id}"
             ))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
@@ -795,8 +794,7 @@ impl FixedDatabaseHandler {
     pub async fn get_by_id(&self, subscription_id: i32, database_id: i32) -> Result<FixedDatabase> {
         self.client
             .get(&format!(
-                "/fixed/subscriptions/{}/databases/{}",
-                subscription_id, database_id
+                "/fixed/subscriptions/{subscription_id}/databases/{database_id}"
             ))
             .await
     }
@@ -813,10 +811,7 @@ impl FixedDatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .put(
-                &format!(
-                    "/fixed/subscriptions/{}/databases/{}",
-                    subscription_id, database_id
-                ),
+                &format!("/fixed/subscriptions/{subscription_id}/databases/{database_id}"),
                 request,
             )
             .await
@@ -833,8 +828,7 @@ impl FixedDatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/fixed/subscriptions/{}/databases/{}/backup",
-                subscription_id, database_id
+                "/fixed/subscriptions/{subscription_id}/databases/{database_id}/backup"
             ))
             .await
     }
@@ -851,10 +845,7 @@ impl FixedDatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!(
-                    "/fixed/subscriptions/{}/databases/{}/backup",
-                    subscription_id, database_id
-                ),
+                &format!("/fixed/subscriptions/{subscription_id}/databases/{database_id}/backup"),
                 request,
             )
             .await
@@ -871,8 +862,7 @@ impl FixedDatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/fixed/subscriptions/{}/databases/{}/import",
-                subscription_id, database_id
+                "/fixed/subscriptions/{subscription_id}/databases/{database_id}/import"
             ))
             .await
     }
@@ -889,10 +879,7 @@ impl FixedDatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!(
-                    "/fixed/subscriptions/{}/databases/{}/import",
-                    subscription_id, database_id
-                ),
+                &format!("/fixed/subscriptions/{subscription_id}/databases/{database_id}/import"),
                 request,
             )
             .await
@@ -909,8 +896,7 @@ impl FixedDatabaseHandler {
     ) -> Result<DatabaseSlowLogEntries> {
         self.client
             .get(&format!(
-                "/fixed/subscriptions/{}/databases/{}/slow-log",
-                subscription_id, database_id
+                "/fixed/subscriptions/{subscription_id}/databases/{database_id}/slow-log"
             ))
             .await
     }
@@ -922,8 +908,7 @@ impl FixedDatabaseHandler {
     pub async fn get_tags(&self, subscription_id: i32, database_id: i32) -> Result<CloudTags> {
         self.client
             .get(&format!(
-                "/fixed/subscriptions/{}/databases/{}/tags",
-                subscription_id, database_id
+                "/fixed/subscriptions/{subscription_id}/databases/{database_id}/tags"
             ))
             .await
     }
@@ -940,10 +925,7 @@ impl FixedDatabaseHandler {
     ) -> Result<CloudTag> {
         self.client
             .post(
-                &format!(
-                    "/fixed/subscriptions/{}/databases/{}/tags",
-                    subscription_id, database_id
-                ),
+                &format!("/fixed/subscriptions/{subscription_id}/databases/{database_id}/tags"),
                 request,
             )
             .await
@@ -961,10 +943,7 @@ impl FixedDatabaseHandler {
     ) -> Result<CloudTags> {
         self.client
             .put(
-                &format!(
-                    "/fixed/subscriptions/{}/databases/{}/tags",
-                    subscription_id, database_id
-                ),
+                &format!("/fixed/subscriptions/{subscription_id}/databases/{database_id}/tags"),
                 request,
             )
             .await
@@ -983,8 +962,7 @@ impl FixedDatabaseHandler {
         let response = self
             .client
             .delete_raw(&format!(
-                "/fixed/subscriptions/{}/databases/{}/tags/{}",
-                subscription_id, database_id, tag_key
+                "/fixed/subscriptions/{subscription_id}/databases/{database_id}/tags/{tag_key}"
             ))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
@@ -1004,8 +982,7 @@ impl FixedDatabaseHandler {
         self.client
             .put(
                 &format!(
-                    "/fixed/subscriptions/{}/databases/{}/tags/{}",
-                    subscription_id, database_id, tag_key
+                    "/fixed/subscriptions/{subscription_id}/databases/{database_id}/tags/{tag_key}"
                 ),
                 request,
             )
@@ -1027,8 +1004,7 @@ impl FixedDatabaseHandler {
     ) -> Result<Value> {
         self.client
             .get_raw(&format!(
-                "/fixed/subscriptions/{}/databases/{}/available-target-versions",
-                subscription_id, database_id
+                "/fixed/subscriptions/{subscription_id}/databases/{database_id}/available-target-versions"
             ))
             .await
     }
@@ -1044,8 +1020,7 @@ impl FixedDatabaseHandler {
     ) -> Result<Value> {
         self.client
             .get_raw(&format!(
-                "/fixed/subscriptions/{}/databases/{}/upgrade",
-                subscription_id, database_id
+                "/fixed/subscriptions/{subscription_id}/databases/{database_id}/upgrade"
             ))
             .await
     }
@@ -1065,10 +1040,7 @@ impl FixedDatabaseHandler {
         });
         self.client
             .post_raw(
-                &format!(
-                    "/fixed/subscriptions/{}/databases/{}/upgrade",
-                    subscription_id, database_id
-                ),
+                &format!("/fixed/subscriptions/{subscription_id}/databases/{database_id}/upgrade"),
                 request,
             )
             .await

--- a/src/fixed/subscriptions.rs
+++ b/src/fixed/subscriptions.rs
@@ -57,7 +57,7 @@ use serde::{Deserialize, Serialize};
 // Models
 // ============================================================================
 
-/// RedisVersions
+/// `RedisVersions`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RedisVersions {
@@ -214,12 +214,16 @@ pub struct FixedSubscriptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_id: Option<i32>,
 
+    /// List of Essentials subscriptions
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscriptions: Option<Vec<FixedSubscription>>,
+
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Vec<Link>>,
 }
 
-/// RedisVersion
+/// `RedisVersion`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RedisVersion {
@@ -323,7 +327,7 @@ pub struct FixedSubscription {
     pub links: Option<Vec<Link>>,
 }
 
-/// TaskStateUpdate
+/// `TaskStateUpdate`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskStateUpdate {
@@ -364,6 +368,7 @@ pub struct FixedSubscriptionHandler {
 
 impl FixedSubscriptionHandler {
     /// Create a new handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -379,10 +384,10 @@ impl FixedSubscriptionHandler {
     ) -> Result<FixedSubscriptionsPlans> {
         let mut query = Vec::new();
         if let Some(v) = provider {
-            query.push(format!("provider={}", v));
+            query.push(format!("provider={v}"));
         }
         if let Some(v) = redis_flex {
-            query.push(format!("redisFlex={}", v));
+            query.push(format!("redisFlex={v}"));
         }
         let query_string = if query.is_empty() {
             String::new()
@@ -390,7 +395,7 @@ impl FixedSubscriptionHandler {
             format!("?{}", query.join("&"))
         };
         self.client
-            .get(&format!("/fixed/plans{}", query_string))
+            .get(&format!("/fixed/plans{query_string}"))
             .await
     }
 
@@ -403,7 +408,7 @@ impl FixedSubscriptionHandler {
         subscription_id: i32,
     ) -> Result<FixedSubscriptionsPlans> {
         self.client
-            .get(&format!("/fixed/plans/subscriptions/{}", subscription_id))
+            .get(&format!("/fixed/plans/subscriptions/{subscription_id}"))
             .await
     }
 
@@ -412,7 +417,7 @@ impl FixedSubscriptionHandler {
     ///
     /// GET /fixed/plans/{planId}
     pub async fn get_plan_by_id(&self, plan_id: i32) -> Result<FixedSubscriptionsPlan> {
-        self.client.get(&format!("/fixed/plans/{}", plan_id)).await
+        self.client.get(&format!("/fixed/plans/{plan_id}")).await
     }
 
     /// Get available Redis database versions for specific Essentials subscription
@@ -421,14 +426,14 @@ impl FixedSubscriptionHandler {
     /// GET /fixed/redis-versions
     pub async fn get_redis_versions(&self, subscription_id: i32) -> Result<RedisVersions> {
         let mut query = Vec::new();
-        query.push(format!("subscriptionId={}", subscription_id));
+        query.push(format!("subscriptionId={subscription_id}"));
         let query_string = if query.is_empty() {
             String::new()
         } else {
             format!("?{}", query.join("&"))
         };
         self.client
-            .get(&format!("/fixed/redis-versions{}", query_string))
+            .get(&format!("/fixed/redis-versions{query_string}"))
             .await
     }
 
@@ -458,7 +463,7 @@ impl FixedSubscriptionHandler {
     pub async fn delete_by_id(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         let response = self
             .client
-            .delete_raw(&format!("/fixed/subscriptions/{}", subscription_id))
+            .delete_raw(&format!("/fixed/subscriptions/{subscription_id}"))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
     }
@@ -469,7 +474,7 @@ impl FixedSubscriptionHandler {
     /// GET /fixed/subscriptions/{subscriptionId}
     pub async fn get_by_id(&self, subscription_id: i32) -> Result<FixedSubscription> {
         self.client
-            .get(&format!("/fixed/subscriptions/{}", subscription_id))
+            .get(&format!("/fixed/subscriptions/{subscription_id}"))
             .await
     }
 
@@ -483,10 +488,7 @@ impl FixedSubscriptionHandler {
         request: &FixedSubscriptionUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .put(
-                &format!("/fixed/subscriptions/{}", subscription_id),
-                request,
-            )
+            .put(&format!("/fixed/subscriptions/{subscription_id}"), request)
             .await
     }
 }

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -15,7 +15,7 @@
 //! - **Database Lifecycle**: Create, update, delete, and manage databases
 //! - **Backup & Restore**: Automated and on-demand backup operations
 //! - **Import/Export**: Import data from RDB files or other Redis instances
-//! - **Modules**: Support for RedisJSON, RediSearch, RedisGraph, RedisTimeSeries, RedisBloom
+//! - **Modules**: Support for `RedisJSON`, `RediSearch`, `RedisGraph`, `RedisTimeSeries`, `RedisBloom`
 //! - **High Availability**: Replication, auto-failover, and clustering support
 //! - **Monitoring**: Metrics, alerts, and performance insights
 //! - **Security**: TLS, password protection, and ACL support
@@ -63,7 +63,7 @@ use std::collections::HashMap;
 // Models
 // ============================================================================
 
-/// RedisLabs Account Subscription Databases information
+/// `RedisLabs` Account Subscription Databases information
 ///
 /// Response from GET /subscriptions/{subscriptionId}/databases
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,7 +83,7 @@ pub struct AccountSubscriptionDatabases {
     pub links: Option<Vec<Link>>,
 }
 
-/// Subscription databases info returned within AccountSubscriptionDatabases
+/// Subscription databases info returned within `AccountSubscriptionDatabases`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionDatabasesInfo {
@@ -125,8 +125,7 @@ where
             Ok(vec![item])
         }
         Some(other) => Err(serde::de::Error::custom(format!(
-            "expected array or object for subscription, got {:?}",
-            other
+            "expected array or object for subscription, got {other:?}"
         ))),
     }
 }
@@ -226,7 +225,7 @@ pub struct DatabaseTagsUpdateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseSyncSourceSpec {
-    /// Redis URI of a source database. Example format: 'redis://user:password@host:port'. If the URI provided is a Redis Cloud database, only host and port should be provided. Example: 'redis://endpoint1:6379'.
+    /// Redis URI of a source database. Example format: 'redis://user:password@host:port'. If the URI provided is a Redis Cloud database, only host and port should be provided. Example: '<redis://endpoint1:6379>'.
     pub endpoint: String,
 
     /// Defines if encryption should be used to connect to the sync source. If not set the source is a Redis Cloud database, it will automatically detect if the source uses encryption.
@@ -267,7 +266,7 @@ pub struct CloudTag {
     pub links: Option<Vec<Link>>,
 }
 
-/// BdbVersionUpgradeStatus
+/// `BdbVersionUpgradeStatus`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BdbVersionUpgradeStatus {
@@ -828,7 +827,7 @@ pub struct Database {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_ip: Option<Vec<String>>,
 
-    /// Client TLS/SSL certificate (deprecated, use client_tls_certificates)
+    /// Client TLS/SSL certificate (deprecated, use `client_tls_certificates`)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_ssl_certificate: Option<String>,
 
@@ -992,7 +991,7 @@ pub struct DatabaseCreateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replication: Option<bool>,
 
-    /// Optional. This database will be a replica of the specified Redis databases provided as one or more URI(s). Example: 'redis://user:password@host:port'. If the URI provided is a Redis Cloud database, only host and port should be provided. Example: ['redis://endpoint1:6379', 'redis://endpoint2:6380'].
+    /// Optional. This database will be a replica of the specified Redis databases provided as one or more URI(s). Example: 'redis://user:password@host:port'. If the URI provided is a Redis Cloud database, only host and port should be provided. Example: ['<redis://endpoint1:6379>', '<redis://endpoint2:6380>'].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replica_of: Option<Vec<String>>,
 
@@ -1114,7 +1113,7 @@ pub struct DatabaseUpgradeRedisVersionRequest {
     pub command_type: Option<String>,
 }
 
-/// DatabaseSlowLogEntries
+/// `DatabaseSlowLogEntries`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatabaseSlowLogEntries {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1160,7 +1159,7 @@ pub struct LocalRegionProperties {
     pub resp_version: Option<String>,
 }
 
-/// TaskStateUpdate
+/// `TaskStateUpdate`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskStateUpdate {
@@ -1236,7 +1235,7 @@ pub struct DatabaseUpdateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regex_rules: Option<Vec<String>>,
 
-    /// Optional. This database will be a replica of the specified Redis databases provided as one or more URI(s). Example: 'redis://user:password@host:port'. If the URI provided is a Redis Cloud database, only host and port should be provided. Example: ['redis://endpoint1:6379', 'redis://endpoint2:6380'].
+    /// Optional. This database will be a replica of the specified Redis databases provided as one or more URI(s). Example: 'redis://user:password@host:port'. If the URI provided is a Redis Cloud database, only host and port should be provided. Example: ['<redis://endpoint1:6379>', '<redis://endpoint2:6380>'].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replica_of: Option<Vec<String>>,
 
@@ -1316,6 +1315,7 @@ pub struct DatabaseHandler {
 
 impl DatabaseHandler {
     /// Create a new handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -1359,10 +1359,10 @@ impl DatabaseHandler {
     ) -> Result<AccountSubscriptionDatabases> {
         let mut query = Vec::new();
         if let Some(v) = offset {
-            query.push(format!("offset={}", v));
+            query.push(format!("offset={v}"));
         }
         if let Some(v) = limit {
-            query.push(format!("limit={}", v));
+            query.push(format!("limit={v}"));
         }
         let query_string = if query.is_empty() {
             String::new()
@@ -1371,8 +1371,7 @@ impl DatabaseHandler {
         };
         self.client
             .get(&format!(
-                "/subscriptions/{}/databases{}",
-                subscription_id, query_string
+                "/subscriptions/{subscription_id}/databases{query_string}"
             ))
             .await
     }
@@ -1388,7 +1387,7 @@ impl DatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!("/subscriptions/{}/databases", subscription_id),
+                &format!("/subscriptions/{subscription_id}/databases"),
                 request,
             )
             .await
@@ -1406,8 +1405,7 @@ impl DatabaseHandler {
         let response = self
             .client
             .delete_raw(&format!(
-                "/subscriptions/{}/databases/{}",
-                subscription_id, database_id
+                "/subscriptions/{subscription_id}/databases/{database_id}"
             ))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
@@ -1445,8 +1443,7 @@ impl DatabaseHandler {
     ) -> Result<Database> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/databases/{}",
-                subscription_id, database_id
+                "/subscriptions/{subscription_id}/databases/{database_id}"
             ))
             .await
     }
@@ -1463,10 +1460,7 @@ impl DatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .put(
-                &format!(
-                    "/subscriptions/{}/databases/{}",
-                    subscription_id, database_id
-                ),
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}"),
                 request,
             )
             .await
@@ -1484,7 +1478,7 @@ impl DatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         let mut query = Vec::new();
         if let Some(v) = region_name {
-            query.push(format!("regionName={}", v));
+            query.push(format!("regionName={v}"));
         }
         let query_string = if query.is_empty() {
             String::new()
@@ -1493,8 +1487,7 @@ impl DatabaseHandler {
         };
         self.client
             .get(&format!(
-                "/subscriptions/{}/databases/{}/backup{}",
-                subscription_id, database_id, query_string
+                "/subscriptions/{subscription_id}/databases/{database_id}/backup{query_string}"
             ))
             .await
     }
@@ -1511,10 +1504,7 @@ impl DatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!(
-                    "/subscriptions/{}/databases/{}/backup",
-                    subscription_id, database_id
-                ),
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}/backup"),
                 request,
             )
             .await
@@ -1531,8 +1521,7 @@ impl DatabaseHandler {
     ) -> Result<DatabaseCertificate> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/databases/{}/certificate",
-                subscription_id, database_id
+                "/subscriptions/{subscription_id}/databases/{database_id}/certificate"
             ))
             .await
     }
@@ -1549,10 +1538,7 @@ impl DatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .put(
-                &format!(
-                    "/subscriptions/{}/databases/{}/flush",
-                    subscription_id, database_id
-                ),
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}/flush"),
                 request,
             )
             .await
@@ -1569,8 +1555,7 @@ impl DatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/databases/{}/import",
-                subscription_id, database_id
+                "/subscriptions/{subscription_id}/databases/{database_id}/import"
             ))
             .await
     }
@@ -1587,10 +1572,7 @@ impl DatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!(
-                    "/subscriptions/{}/databases/{}/import",
-                    subscription_id, database_id
-                ),
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}/import"),
                 request,
             )
             .await
@@ -1608,10 +1590,7 @@ impl DatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .put(
-                &format!(
-                    "/subscriptions/{}/databases/{}/regions",
-                    subscription_id, database_id
-                ),
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}/regions"),
                 request,
             )
             .await
@@ -1629,7 +1608,7 @@ impl DatabaseHandler {
     ) -> Result<DatabaseSlowLogEntries> {
         let mut query = Vec::new();
         if let Some(v) = region_name {
-            query.push(format!("regionName={}", v));
+            query.push(format!("regionName={v}"));
         }
         let query_string = if query.is_empty() {
             String::new()
@@ -1638,8 +1617,7 @@ impl DatabaseHandler {
         };
         self.client
             .get(&format!(
-                "/subscriptions/{}/databases/{}/slow-log{}",
-                subscription_id, database_id, query_string
+                "/subscriptions/{subscription_id}/databases/{database_id}/slow-log{query_string}"
             ))
             .await
     }
@@ -1651,8 +1629,7 @@ impl DatabaseHandler {
     pub async fn get_tags(&self, subscription_id: i32, database_id: i32) -> Result<CloudTags> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/databases/{}/tags",
-                subscription_id, database_id
+                "/subscriptions/{subscription_id}/databases/{database_id}/tags"
             ))
             .await
     }
@@ -1669,10 +1646,7 @@ impl DatabaseHandler {
     ) -> Result<CloudTag> {
         self.client
             .post(
-                &format!(
-                    "/subscriptions/{}/databases/{}/tags",
-                    subscription_id, database_id
-                ),
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}/tags"),
                 request,
             )
             .await
@@ -1690,10 +1664,7 @@ impl DatabaseHandler {
     ) -> Result<CloudTags> {
         self.client
             .put(
-                &format!(
-                    "/subscriptions/{}/databases/{}/tags",
-                    subscription_id, database_id
-                ),
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}/tags"),
                 request,
             )
             .await
@@ -1712,8 +1683,7 @@ impl DatabaseHandler {
         let response = self
             .client
             .delete_raw(&format!(
-                "/subscriptions/{}/databases/{}/tags/{}",
-                subscription_id, database_id, tag_key
+                "/subscriptions/{subscription_id}/databases/{database_id}/tags/{tag_key}"
             ))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
@@ -1732,10 +1702,7 @@ impl DatabaseHandler {
     ) -> Result<CloudTag> {
         self.client
             .put(
-                &format!(
-                    "/subscriptions/{}/databases/{}/tags/{}",
-                    subscription_id, database_id, tag_key
-                ),
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}/tags/{tag_key}"),
                 request,
             )
             .await
@@ -1752,8 +1719,7 @@ impl DatabaseHandler {
     ) -> Result<BdbVersionUpgradeStatus> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/databases/{}/upgrade",
-                subscription_id, database_id
+                "/subscriptions/{subscription_id}/databases/{database_id}/upgrade"
             ))
             .await
     }
@@ -1769,10 +1735,7 @@ impl DatabaseHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!(
-                    "/subscriptions/{}/databases/{}/upgrade",
-                    subscription_id, database_id
-                ),
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}/upgrade"),
                 request,
             )
             .await
@@ -1789,8 +1752,7 @@ impl DatabaseHandler {
     ) -> Result<Value> {
         self.client
             .get_raw(&format!(
-                "/subscriptions/{}/databases/{}/available-target-versions",
-                subscription_id, database_id
+                "/subscriptions/{subscription_id}/databases/{database_id}/available-target-versions"
             ))
             .await
     }
@@ -1807,10 +1769,7 @@ impl DatabaseHandler {
         // Empty body for standard flush
         self.client
             .put_raw(
-                &format!(
-                    "/subscriptions/{}/databases/{}/flush",
-                    subscription_id, database_id
-                ),
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}/flush"),
                 serde_json::json!({}),
             )
             .await
@@ -1889,13 +1848,14 @@ impl DatabaseHandler {
                     break;
                 }
 
-                let count = databases.len() as i32;
+                let count = databases.len();
                 for db in databases {
                     yield db;
                 }
 
                 // If we got fewer than page_size, we've reached the end
-                if count < page_size {
+                #[allow(clippy::cast_sign_loss)]
+                if count < page_size as usize {
                     break;
                 }
 
@@ -1941,10 +1901,11 @@ impl DatabaseHandler {
                 .await?;
 
             let page = Self::extract_databases_from_response(&response);
-            let count = page.len() as i32;
+            let count = page.len();
             databases.extend(page);
 
-            if count < page_size {
+            #[allow(clippy::cast_sign_loss)]
+            if count < page_size as usize {
                 break;
             }
             offset += page_size;
@@ -1953,7 +1914,7 @@ impl DatabaseHandler {
         Ok(databases)
     }
 
-    /// Extract databases from an AccountSubscriptionDatabases response
+    /// Extract databases from an `AccountSubscriptionDatabases` response
     fn extract_databases_from_response(response: &AccountSubscriptionDatabases) -> Vec<Database> {
         response
             .subscription

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -170,7 +170,7 @@ pub struct SubscriptionUpdateCMKRequest {
     pub customer_managed_keys: Vec<CustomerManagedKey>,
 }
 
-/// SubscriptionPricings
+/// `SubscriptionPricings`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubscriptionPricings {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -217,7 +217,7 @@ pub struct CidrAllowlistUpdateRequest {
     pub command_type: Option<String>,
 }
 
-/// SubscriptionMaintenanceWindowsSpec
+/// `SubscriptionMaintenanceWindowsSpec`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubscriptionMaintenanceWindowsSpec {
     /// Maintenance window mode: either 'manual' or 'automatic'. Must provide 'windows' if manual.
@@ -228,7 +228,7 @@ pub struct SubscriptionMaintenanceWindowsSpec {
     pub windows: Option<Vec<MaintenanceWindowSpec>>,
 }
 
-/// MaintenanceWindowSkipStatus
+/// `MaintenanceWindowSkipStatus`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MaintenanceWindowSkipStatus {
@@ -251,7 +251,7 @@ pub struct ActiveActiveSubscriptionRegions {
     pub links: Option<Vec<Link>>,
 }
 
-/// SubscriptionPricing
+/// `SubscriptionPricing`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionPricing {
@@ -443,7 +443,7 @@ pub struct SubscriptionRegionNetworkingSpec {
     pub security_group_id: Option<String>,
 }
 
-/// RedisVersion
+/// `RedisVersion`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RedisVersion {
@@ -460,7 +460,7 @@ pub struct RedisVersion {
     pub is_default: Option<bool>,
 }
 
-/// MaintenanceWindow
+/// `MaintenanceWindow`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MaintenanceWindow {
@@ -537,7 +537,7 @@ pub struct SubscriptionNetworking {
     pub subnet_id: Option<String>,
 }
 
-/// RedisLabs Subscription information
+/// `RedisLabs` Subscription information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 /// Subscription
@@ -636,7 +636,7 @@ pub struct MaintenanceWindowSpec {
     pub days: Vec<String>,
 }
 
-/// RedisLabs list of subscriptions in current account
+/// `RedisLabs` list of subscriptions in current account
 ///
 /// Response from GET /subscriptions
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -693,7 +693,7 @@ pub struct ActiveActiveRegionCreateRequest {
     pub command_type: Option<String>,
 }
 
-/// RedisVersions
+/// `RedisVersions`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RedisVersions {
@@ -728,7 +728,7 @@ pub struct ActiveActiveRegionToDelete {
     pub region: Option<String>,
 }
 
-/// TaskStateUpdate
+/// `TaskStateUpdate`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskStateUpdate {
@@ -774,7 +774,7 @@ pub struct SubscriptionRegionSpec {
     pub networking: Option<SubscriptionRegionNetworkingSpec>,
 }
 
-/// SubscriptionMaintenanceWindows
+/// `SubscriptionMaintenanceWindows`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionMaintenanceWindows {
@@ -805,6 +805,7 @@ pub struct SubscriptionHandler {
 
 impl SubscriptionHandler {
     /// Create a new handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -857,7 +858,7 @@ impl SubscriptionHandler {
     pub async fn get_redis_versions(&self, subscription_id: Option<i32>) -> Result<RedisVersions> {
         let mut query = Vec::new();
         if let Some(v) = subscription_id {
-            query.push(format!("subscriptionId={}", v));
+            query.push(format!("subscriptionId={v}"));
         }
         let query_string = if query.is_empty() {
             String::new()
@@ -865,7 +866,7 @@ impl SubscriptionHandler {
             format!("?{}", query.join("&"))
         };
         self.client
-            .get(&format!("/subscriptions/redis-versions{}", query_string))
+            .get(&format!("/subscriptions/redis-versions{query_string}"))
             .await
     }
 
@@ -876,7 +877,7 @@ impl SubscriptionHandler {
     pub async fn delete_subscription_by_id(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         let response = self
             .client
-            .delete_raw(&format!("/subscriptions/{}", subscription_id))
+            .delete_raw(&format!("/subscriptions/{subscription_id}"))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
     }
@@ -908,7 +909,7 @@ impl SubscriptionHandler {
     /// ```
     pub async fn get_subscription_by_id(&self, subscription_id: i32) -> Result<Subscription> {
         self.client
-            .get(&format!("/subscriptions/{}", subscription_id))
+            .get(&format!("/subscriptions/{subscription_id}"))
             .await
     }
 
@@ -922,7 +923,7 @@ impl SubscriptionHandler {
         request: &BaseSubscriptionUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .put(&format!("/subscriptions/{}", subscription_id), request)
+            .put(&format!("/subscriptions/{subscription_id}"), request)
             .await
     }
 
@@ -932,7 +933,7 @@ impl SubscriptionHandler {
     /// GET /subscriptions/{subscriptionId}/cidr
     pub async fn get_cidr_allowlist(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
-            .get(&format!("/subscriptions/{}/cidr", subscription_id))
+            .get(&format!("/subscriptions/{subscription_id}/cidr"))
             .await
     }
 
@@ -946,7 +947,7 @@ impl SubscriptionHandler {
         request: &CidrAllowlistUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .put(&format!("/subscriptions/{}/cidr", subscription_id), request)
+            .put(&format!("/subscriptions/{subscription_id}/cidr"), request)
             .await
     }
 
@@ -960,8 +961,7 @@ impl SubscriptionHandler {
     ) -> Result<SubscriptionMaintenanceWindows> {
         self.client
             .get(&format!(
-                "/subscriptions/{}/maintenance-windows",
-                subscription_id
+                "/subscriptions/{subscription_id}/maintenance-windows"
             ))
             .await
     }
@@ -977,7 +977,7 @@ impl SubscriptionHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .put(
-                &format!("/subscriptions/{}/maintenance-windows", subscription_id),
+                &format!("/subscriptions/{subscription_id}/maintenance-windows"),
                 request,
             )
             .await
@@ -992,7 +992,7 @@ impl SubscriptionHandler {
         subscription_id: i32,
     ) -> Result<SubscriptionPricings> {
         self.client
-            .get(&format!("/subscriptions/{}/pricing", subscription_id))
+            .get(&format!("/subscriptions/{subscription_id}/pricing"))
             .await
     }
 
@@ -1009,7 +1009,7 @@ impl SubscriptionHandler {
         let _ = request; // Suppress unused variable warning
         let response = self
             .client
-            .delete_raw(&format!("/subscriptions/{}/regions", subscription_id))
+            .delete_raw(&format!("/subscriptions/{subscription_id}/regions"))
             .await?;
         serde_json::from_value(response).map_err(Into::into)
     }
@@ -1023,7 +1023,7 @@ impl SubscriptionHandler {
         subscription_id: i32,
     ) -> Result<ActiveActiveSubscriptionRegions> {
         self.client
-            .get(&format!("/subscriptions/{}/regions", subscription_id))
+            .get(&format!("/subscriptions/{subscription_id}/regions"))
             .await
     }
 
@@ -1038,7 +1038,7 @@ impl SubscriptionHandler {
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!("/subscriptions/{}/regions", subscription_id),
+                &format!("/subscriptions/{subscription_id}/regions"),
                 request,
             )
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Allow doc strings with quoted values like 'true'/'false' from OpenAPI spec
+#![allow(clippy::doc_link_with_quotes)]
+
 //! Redis Cloud REST API Client
 //!
 //! A comprehensive Rust client for the Redis Cloud REST API, providing full access to

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -73,7 +73,7 @@ pub struct TaskStateUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
 
-    /// Type of command being executed (e.g., "CREATE_DATABASE", "DELETE_SUBSCRIPTION")
+    /// Type of command being executed (e.g., "`CREATE_DATABASE`", "`DELETE_SUBSCRIPTION`")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 
@@ -116,6 +116,7 @@ pub struct TasksHandler {
 
 impl TasksHandler {
     /// Create a new handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -158,6 +159,6 @@ impl TasksHandler {
     /// # }
     /// ```
     pub async fn get_task_by_id(&self, task_id: String) -> Result<TaskStateUpdate> {
-        self.client.get(&format!("/tasks/{}", task_id)).await
+        self.client.get(&format!("/tasks/{task_id}")).await
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 // Task Types (Most common - appears in 37 endpoints)
 // ============================================================================
 
-/// TaskStateUpdate - Line 9725 in OpenAPI spec
+/// `TaskStateUpdate` - Line 9725 in `OpenAPI` spec
 /// Represents the state of an asynchronous task
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -43,7 +43,7 @@ pub struct TaskStateUpdate {
     pub links: Option<Vec<Link>>,
 }
 
-/// TaskStatus enum - Part of TaskStateUpdate schema
+/// `TaskStatus` enum - Part of `TaskStateUpdate` schema
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum TaskStatus {
@@ -54,7 +54,7 @@ pub enum TaskStatus {
     ProcessingError,
 }
 
-/// ProcessorResponse - Line 14268 in OpenAPI spec
+/// `ProcessorResponse` - Line 14268 in `OpenAPI` spec
 /// Contains the result or error from task processing
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -80,7 +80,7 @@ pub struct ProcessorResponse {
     pub additional_info: Option<String>,
 }
 
-/// ProcessorError - Subset of massive error enum for common errors
+/// `ProcessorError` - Subset of massive error enum for common errors
 /// Full enum has 600+ values, we'll add as needed
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProcessorError {
@@ -96,7 +96,7 @@ pub enum ProcessorError {
     Other,
 }
 
-/// TasksStateUpdate - Collection of task updates
+/// `TasksStateUpdate` - Collection of task updates
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TasksStateUpdate {
     pub tasks: Vec<TaskStateUpdate>,
@@ -106,14 +106,14 @@ pub struct TasksStateUpdate {
 // Tag Types (Used in database and subscription endpoints)
 // ============================================================================
 
-/// CloudTag - Individual tag with key-value
+/// `CloudTag` - Individual tag with key-value
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloudTag {
     pub key: String,
     pub value: String,
 }
 
-/// CloudTags - Collection of tags
+/// `CloudTags` - Collection of tags
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloudTags {
     pub tags: Vec<CloudTag>,

--- a/src/users.rs
+++ b/src/users.rs
@@ -181,6 +181,7 @@ pub struct UsersHandler {
 
 impl UsersHandler {
     /// Create a new handler
+    #[must_use]
     pub fn new(client: CloudClient) -> Self {
         Self { client }
     }
@@ -198,10 +199,7 @@ impl UsersHandler {
     ///
     /// DELETE /users/{userId}
     pub async fn delete_user_by_id(&self, user_id: i32) -> Result<TaskStateUpdate> {
-        let response = self
-            .client
-            .delete_raw(&format!("/users/{}", user_id))
-            .await?;
+        let response = self.client.delete_raw(&format!("/users/{user_id}")).await?;
         serde_json::from_value(response).map_err(Into::into)
     }
 
@@ -210,7 +208,7 @@ impl UsersHandler {
     ///
     /// GET /users/{userId}
     pub async fn get_user_by_id(&self, user_id: i32) -> Result<AccountUser> {
-        self.client.get(&format!("/users/{}", user_id)).await
+        self.client.get(&format!("/users/{user_id}")).await
     }
 
     /// Update a user
@@ -222,8 +220,6 @@ impl UsersHandler {
         user_id: i32,
         request: &AccountUserUpdateRequest,
     ) -> Result<TaskStateUpdate> {
-        self.client
-            .put(&format!("/users/{}", user_id), request)
-            .await
+        self.client.put(&format!("/users/{user_id}"), request).await
     }
 }


### PR DESCRIPTION
## Summary

- Apply clippy auto-fixes for format string variables
- Add `#[must_use]` to builder methods
- Fix usize/i32 casting in pagination code
- Allow `doc_link_with_quotes` lint (intentional OpenAPI style)
- Fix `FixedSubscriptions` to include subscriptions field

## Examples Added

- `basic.rs` - Connect and list subscriptions
- `databases.rs` - Database operations  
- `stream_databases.rs` - Streaming with pagination

## Run Examples

```bash
REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example basic
REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example databases
REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example stream_databases -- SUBSCRIPTION_ID
```