### PR TITLE
fix(flexible/databases): rename Database.activated to activated_on (wire field is activatedOn)

### DIFF
--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -923,9 +923,13 @@ pub struct Database {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tls_client_authentication: Option<bool>,
 
-    /// Timestamp when database was activated
+    /// Timestamp when the database was activated.
+    ///
+    /// Wire field is `activatedOn` per the OpenAPI spec. The previous Rust
+    /// name (`activated`) serialized as `activated`, so real responses
+    /// silently deserialized to `None`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub activated: Option<String>,
+    pub activated_on: Option<String>,
 
     /// Timestamp of last modification
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/databases_tests.rs
+++ b/tests/databases_tests.rs
@@ -141,7 +141,7 @@ async fn test_get_database_by_id() {
             "privateEndpoint": "redis-12345.c1.us-east-1.redislabs.com:16379",
             "publicEndpoint": "redis-12345-ext.c1.us-east-1.redislabs.com:16379",
             "protocol": "redis",
-            "activated": "2024-01-01T00:00:00Z",
+            "activatedOn": "2024-01-01T00:00:00Z",
             "lastModified": "2024-01-01T12:00:00Z"
         })))
         .mount(&mock_server)
@@ -177,6 +177,11 @@ async fn test_get_database_by_id() {
     assert_eq!(result.replication, Some(true));
     assert_eq!(result.data_persistence, Some("aof-every-1-sec".to_string()));
     assert_eq!(result.protocol, Some("redis".to_string()));
+    // Regression guard for #76: the wire field is `activatedOn`, not `activated`.
+    assert_eq!(
+        result.activated_on,
+        Some("2024-01-01T00:00:00Z".to_string())
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

`Database.activated` was named to serialize as `"activated"` on the wire (via `rename_all = "camelCase"`), but the Redis Cloud API returns the activation timestamp under `activatedOn` per the OpenAPI spec example. Every real response silently deserialized to `None`.

Renamed the Rust field to `activated_on`; the camelCase derive now produces the correct wire name `activatedOn` automatically.

## Test changes

- `test_get_database_by_id` mock now uses `"activatedOn"` (the real wire key) and asserts the value round-trips — regression guard.

## Breaking change

`Database.activated` → `Database.activated_on`. In practice the previous field was always `None`, so callers can't have been using it meaningfully. CHANGELOG-worthy note when releasing.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Closes #76
Refs #40 (spec deltas)