### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.0...v0.9.1) - 2026-01-31
+
+### Added
+
+- add test-support feature for consumer testing ([#43](https://github.com/redis-developer/redis-cloud-rs/pull/43))
+
+### Fixed
+
+- correct mock response formats for tasks and databases ([#45](https://github.com/redis-developer/redis-cloud-rs/pull/45))
+
 ## [0.9.0](https://github.com/redis-developer/redis-cloud-rs/compare/v0.8.0...v0.9.0) - 2026-01-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.9.0 -> 0.9.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.1](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.0...v0.9.1) - 2026-01-31

### Added

- add test-support feature for consumer testing ([#43](https://github.com/redis-developer/redis-cloud-rs/pull/43))

### Fixed

- correct mock response formats for tasks and databases ([#45](https://github.com/redis-developer/redis-cloud-rs/pull/45))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).