### PR TITLE
fix(fixed/databases): add missing 'subscription' field to AccountFixedSubscriptionDatabases

### DIFF
--- a/src/fixed/databases.rs
+++ b/src/fixed/databases.rs
@@ -57,11 +57,47 @@ use typed_builder::TypedBuilder;
 // ============================================================================
 
 /// `RedisLabs` Account Subscription Databases information
+///
+/// Response from `GET /fixed/subscriptions/{subscriptionId}/databases`.
+///
+/// Note: the OpenAPI schema lists only `accountId` and `links`, but real responses
+/// (and the spec's own example) include a `subscription` object containing the
+/// databases. See [`FixedSubscriptionDatabasesInfo`] for the inner shape.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountFixedSubscriptionDatabases {
+    /// Account ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_id: Option<i32>,
+
+    /// Subscription information with the nested databases array.
+    ///
+    /// The Essentials response wraps databases under a single `subscription` object
+    /// (unlike the Pro response, which uses an array — see
+    /// [`crate::flexible::databases::AccountSubscriptionDatabases`]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription: Option<FixedSubscriptionDatabasesInfo>,
+
+    /// HATEOAS links
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
+}
+
+/// Subscription databases info returned within [`AccountFixedSubscriptionDatabases`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixedSubscriptionDatabasesInfo {
+    /// Subscription ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription_id: Option<i32>,
+
+    /// Number of databases reported by the API for this subscription
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number_of_databases: Option<i32>,
+
+    /// List of databases in this subscription
+    #[serde(default)]
+    pub databases: Vec<FixedDatabase>,
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/fixed_databases_tests.rs
+++ b/tests/fixed_databases_tests.rs
@@ -7,15 +7,48 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 async fn test_get_fixed_subscription_databases() {
     let mock_server = MockServer::start().await;
 
+    // Shape derived from the AccountFixedSubscriptionDatabases.example field in the
+    // bundled cloud_openapi.json: subscription is a single object containing
+    // subscriptionId, numberOfDatabases, databases[], and links.
     Mock::given(method("GET"))
         .and(path("/fixed/subscriptions/123/databases"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "accountId": 456,
             "subscription": {
                 "subscriptionId": 123,
-                "numberOfDatabases": 3,
-                "planType": "fixed"
+                "numberOfDatabases": 2,
+                "databases": [
+                    {
+                        "databaseId": 51324587,
+                        "name": "bdb",
+                        "protocol": "stack",
+                        "provider": "AWS",
+                        "region": "us-east-1",
+                        "redisVersion": "7.4",
+                        "status": "active",
+                        "planMemoryLimit": 250,
+                        "memoryLimitMeasurementUnit": "MB",
+                        "memoryUsedInMb": 1,
+                        "memoryStorage": "ram",
+                        "dataPersistence": "none",
+                        "replication": true,
+                        "dataEvictionPolicy": "noeviction",
+                    },
+                    {
+                        "databaseId": 51324586,
+                        "name": "firstDB",
+                        "protocol": "stack",
+                        "provider": "AWS",
+                        "region": "us-east-1",
+                        "status": "active",
+                        "planMemoryLimit": 250,
+                        "memoryLimitMeasurementUnit": "MB",
+                        "memoryStorage": "ram",
+                    },
+                ],
+                "links": []
             },
             "links": [
                 {
@@ -24,7 +57,6 @@ async fn test_get_fixed_subscription_databases() {
                     "type": "GET"
                 }
             ],
-            "accountId": 456
         })))
         .mount(&mock_server)
         .await;
@@ -41,6 +73,17 @@ async fn test_get_fixed_subscription_databases() {
 
     assert_eq!(result.account_id, Some(456));
     assert!(result.links.is_some());
+
+    let subscription = result
+        .subscription
+        .expect("response should include the subscription object");
+    assert_eq!(subscription.subscription_id, Some(123));
+    assert_eq!(subscription.number_of_databases, Some(2));
+    assert_eq!(subscription.databases.len(), 2);
+    assert_eq!(subscription.databases[0].database_id, Some(51324587));
+    assert_eq!(subscription.databases[0].name.as_deref(), Some("bdb"));
+    assert_eq!(subscription.databases[1].database_id, Some(51324586));
+    assert_eq!(subscription.databases[1].name.as_deref(), Some("firstDB"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds the missing `subscription` field to `AccountFixedSubscriptionDatabases` so `FixedDatabaseHandler::list()` actually surfaces the databases array.
- Introduces `FixedSubscriptionDatabasesInfo` mirroring the Pro side's `SubscriptionDatabasesInfo`, but as a single object (not an array — Essentials returns one, not many).
- Replaces the previous vacuous `test_get_fixed_subscription_databases` with one that asserts a populated `databases[]` round-trips: database id, name, and the `subscription_id`/`number_of_databases` summary.

## Why

The OpenAPI schema for `AccountFixedSubscriptionDatabases` declares only `accountId` and `links` as properties — but the spec's own `example` for the same schema shows `subscription` as an object containing `databases[]`. The Rust struct mirrored the schema, not the example. Result: every list call returned an empty wrapper with no way to access the databases. The existing test passed only because it asserted on the two fields that did deserialize.

## Scope

Tightly scoped to fixing the response shape. Harmonizing `list()` to return `Vec<FixedDatabase>` directly (as the Pro side already does via the harmonization work) is **out of scope here** and remains tracked under #65.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass (288 total)
- [x] `cargo test --test fixed_databases_tests` — 11 pass

Closes #73
Refs #40 (spec deltas tracking)