### PR TITLE
fix(subscriptions): send body when deleting AA regions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -1072,13 +1072,12 @@ impl SubscriptionHandler {
         subscription_id: i32,
         request: &ActiveActiveRegionDeleteRequest,
     ) -> Result<TaskStateUpdate> {
-        // TODO: DELETE with body not yet supported by client
-        let _ = request; // Suppress unused variable warning
-        let response = self
-            .client
-            .delete_raw(&format!("/subscriptions/{subscription_id}/regions"))
-            .await?;
-        serde_json::from_value(response).map_err(Into::into)
+        self.client
+            .delete_with_body(
+                &format!("/subscriptions/{subscription_id}/regions"),
+                serde_json::to_value(request)?,
+            )
+            .await
     }
 
     /// Get regions in an Active-Active subscription

--- a/tests/subscriptions_tests.rs
+++ b/tests/subscriptions_tests.rs
@@ -1,6 +1,6 @@
 use redis_cloud::{CloudClient, SubscriptionsHandler};
 use serde_json::json;
-use wiremock::matchers::{header, method, path, query_param};
+use wiremock::matchers::{body_json, header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
@@ -424,8 +424,59 @@ async fn test_get_subscription_pricing() {
     assert_eq!(pricing[0].r#type, Some("Shards".to_string()));
 }
 
-// Skipping test_delete_regions_from_active_active_subscription
-// as the client doesn't yet support DELETE with body
+#[tokio::test]
+async fn test_delete_regions_from_active_active_subscription() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/subscriptions/123/regions"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .and(body_json(json!({
+            "regions": [
+                {
+                    "region": "us-east-1"
+                }
+            ],
+            "dryRun": false,
+            "commandType": "DELETE_REGION"
+        })))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-delete-region",
+            "commandType": "DELETE_REGION",
+            "status": "processing"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = SubscriptionsHandler::new(client);
+    let request = redis_cloud::subscriptions::ActiveActiveRegionDeleteRequest {
+        subscription_id: None,
+        regions: Some(vec![
+            redis_cloud::subscriptions::ActiveActiveRegionToDelete {
+                region: Some("us-east-1".to_string()),
+            },
+        ]),
+        dry_run: Some(false),
+        command_type: Some("DELETE_REGION".to_string()),
+    };
+
+    let result = handler
+        .delete_regions_from_active_active_subscription(123, &request)
+        .await
+        .unwrap();
+
+    assert_eq!(result.task_id.as_deref(), Some("task-delete-region"));
+    assert_eq!(result.command_type.as_deref(), Some("DELETE_REGION"));
+    assert_eq!(result.status.as_deref(), Some("processing"));
+}
 
 #[tokio::test]
 async fn test_get_regions_from_active_active_subscription() {


### PR DESCRIPTION
## Summary
- send the `ActiveActiveRegionDeleteRequest` body when deleting regions from an active-active subscription
- route the operation through the existing `delete_with_body` helper instead of dropping the request payload
- add a strict request-shape test that asserts the DELETE body on the wire

## Testing
- cargo fmt
- cargo test

Closes #59
