### PR TITLE
fix(tasks): handle the canonical TasksStateUpdate wrapper from GET /tasks

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -55,6 +55,7 @@
 //! # }
 //! ```
 
+use crate::error::CloudError;
 use crate::types::{Link, ProcessorResponse};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
@@ -62,6 +63,16 @@ use serde::{Deserialize, Serialize};
 // ============================================================================
 // Models
 // ============================================================================
+
+/// Wrapper response for `GET /tasks` per the OpenAPI spec (`TasksStateUpdate`).
+///
+/// Kept private because [`TasksHandler::get_all_tasks`] unwraps to the inner
+/// `Vec<TaskStateUpdate>` for caller ergonomics.
+#[derive(Debug, Clone, Deserialize)]
+struct TasksStateUpdate {
+    #[serde(default)]
+    tasks: Vec<TaskStateUpdate>,
+}
 
 /// Task state update
 ///
@@ -124,17 +135,32 @@ impl TasksHandler {
     /// Get tasks
     /// Gets a list of all currently running tasks for this account.
     ///
-    /// The API returns an array when tasks exist but an empty object `{}` when
-    /// there are no tasks, so we handle both cases.
+    /// The OpenAPI spec defines the response as `TasksStateUpdate { tasks: [...] }`
+    /// (a wrapper object). In practice the API also returns:
+    /// - an empty object `{}` when there are no tasks,
+    /// - and historically a bare JSON array.
+    ///
+    /// All three shapes deserialize cleanly to `Vec<TaskStateUpdate>`. Any other
+    /// shape surfaces as [`CloudError::JsonError`] rather than silently returning
+    /// an empty list, so a future schema change is loud instead of invisible.
     ///
     /// GET /tasks
     pub async fn get_all_tasks(&self) -> Result<Vec<TaskStateUpdate>> {
         let value: serde_json::Value = self.client.get_raw("/tasks").await?;
         match value {
-            serde_json::Value::Array(arr) => {
-                Ok(serde_json::from_value(serde_json::Value::Array(arr))?)
+            // Canonical spec shape: {"tasks": [...]}
+            serde_json::Value::Object(ref obj) if obj.contains_key("tasks") => {
+                let wrapped: TasksStateUpdate = serde_json::from_value(value)?;
+                Ok(wrapped.tasks)
             }
-            _ => Ok(Vec::new()),
+            // No tasks: API returns `{}` (or null) instead of the wrapper.
+            serde_json::Value::Object(obj) if obj.is_empty() => Ok(Vec::new()),
+            serde_json::Value::Null => Ok(Vec::new()),
+            // Legacy bare-array shape, still tolerated.
+            serde_json::Value::Array(_) => Ok(serde_json::from_value(value)?),
+            other => Err(CloudError::JsonError(format!(
+                "GET /tasks: expected {{\"tasks\": [...]}}, {{}}, null, or a bare array; got {other}"
+            ))),
         }
     }
 

--- a/src/testing/server.rs
+++ b/src/testing/server.rs
@@ -273,13 +273,19 @@ impl MockCloudServer {
 
     /// Mock the tasks list endpoint (GET /tasks)
     ///
-    /// Returns a direct array since `get_all_tasks()` returns `Result<Vec<TaskStateUpdate>>`.
+    /// Wraps the supplied tasks in the canonical `{"tasks": [...]}` shape that
+    /// the real Redis Cloud API returns (per the OpenAPI `TasksStateUpdate`
+    /// schema). Callers continue to pass `Vec<Value>`; the wrapper is added on
+    /// the wire so `get_all_tasks()` exercises the same code path it would
+    /// against production.
     pub async fn mock_tasks_list(&self, tasks: Vec<Value>) {
         Mock::given(method("GET"))
             .and(path("/tasks"))
             .and(header("x-api-key", "test-key"))
             .and(header("x-api-secret-key", "test-secret"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(tasks))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "tasks": tasks,
+            })))
             .mount(&self.server)
             .await;
     }

--- a/tests/tasks_tests.rs
+++ b/tests/tasks_tests.rs
@@ -3,8 +3,19 @@ use serde_json::json;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+// Helper: build a Cloud client wired to the given mock server URI.
+fn test_client(uri: String) -> CloudClient {
+    CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(uri)
+        .build()
+        .unwrap()
+}
+
 #[tokio::test]
