### PR TITLE
chore: release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.2...v0.9.3) - 2026-02-04
+
+### Added
+
+- harmonize API patterns with redis-enterprise ([#49](https://github.com/redis-developer/redis-cloud-rs/pull/49))
+
 ## [0.9.2](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.1...v0.9.2) - 2026-02-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.9.2 -> 0.9.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.3](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.2...v0.9.3) - 2026-02-04

### Added

- harmonize API patterns with redis-enterprise ([#49](https://github.com/redis-developer/redis-cloud-rs/pull/49))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).