### PR TITLE
docs(python): align from_env secret messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ subs = client.subscriptions_sync()
 - `REDIS_CLOUD_API_SECRET` - API secret
 - `REDIS_CLOUD_BASE_URL` - Base URL (optional)
 
+Python `CloudClient.from_env()` also accepts the legacy aliases
+`REDIS_CLOUD_ACCOUNT_KEY`, `REDIS_CLOUD_SECRET_KEY`, and `REDIS_CLOUD_USER_KEY`.
+
 ## API Coverage
 
 This library provides comprehensive coverage of the Redis Cloud REST API:

--- a/python/src/client.rs
+++ b/python/src/client.rs
@@ -59,7 +59,7 @@ impl PyCloudClient {
             .or_else(|_| std::env::var("REDIS_CLOUD_USER_KEY"))
             .map_err(|_| {
                 pyo3::exceptions::PyValueError::new_err(
-                    "API secret not found. Set REDIS_CLOUD_API_SECRET",
+                    "API secret not found. Set REDIS_CLOUD_API_SECRET, REDIS_CLOUD_SECRET_KEY, or REDIS_CLOUD_USER_KEY",
                 )
             })?;
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -63,8 +63,13 @@ class TestClientCreation:
             os.environ.pop(var, None)
 
         try:
-            with pytest.raises(ValueError, match="API secret not found"):
+            with pytest.raises(ValueError, match="API secret not found") as exc_info:
                 CloudClient.from_env()
+
+            message = str(exc_info.value)
+            assert "REDIS_CLOUD_API_SECRET" in message
+            assert "REDIS_CLOUD_SECRET_KEY" in message
+            assert "REDIS_CLOUD_USER_KEY" in message
         finally:
             os.environ.pop("REDIS_CLOUD_API_KEY", None)
 


### PR DESCRIPTION
## Summary
- update the Python `CloudClient.from_env()` error message so it names every supported secret env var
- document the legacy key and secret aliases accepted by the Python binding
- strengthen the Python test to assert the alias names are present in the error message

## Testing
- cargo test
- pytest python/tests/test_client.py *(fails in local env: missing built `redis_cloud.redis_cloud` extension module during test collection)*

Closes #58
