### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.5...v0.10.0) - 2026-06-02
+
+### Added
+
+- *(python)* expand bindings to cover all major read domains, document parity scope (closes #66) ([#113](https://github.com/redis-developer/redis-cloud-rs/pull/113))
+- *(api)* add simplified alias methods across remaining domain handlers (closes #65) ([#112](https://github.com/redis-developer/redis-cloud-rs/pull/112))
+- *(api)* [**breaking**] implement remaining uncovered spec routes (#72, PR 2) ([#111](https://github.com/redis-developer/redis-cloud-rs/pull/111))
+
+### Fixed
+
+- *(flexible/databases)* correct timeUTC serde casing in DatabaseBackupConfig ([#108](https://github.com/redis-developer/redis-cloud-rs/pull/108)) ([#109](https://github.com/redis-developer/redis-cloud-rs/pull/109))
+- *(tasks)* accept object-shaped response.error on failed tasks ([#103](https://github.com/redis-developer/redis-cloud-rs/pull/103))
+- *(subscriptions)* send body when deleting Active-Active regions ([#99](https://github.com/redis-developer/redis-cloud-rs/pull/99))
+- *(connectivity)* vpc_peering create body serializes the spec's wire keys ([#89](https://github.com/redis-developer/redis-cloud-rs/pull/89))
+- *(account)* PaymentMethod.credit_card_ends_with should be String, not i32 ([#87](https://github.com/redis-developer/redis-cloud-rs/pull/87))
+- *(flexible/databases)* rename Database.activated to activated_on (wire field is `activatedOn`) ([#86](https://github.com/redis-developer/redis-cloud-rs/pull/86))
+- *(tasks)* handle the canonical TasksStateUpdate wrapper from GET /tasks ([#85](https://github.com/redis-developer/redis-cloud-rs/pull/85))
+- *(fixed/databases)* add missing 'subscription' field to AccountFixedSubscriptionDatabases ([#81](https://github.com/redis-developer/redis-cloud-rs/pull/81))
+
+### Other
+
+- audit and expand coverage for alias layer and new domains ([#116](https://github.com/redis-developer/redis-cloud-rs/pull/116))
+- audit and update documentation for release readiness (closes #114) ([#117](https://github.com/redis-developer/redis-cloud-rs/pull/117))
+- *(connectivity)* [**breaking**] reconcile TGW + PSC handler paths with spec (#72, PR 1) ([#110](https://github.com/redis-developer/redis-cloud-rs/pull/110))
+- *(openapi)* add executable route-coverage checks vs bundled spec ([#67](https://github.com/redis-developer/redis-cloud-rs/pull/67)) ([#107](https://github.com/redis-developer/redis-cloud-rs/pull/107))
+- *(connectivity)* [**breaking**] return TaskStateUpdate for task-returning endpoints ([#78](https://github.com/redis-developer/redis-cloud-rs/pull/78)) ([#106](https://github.com/redis-developer/redis-cloud-rs/pull/106))
+- *(types)* [**breaking**] consolidate shared task/tag models onto canonical types ([#64](https://github.com/redis-developer/redis-cloud-rs/pull/64)) ([#104](https://github.com/redis-developer/redis-cloud-rs/pull/104))
+- *(spec)* refresh bundled cloud_openapi.json from upstream ([#101](https://github.com/redis-developer/redis-cloud-rs/pull/101))
+- README + examples refresh for v0.10.0 ([#100](https://github.com/redis-developer/redis-cloud-rs/pull/100))
+- enforce #![deny(missing_docs)] and rustdoc::broken_intra_doc_links ([#98](https://github.com/redis-developer/redis-cloud-rs/pull/98))
+- *(models)* document fields in the four large request/response modules ([#96](https://github.com/redis-developer/redis-cloud-rs/pull/96))
+- *(users)* document all undocumented fields in user request/response models ([#95](https://github.com/redis-developer/redis-cloud-rs/pull/95))
+- *(small modules)* document the remaining undocumented fields in 6 short modules ([#94](https://github.com/redis-developer/redis-cloud-rs/pull/94))
+- *(connectivity)* expand thin module headers (psc, transit_gateway, vpc_peering) ([#93](https://github.com/redis-developer/redis-cloud-rs/pull/93))
+- *(types)* expand module header and document all variants/fields in shared types ([#92](https://github.com/redis-developer/redis-cloud-rs/pull/92))
+- *(connectivity)* document ConnectivityHandler delegation methods and struct fields ([#91](https://github.com/redis-developer/redis-cloud-rs/pull/91))
+- *(lib.rs)* refresh stale examples in crate-level docs ([#90](https://github.com/redis-developer/redis-cloud-rs/pull/90))
+- *(cost_report)* add wiremock integration coverage for the exported handler ([#88](https://github.com/redis-developer/redis-cloud-rs/pull/88))
+
 ### Added
 
 - Simplified alias methods across all domain handlers for a concise, ergonomic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.9.5"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.9.5 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `redis-cloud` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CloudTags.account_id in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:259
  field CloudTags.links in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:263
  field AccountFixedSubscriptionDatabases.subscription in /tmp/.tmp9y24jr/redis-cloud-rs/src/fixed/databases.rs:80
  field AccountFixedSubscriptionDatabases.subscription in /tmp/.tmp9y24jr/redis-cloud-rs/src/fixed/databases.rs:80
  field CloudTag.created_at in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:239
  field CloudTag.updated_at in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:243
  field CloudTag.links in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:247
  field Database.activated_on in /tmp/.tmp9y24jr/redis-cloud-rs/src/flexible/databases.rs:943
  field Database.activated_on in /tmp/.tmp9y24jr/redis-cloud-rs/src/flexible/databases.rs:943
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65
  field TaskStateUpdate.progress in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:65

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant TaskStatus:Unknown in /tmp/.tmp9y24jr/redis-cloud-rs/src/types.rs:101

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/inherent_method_missing.ron

Failed in:
  TransitGatewayHandler::create_attachment, previously in file /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:223
  TransitGatewayHandler::create_attachment, previously in file /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:223
  TransitGatewayHandler::create_attachment, previously in file /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:223

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/method_parameter_count_changed.ron

Failed in:
  redis_cloud::connectivity::ConnectivityHandler::create_psc_endpoint takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/mod.rs:138, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/mod.rs:259
  redis_cloud::connectivity::ConnectivityHandler::update_psc_service_endpoint takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/mod.rs:201, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/mod.rs:382
  redis_cloud::ConnectivityHandler::create_psc_endpoint takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/mod.rs:138, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/mod.rs:259
  redis_cloud::ConnectivityHandler::update_psc_service_endpoint takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/mod.rs:201, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/mod.rs:382
  redis_cloud::connectivity::transit_gateway::TransitGatewayHandler::get_attachments_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:258, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/transit_gateway.rs:275
  redis_cloud::connectivity::transit_gateway::TransitGatewayHandler::get_shared_invitations_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:270, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/transit_gateway.rs:288
  redis_cloud::connectivity::transit_gateway::TransitGatewayHandler::create_attachment_active_active takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:331, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/transit_gateway.rs:347
  redis_cloud::connectivity::TransitGatewayHandler::get_attachments_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:258, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/transit_gateway.rs:275
  redis_cloud::connectivity::TransitGatewayHandler::get_shared_invitations_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:270, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/transit_gateway.rs:288
  redis_cloud::connectivity::TransitGatewayHandler::create_attachment_active_active takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:331, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/transit_gateway.rs:347
  redis_cloud::TransitGatewayHandler::get_attachments_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:258, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/transit_gateway.rs:275
  redis_cloud::TransitGatewayHandler::get_shared_invitations_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:270, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/transit_gateway.rs:288
  redis_cloud::TransitGatewayHandler::create_attachment_active_active takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/transit_gateway.rs:331, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/transit_gateway.rs:347
  redis_cloud::connectivity::psc::PscHandler::get_endpoints takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:206, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:262
  redis_cloud::connectivity::psc::PscHandler::create_endpoint takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:215, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:243
  redis_cloud::connectivity::psc::PscHandler::delete_endpoint takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:229, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:275
  redis_cloud::connectivity::psc::PscHandler::update_endpoint takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:243, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:289
  redis_cloud::connectivity::psc::PscHandler::get_endpoint_creation_script takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:262, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:307
  redis_cloud::connectivity::psc::PscHandler::get_endpoint_deletion_script takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:275, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:321
  redis_cloud::connectivity::psc::PscHandler::delete_service_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:292, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:339
  redis_cloud::connectivity::psc::PscHandler::get_service_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:305, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:352
  redis_cloud::connectivity::psc::PscHandler::create_service_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:314, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:365
  redis_cloud::connectivity::psc::PscHandler::get_endpoints_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:327, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:403
  redis_cloud::connectivity::psc::PscHandler::create_endpoint_active_active takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:339, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:382
  redis_cloud::connectivity::psc::PscHandler::delete_endpoint_active_active takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:355, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:417
  redis_cloud::connectivity::psc::PscHandler::update_endpoint_active_active takes 4 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:370, but now takes 5 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:430
  redis_cloud::connectivity::PscHandler::get_endpoints takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:206, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:262
  redis_cloud::connectivity::PscHandler::create_endpoint takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:215, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:243
  redis_cloud::connectivity::PscHandler::delete_endpoint takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:229, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:275
  redis_cloud::connectivity::PscHandler::update_endpoint takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:243, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:289
  redis_cloud::connectivity::PscHandler::get_endpoint_creation_script takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:262, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:307
  redis_cloud::connectivity::PscHandler::get_endpoint_deletion_script takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:275, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:321
  redis_cloud::connectivity::PscHandler::delete_service_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:292, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:339
  redis_cloud::connectivity::PscHandler::get_service_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:305, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:352
  redis_cloud::connectivity::PscHandler::create_service_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:314, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:365
  redis_cloud::connectivity::PscHandler::get_endpoints_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:327, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:403
  redis_cloud::connectivity::PscHandler::create_endpoint_active_active takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:339, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:382
  redis_cloud::connectivity::PscHandler::delete_endpoint_active_active takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:355, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:417
  redis_cloud::connectivity::PscHandler::update_endpoint_active_active takes 4 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:370, but now takes 5 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:430
  redis_cloud::PscHandler::get_endpoints takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:206, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:262
  redis_cloud::PscHandler::create_endpoint takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:215, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:243
  redis_cloud::PscHandler::delete_endpoint takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:229, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:275
  redis_cloud::PscHandler::update_endpoint takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:243, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:289
  redis_cloud::PscHandler::get_endpoint_creation_script takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:262, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:307
  redis_cloud::PscHandler::get_endpoint_deletion_script takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:275, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:321
  redis_cloud::PscHandler::delete_service_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:292, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:339
  redis_cloud::PscHandler::get_service_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:305, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:352
  redis_cloud::PscHandler::create_service_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:314, but now takes 2 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:365
  redis_cloud::PscHandler::get_endpoints_active_active takes 1 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:327, but now takes 3 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:403
  redis_cloud::PscHandler::create_endpoint_active_active takes 2 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:339, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:382
  redis_cloud::PscHandler::delete_endpoint_active_active takes 3 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:355, but now takes 4 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:417
  redis_cloud::PscHandler::update_endpoint_active_active takes 4 parameters in /tmp/.tmpS7q78D/redis-cloud/src/connectivity/psc.rs:370, but now takes 5 parameters in /tmp/.tmp9y24jr/redis-cloud-rs/src/connectivity/psc.rs:430

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field activated of struct Database, previously in file /tmp/.tmpS7q78D/redis-cloud/src/flexible/databases.rs:928
  field activated of struct Database, previously in file /tmp/.tmpS7q78D/redis-cloud/src/flexible/databases.rs:928
  field tags of struct CloudTags, previously in file /tmp/.tmpS7q78D/redis-cloud/src/types.rs:119
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.5...v0.10.0) - 2026-06-02

### Added

- *(python)* expand bindings to cover all major read domains, document parity scope (closes #66) ([#113](https://github.com/redis-developer/redis-cloud-rs/pull/113))
- *(api)* add simplified alias methods across remaining domain handlers (closes #65) ([#112](https://github.com/redis-developer/redis-cloud-rs/pull/112))
- *(api)* [**breaking**] implement remaining uncovered spec routes (#72, PR 2) ([#111](https://github.com/redis-developer/redis-cloud-rs/pull/111))

### Fixed

- *(flexible/databases)* correct timeUTC serde casing in DatabaseBackupConfig ([#108](https://github.com/redis-developer/redis-cloud-rs/pull/108)) ([#109](https://github.com/redis-developer/redis-cloud-rs/pull/109))
- *(tasks)* accept object-shaped response.error on failed tasks ([#103](https://github.com/redis-developer/redis-cloud-rs/pull/103))
- *(subscriptions)* send body when deleting Active-Active regions ([#99](https://github.com/redis-developer/redis-cloud-rs/pull/99))
- *(connectivity)* vpc_peering create body serializes the spec's wire keys ([#89](https://github.com/redis-developer/redis-cloud-rs/pull/89))
- *(account)* PaymentMethod.credit_card_ends_with should be String, not i32 ([#87](https://github.com/redis-developer/redis-cloud-rs/pull/87))
- *(flexible/databases)* rename Database.activated to activated_on (wire field is `activatedOn`) ([#86](https://github.com/redis-developer/redis-cloud-rs/pull/86))
- *(tasks)* handle the canonical TasksStateUpdate wrapper from GET /tasks ([#85](https://github.com/redis-developer/redis-cloud-rs/pull/85))
- *(fixed/databases)* add missing 'subscription' field to AccountFixedSubscriptionDatabases ([#81](https://github.com/redis-developer/redis-cloud-rs/pull/81))

### Other

- audit and expand coverage for alias layer and new domains ([#116](https://github.com/redis-developer/redis-cloud-rs/pull/116))
- audit and update documentation for release readiness (closes #114) ([#117](https://github.com/redis-developer/redis-cloud-rs/pull/117))
- *(connectivity)* [**breaking**] reconcile TGW + PSC handler paths with spec (#72, PR 1) ([#110](https://github.com/redis-developer/redis-cloud-rs/pull/110))
- *(openapi)* add executable route-coverage checks vs bundled spec ([#67](https://github.com/redis-developer/redis-cloud-rs/pull/67)) ([#107](https://github.com/redis-developer/redis-cloud-rs/pull/107))
- *(connectivity)* [**breaking**] return TaskStateUpdate for task-returning endpoints ([#78](https://github.com/redis-developer/redis-cloud-rs/pull/78)) ([#106](https://github.com/redis-developer/redis-cloud-rs/pull/106))
- *(types)* [**breaking**] consolidate shared task/tag models onto canonical types ([#64](https://github.com/redis-developer/redis-cloud-rs/pull/64)) ([#104](https://github.com/redis-developer/redis-cloud-rs/pull/104))
- *(spec)* refresh bundled cloud_openapi.json from upstream ([#101](https://github.com/redis-developer/redis-cloud-rs/pull/101))
- README + examples refresh for v0.10.0 ([#100](https://github.com/redis-developer/redis-cloud-rs/pull/100))
- enforce #![deny(missing_docs)] and rustdoc::broken_intra_doc_links ([#98](https://github.com/redis-developer/redis-cloud-rs/pull/98))
- *(models)* document fields in the four large request/response modules ([#96](https://github.com/redis-developer/redis-cloud-rs/pull/96))
- *(users)* document all undocumented fields in user request/response models ([#95](https://github.com/redis-developer/redis-cloud-rs/pull/95))
- *(small modules)* document the remaining undocumented fields in 6 short modules ([#94](https://github.com/redis-developer/redis-cloud-rs/pull/94))
- *(connectivity)* expand thin module headers (psc, transit_gateway, vpc_peering) ([#93](https://github.com/redis-developer/redis-cloud-rs/pull/93))
- *(types)* expand module header and document all variants/fields in shared types ([#92](https://github.com/redis-developer/redis-cloud-rs/pull/92))
- *(connectivity)* document ConnectivityHandler delegation methods and struct fields ([#91](https://github.com/redis-developer/redis-cloud-rs/pull/91))
- *(lib.rs)* refresh stale examples in crate-level docs ([#90](https://github.com/redis-developer/redis-cloud-rs/pull/90))
- *(cost_report)* add wiremock integration coverage for the exported handler ([#88](https://github.com/redis-developer/redis-cloud-rs/pull/88))

### Added

- Simplified alias methods across all domain handlers for a concise, ergonomic
  API surface ([#65](https://github.com/redis-developer/redis-cloud-rs/issues/65)).
  Every handler that previously exposed only verbose `get_all_X` / `get_X_by_id` /
  `create_X` style methods now also exposes short `list` / `get` / `create` /
  `update` / `delete` aliases. The verbose forms are retained for backward
  compatibility. Accessible via `client.subscriptions().list()`,
  `client.databases().list(sub_id)`, `client.acl().list_redis_rules()`, etc.

- Python bindings expanded to cover all major read domains: Account, Tasks,
  Users, ACL (redis rules, roles, users), Cloud Accounts, Essentials
  Subscriptions, and Essentials Databases, in addition to the previously covered
  Pro subscriptions and databases
  ([#66](https://github.com/redis-developer/redis-cloud-rs/issues/66)).
  Every domain method is available in both async and `_sync` blocking variants.
  Coverage table and parity-scope documentation updated in `python/README.md`.

- Implemented every remaining uncovered spec route, raising route coverage to
  **155/155 (100%)** and emptying the unsupported-route allowlist
  ([#72](https://github.com/redis-developer/redis-cloud-rs/issues/72)). New
  typed handler methods and request/response types:
  - Active-Active VPC peering CRUD on `VpcPeeringHandler` (see the Changed note
    above), with a new `ActiveActiveVpcPeeringCreateRequest`
    (`for_aws` / `for_gcp` constructors).
  - `PrivateLinkHandler::disassociate_connections`, `delete_active_active`, and
    `disassociate_connections_active_active`, with new
    `PrivateLinkConnectionsDisassociateRequest`,
    `PrivateLinkActiveActiveConnectionsDisassociateRequest`, and
    `PrivateLinkConnectionDisassociate` types.
  - `PscHandler::get_endpoints` and `get_endpoints_active_active`
    (`GET .../private-service-connect/{pscServiceId}`).
  - `get_traffic` and `resume_traffic` on both the Pro and Essentials database
    handlers, with a shared `types::DatabaseTrafficStateResponse`.
  - `SubscriptionHandler::update_resource_tags`
    (`PUT /subscriptions/{id}/resource-tags`) with a new
    `SubscriptionResourceTagsUpdateRequest`.

- Executable route-coverage checks between the typed client handlers and the
  bundled OpenAPI spec
  ([#67](https://github.com/redis-developer/redis-cloud-rs/issues/67)). A new
  `tests/openapi_route_coverage.rs` extracts the client's routes from source and
  diffs them against the spec; intentional gaps are tracked in two allowlists
  (`tests/fixtures/openapi_unsupported_routes.txt`,
  `openapi_non_spec_routes.txt`). CI now fails when a spec route becomes
  uncovered — or a handler route goes off-spec — without an explicit entry, and
  when an allowlist entry goes stale.

### Changed

- **Breaking:** reconciled the connectivity (Transit Gateway + Private Service
  Connect) handler paths with the refreshed OpenAPI spec
  ([#72](https://github.com/redis-developer/redis-cloud-rs/issues/72)). This
  clears the entire non-spec route allowlist (22 → 0) and raises spec coverage
  to 141/155. Signature/behavior changes:
  - TGW invitation accept/reject now issue `PUT .../transitGateways/invitations/{id}/{accept,reject}`
    (previously `POST .../tgw/shared-invitations/...`); `get_shared_invitations`
    now hits `.../transitGateways/invitations`.
  - Active-Active TGW methods (`get_attachments_active_active`,
    `get_shared_invitations_active_active`) gained a `region_id` parameter, and
    `create_attachment_active_active` / `update_attachment_cidrs_active_active` /
    `delete_attachment_active_active` now use the spec
    `.../regions/{regionId}/transitGateways/{tgwId}/attachment` shape (with a
    `tgw_id` parameter where required).
  - Removed `TransitGatewayHandler::create_attachment` (the no-id variant that
    posted to the non-spec `.../transitGateways/attachments`); use
    `create_attachment_with_id`.
  - PSC endpoint operations (`create_endpoint`, `delete_endpoint`,
    `update_endpoint`, creation/deletion scripts, and their Active-Active
    variants) now take an explicit `psc_service_id` and target the spec
    `.../private-service-connect/{pscServiceId}/endpoints/{endpointId}` shape;
    the Active-Active service methods gained a `region_id` parameter. Removed
    the non-spec `get_endpoints` / `get_endpoints_active_active` list methods.
  - `ConnectivityHandler::create_psc_endpoint` and `update_psc_service_endpoint`
    gained the corresponding `psc_service_id` parameter.

- **Breaking:** the Active-Active VPC peering methods on `VpcPeeringHandler`
  (`get_active_active`, `create_active_active`, `update_active_active`,
  `delete_active_active`) previously delegated to the standard
  `/subscriptions/{id}/peerings` endpoints; they now target the correct
  `/subscriptions/{id}/regions/peerings[/{peeringId}]` spec surface
  ([#72](https://github.com/redis-developer/redis-cloud-rs/issues/72)).
  `create_active_active` now takes `&ActiveActiveVpcPeeringCreateRequest`
  (was `&VpcPeeringCreateRequest`); `update_active_active` now takes
  `&VpcPeeringUpdateAwsRequest`.

- **Breaking:** connectivity handlers now return `TaskStateUpdate` instead of
  `serde_json::Value` for every endpoint the spec marks task-returning
  ([#78](https://github.com/redis-developer/redis-cloud-rs/issues/78)). This
  covers all 11 `private_link` methods, the PSC/Transit Gateway/VPC peering
  deletes (which previously discarded the body and returned `Value::Null`), and
  the corresponding `ConnectivityHandler` façade deletes. Callers can now poll
  the returned `task_id` to completion instead of dropping to raw HTTP. Added
  `CloudClient::delete_typed` for bodyless DELETEs that return a parsed body.

- **Breaking:** consolidated shared task and tag models onto canonical types in
  `crate::types` ([#64](https://github.com/redis-developer/redis-cloud-rs/issues/64)).
  The per-module `TaskStateUpdate` copies (in `tasks`, `users`, `cloud_accounts`,
  `acl`, `flexible::{subscriptions,databases}`, `fixed::{subscriptions,databases}`)
  are now re-exports of `types::TaskStateUpdate`.
  - `TaskStateUpdate::status` is now the typed `Option<TaskStatus>` enum instead
    of `Option<String>`. Unrecognized wire values deserialize to
    `TaskStatus::Unknown` rather than failing. `TaskStateUpdate` also gains a
    `progress: Option<f64>` field.
  - `types::CloudTag` and `types::CloudTags` now match the wire shapes the
    database tag endpoints actually return (`CloudTag` carries
    `created_at`/`updated_at`/`links`; `CloudTags` is the `account_id`/`links`
    HATEOAS envelope). The key/value request pair is now `types::Tag`.
    `flexible::databases` and `fixed::databases` re-export these.

### Fixed

- `DatabaseBackupConfig::time_utc` and `database_backup_time_utc` now serialize
  as `timeUTC` / `databaseBackupTimeUTC` (uppercase `UTC`) to match the OpenAPI
  spec ([#108](https://github.com/redis-developer/redis-cloud-rs/issues/108)).
  The previous camelCase (`timeUtc`) did not match the API, so a backup start
  hour set on a create/update request was silently dropped. Also corrected the
  docs on the paired `backup_interval`/`database_backup_time_utc`/
  `backup_storage_type` fields: they are alternate **request** field names the
  API accepts, not server-returned aliases (investigation from #97).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).