-async fn test_get_all_tasks() {
+async fn test_get_all_tasks_canonical_wrapper() {
+    // OpenAPI spec response shape: TasksStateUpdate { tasks: [TaskStateUpdate] }.
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
@@ -16,7 +27,7 @@ async fn test_get_all_tasks() {
                 {
                     "taskId": "task-1",
                     "commandType": "CREATE_DATABASE",
-                    "status": "completed",
+                    "status": "processing-completed",
                     "description": "Created database successfully",
                     "timestamp": "2024-01-01T10:00:00Z",
                     "response": {
@@ -26,14 +37,14 @@ async fn test_get_all_tasks() {
                 {
                     "taskId": "task-2",
                     "commandType": "UPDATE_SUBSCRIPTION",
-                    "status": "processing",
+                    "status": "processing-in-progress",
                     "description": "Updating subscription",
                     "timestamp": "2024-01-01T11:00:00Z"
                 },
                 {
                     "taskId": "task-3",
                     "commandType": "DELETE_DATABASE",
-                    "status": "failed",
+                    "status": "processing-error",
                     "description": "Failed to delete database",
                     "timestamp": "2024-01-01T12:00:00Z",
                     "response": {
@@ -45,18 +56,77 @@ async fn test_get_all_tasks() {
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key".to_string())
-        .api_secret("test-secret".to_string())
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
+    let handler = TasksHandler::new(test_client(mock_server.uri()));
+    let tasks = handler.get_all_tasks().await.unwrap();
 
-    let _handler = TasksHandler::new(client);
-    // Note: get_all_tasks currently returns () - the method seems not fully implemented
-    // For now, we skip the actual test since the endpoint doesn't return the expected response
-    // let result = handler.get_all_tasks().await;
-    // assert!(result.is_ok());
+    assert_eq!(tasks.len(), 3);
+    assert_eq!(tasks[0].task_id, Some("task-1".to_string()));
+    assert_eq!(tasks[0].command_type, Some("CREATE_DATABASE".to_string()));
+    assert_eq!(tasks[1].status, Some("processing-in-progress".to_string()));
+    assert_eq!(tasks[2].task_id, Some("task-3".to_string()));
+}
+
+#[tokio::test]
+async fn test_get_all_tasks_empty_object() {
+    // When the account has no tasks, the API returns `{}` rather than the wrapper.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/tasks"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&mock_server)
+        .await;
+
+    let handler = TasksHandler::new(test_client(mock_server.uri()));
+    let tasks = handler.get_all_tasks().await.unwrap();
+
+    assert!(tasks.is_empty());
+}
+
+#[tokio::test]
+async fn test_get_all_tasks_legacy_bare_array() {
+    // Older responses use a bare array. Still tolerated for backward compatibility.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/tasks"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "taskId": "legacy-1", "status": "processing-completed" }
+        ])))
+        .mount(&mock_server)
+        .await;
+
+    let handler = TasksHandler::new(test_client(mock_server.uri()));
+    let tasks = handler.get_all_tasks().await.unwrap();
+
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].task_id, Some("legacy-1".to_string()));
+}
+
+#[tokio::test]
+async fn test_get_all_tasks_unknown_shape_errors() {
+    // Anything outside the three known shapes should surface a JsonError —
+    // never an empty Vec that silently masks a schema regression.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/tasks"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("\"unexpected string\""))
+        .mount(&mock_server)
+        .await;
+
+    let handler = TasksHandler::new(test_client(mock_server.uri()));
+    let err = handler.get_all_tasks().await.unwrap_err();
+
+    match err {
+        redis_cloud::CloudError::JsonError(msg) => {
+            assert!(
+                msg.contains("GET /tasks"),
+                "JsonError message should mention the endpoint: {msg}"
+            );
+        }
+        other => panic!("expected CloudError::JsonError, got: {other:?}"),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `get_all_tasks` now correctly handles the OpenAPI-defined response shape `TasksStateUpdate { tasks: [TaskStateUpdate] }`. Previously the handler only matched on a bare JSON array, so every real-API response fell through to a silent `Vec::new()`.
- Tolerates the legitimate empty replies the API also returns (`{}`, `null`) and the legacy bare-array shape (backward compatibility).
- Any other shape surfaces as `CloudError::JsonError` instead of silently returning empty — so a future schema change is loud, not invisible.
- `mock_tasks_list` in `src/testing/server.rs` now wraps its payload in the canonical shape so consumers of the test-support feature exercise the same code path as real callers.
- Replaces the previously dead-letter `test_get_all_tasks` (which mounted a wiremock expectation but never called the handler) with four focused tests covering wrapper, empty-object, bare-array, and unknown-shape cases.

## Why

Issue #74 documents the bug. Static analysis against `cloud_openapi.json` and the existing test fixture both confirm the wire shape; the previous handler couldn't decode it.

This PR is scoped to `get_all_tasks` only. The broader `TaskStateUpdate` deduplication across the crate is tracked in #64.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass (full suite)
- [x] 4 new tests, all green
- [x] `mock_tasks_list` change verified against the existing `test_mock_tasks_list_with_handler` inside `src/testing/server.rs`

Closes #74
Refs #64 (task type dedup)