### PR TITLE
fix(deps): update aws-lc-sys and rustls-webpki for 6 RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -1215,9 +1215,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Cargo.lock-only update fixing six RUSTSEC advisories that have been flagged by cargo-deny on every CI Security Audit run since the advisories were published.

| Crate | Before | After | Advisories |
|---|---|---|---|
| `aws-lc-rs` | 1.15.4 | 1.16.3 | (transitive) |
| `aws-lc-sys` | 0.37.0 | 0.40.0 | RUSTSEC-2026-0044, RUSTSEC-2026-0045 |
| `rustls-webpki` | 0.103.9 | 0.103.13 | RUSTSEC-2026-0049, -0098, -0099, -0104 |

## Why two crates in one PR

Bumping aws-lc-sys directly was blocked: `aws-lc-rs 1.15.4` pins `aws-lc-sys = "^0.37.0"` which excludes the patched 0.39+ range by semver. So we have to bump `aws-lc-rs` to 1.16.3 to relax that constraint. Once that's done, `rustls-webpki` advisories also surface in cargo-deny output (they were behind aws-lc errors before — same Security Audit failure surface). Bumping both together keeps the Security Audit gate green in one shot.

## Pattern

Same shape as #57 (`fix: update quinn-proto to 0.11.14 (RUSTSEC-2026-0037)`) — focused, lockfile-only, no source code changes.

## Test plan

- [x] `cargo deny check advisories` — `advisories ok`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all 288 tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] No source files changed; only `Cargo.lock`

Closes #82