### PR TITLE
chore: release v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.3...v0.9.4) - 2026-02-05
+
+### Other
+
+- update rust-version to 1.89 and author email ([#52](https://github.com/redis-developer/redis-cloud-rs/pull/52))
+
 ## [0.9.3](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.2...v0.9.3) - 2026-02-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.9.3 -> 0.9.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.4](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.3...v0.9.4) - 2026-02-05

### Other

- update rust-version to 1.89 and author email ([#52](https://github.com/redis-developer/redis-cloud-rs/pull/52))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).