### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.1...v0.9.2) - 2026-02-03
+
+### Other
+
+- upgrade reqwest to 0.13 ([#46](https://github.com/redis-developer/redis-cloud-rs/pull/46))
+
 ## [0.9.1](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.0...v0.9.1) - 2026-01-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.9.1 -> 0.9.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.2](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.1...v0.9.2) - 2026-02-03

### Other

- upgrade reqwest to 0.13 ([#46](https://github.com/redis-developer/redis-cloud-rs/pull/46))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).