### PR TITLE
fix: handle empty object response from /tasks endpoint

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -124,9 +124,18 @@ impl TasksHandler {
     /// Get tasks
     /// Gets a list of all currently running tasks for this account.
     ///
+    /// The API returns an array when tasks exist but an empty object `{}` when
+    /// there are no tasks, so we handle both cases.
+    ///
     /// GET /tasks
     pub async fn get_all_tasks(&self) -> Result<Vec<TaskStateUpdate>> {
-        self.client.get("/tasks").await
+        let value: serde_json::Value = self.client.get_raw("/tasks").await?;
+        match value {
+            serde_json::Value::Array(arr) => {
+                Ok(serde_json::from_value(serde_json::Value::Array(arr))?)
+            }
+            _ => Ok(Vec::new()),
+        }
     }
 
     /// Get tasks (raw JSON)


### PR DESCRIPTION
## Summary

- Fix deserialization error when `/tasks` API returns `{}` (empty object) instead of `[]` (empty array) when there are no active tasks
- Use `get_raw()` and pattern match on `Value::Array` vs fallback to empty `Vec`
- The existing `get_all_tasks_raw()` method was already unaffected since it returns raw JSON

## Context

The Redis Cloud API inconsistently returns `{}` when there are no tasks and `[{...}]` when tasks exist. The previous implementation used `self.client.get("/tasks")` which tries to deserialize directly into `Vec<TaskStateUpdate>`, failing with:

```
invalid type: map, expected a sequence
```

## Test plan

- [x] All existing tests pass (`cargo test --lib --all-features` and `cargo test --test '*' --all-features`)
- [ ] Verify via MCP tool call against live account with no active tasks