### PR TITLE
fix(account): PaymentMethod.credit_card_ends_with should be String, not i32

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -239,9 +239,13 @@ pub struct PaymentMethod {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
 
-    /// Last 4 digits of the credit card
+    /// Last digits of the credit card as a masked string.
+    ///
+    /// Typed as `Option<String>` because the OpenAPI example shows a string
+    /// value and real responses can include leading zeros (`"0042"`) or
+    /// non-numeric formatting that would be lost or fail to parse as `i32`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub credit_card_ends_with: Option<i32>,
+    pub credit_card_ends_with: Option<String>,
 
     /// Name on the card
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/account_tests.rs
+++ b/tests/account_tests.rs
@@ -182,12 +182,26 @@ async fn test_get_supported_regions() {
 async fn test_get_account_payment_methods() {
     let mock_server = MockServer::start().await;
 
+    // Realistic shape including a paymentMethods array entry with a
+    // string `creditCardEndsWith` containing leading zeros — the previous
+    // `Option<i32>` typing would either drop the leading zero or fail
+    // outright.
     Mock::given(method("GET"))
         .and(path("/payment-methods"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "accountId": 123
+            "accountId": 123,
+            "paymentMethods": [
+                {
+                    "id": 555,
+                    "type": "Visa",
+                    "creditCardEndsWith": "0042",
+                    "nameOnCard": "Alex Example",
+                    "expirationMonth": 9,
+                    "expirationYear": 2030
+                }
+            ]
         })))
         .mount(&mock_server)
         .await;
@@ -202,7 +216,15 @@ async fn test_get_account_payment_methods() {
     let handler = AccountHandler::new(client);
     let result = handler.get_account_payment_methods().await.unwrap();
 
-    assert!(result.account_id.is_some());
+    assert_eq!(result.account_id, Some(123));
+    let methods = result
+        .payment_methods
+        .expect("response should include paymentMethods");
+    assert_eq!(methods.len(), 1);
+    assert_eq!(methods[0].id, Some(555));
+    assert_eq!(methods[0].r#type.as_deref(), Some("Visa"));
+    // Regression guard for #77: leading-zero card tails survive the round-trip.
+    assert_eq!(methods[0].credit_card_ends_with.as_deref(), Some("0042"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

`PaymentMethod.credit_card_ends_with` was typed `Option<i32>` but the OpenAPI example shows it as a string. Real responses commonly include leading-zero card tails (e.g. `"0042"`) which an `i32` would mangle (drop the leading zero) or fail to deserialize.

Changed to `Option<String>`. Updated the previously vacuous `test_get_account_payment_methods` to mount a realistic shape including a leading-zero tail and assert it round-trips intact.

## Breaking change

Public field type changed. The previous typing silently mis-handled real responses, so no production caller can have been relying on it.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass; `test_get_account_payment_methods` now asserts the actual round-trip

Closes #77
Refs #40 (spec deltas)