### PR TITLE
fix(connectivity): vpc_peering create body serializes the spec's wire keys

### DIFF
--- a/src/connectivity/vpc_peering.rs
+++ b/src/connectivity/vpc_peering.rs
@@ -6,43 +6,95 @@
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 
-/// VPC peering creation request
+/// VPC peering creation request.
+///
+/// The Redis Cloud API documents this as a `oneOf` between an AWS-shaped
+/// body (requiring `region`, `awsAccountId`, `vpcId`) and a GCP-shaped body
+/// (requiring `vpcProjectUid`, `vpcNetworkName`). This struct keeps both
+/// providers in one type for caller flexibility, but uses
+/// `#[serde(rename = ...)]` so the AWS and GCP fields serialize to the
+/// **exact wire names the spec requires**. Use [`Self::for_aws`] or
+/// [`Self::for_gcp`] to construct provider-targeted bodies that avoid
+/// mixing fields.
+///
+/// A type-safe enum split that prevents AWS+GCP field mixing at compile
+/// time is tracked as a follow-on under #65.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VpcPeeringCreateRequest {
+    /// Cloud provider discriminator (e.g. "AWS", "GCP").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
 
+    /// Read-only on the response; populated by the server.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 
-    /// AWS VPC ID
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub vpc_id: Option<String>,
-
-    /// AWS region
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // ------- AWS body -------
+    /// AWS region. Wire name: `region` (spec required for AWS).
+    #[serde(rename = "region", skip_serializing_if = "Option::is_none")]
     pub aws_region: Option<String>,
 
-    /// AWS account ID
+    /// AWS account ID (spec required for AWS).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aws_account_id: Option<String>,
 
-    /// VPC CIDR
+    /// AWS VPC ID (spec required for AWS).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vpc_id: Option<String>,
+
+    /// VPC CIDR. AWS only; optional.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vpc_cidr: Option<String>,
 
-    /// List of VPC CIDRs
+    /// List of VPC CIDRs. AWS only; optional.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vpc_cidrs: Option<Vec<String>>,
 
-    /// GCP project ID
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // ------- GCP body -------
+    /// GCP project UID. Wire name: `vpcProjectUid` (spec required for GCP).
+    #[serde(rename = "vpcProjectUid", skip_serializing_if = "Option::is_none")]
     pub gcp_project_id: Option<String>,
 
-    /// GCP network name
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// GCP network name. Wire name: `vpcNetworkName` (spec required for GCP).
+    #[serde(rename = "vpcNetworkName", skip_serializing_if = "Option::is_none")]
     pub network_name: Option<String>,
+}
+
+impl VpcPeeringCreateRequest {
+    /// Construct an AWS-targeted VPC peering creation body.
+    ///
+    /// Pre-populates `provider = "AWS"` and the three required AWS fields
+    /// (`region`, `awsAccountId`, `vpcId`). Optional CIDR fields can be set
+    /// directly on the returned struct.
+    #[must_use]
+    pub fn for_aws(
+        region: impl Into<String>,
+        aws_account_id: impl Into<String>,
+        vpc_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: Some("AWS".to_string()),
+            aws_region: Some(region.into()),
+            aws_account_id: Some(aws_account_id.into()),
+            vpc_id: Some(vpc_id.into()),
+            ..Self::default()
+        }
+    }
+
+    /// Construct a GCP-targeted VPC peering creation body.
+    ///
+    /// Pre-populates `provider = "GCP"` and the two required GCP fields
+    /// (`vpcProjectUid`, `vpcNetworkName`).
+    #[must_use]
+    pub fn for_gcp(project_uid: impl Into<String>, network_name: impl Into<String>) -> Self {
+        Self {
+            provider: Some("GCP".to_string()),
+            gcp_project_id: Some(project_uid.into()),
+            network_name: Some(network_name.into()),
+            ..Self::default()
+        }
+    }
 }
 
 /// Base VPC peering creation request (for backward compatibility)

--- a/tests/connectivity_tests.rs
+++ b/tests/connectivity_tests.rs
@@ -1,6 +1,6 @@
 use redis_cloud::{CloudClient, ConnectivityHandler};
 use serde_json::json;
-use wiremock::matchers::{header, method, path};
+use wiremock::matchers::{body_json, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
@@ -693,4 +693,89 @@ async fn test_error_handling_500() {
         Err(redis_cloud::CloudError::InternalServerError { .. }) => {}
         _ => panic!("Expected InternalServerError error"),
     }
+}
+
+// Regression guards for #75: VPC peering create body must serialize with the
+// spec's wire-key names (`region` for AWS, `vpcProjectUid` / `vpcNetworkName`
+// for GCP) — not the previous incorrect `awsRegion` / `gcpProjectId` /
+// `networkName`.
+
+#[tokio::test]
+async fn test_vpc_peering_create_aws_wire_keys() {
+    let mock_server = MockServer::start().await;
+
+    // The exact body the SDK should send for an AWS peering create.
+    let expected_body = json!({
+        "provider": "AWS",
+        "region": "us-east-1",
+        "awsAccountId": "123456789012",
+        "vpcId": "vpc-abcdef01",
+        "vpcCidr": "10.0.0.0/16",
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/subscriptions/123/peerings"))
+        .and(body_json(&expected_body))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-aws-keys",
+            "status": "received"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = ConnectivityHandler::new(client);
+    let mut request = redis_cloud::connectivity::VpcPeeringCreateRequest::for_aws(
+        "us-east-1",
+        "123456789012",
+        "vpc-abcdef01",
+    );
+    request.vpc_cidr = Some("10.0.0.0/16".to_string());
+
+    let result = handler.create_vpc_peering(123, &request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-aws-keys".to_string()));
+}
+
+#[tokio::test]
+async fn test_vpc_peering_create_gcp_wire_keys() {
+    let mock_server = MockServer::start().await;
+
+    // GCP body: must use the spec's `vpcProjectUid` and `vpcNetworkName`.
+    let expected_body = json!({
+        "provider": "GCP",
+        "vpcProjectUid": "my-gcp-project-uid",
+        "vpcNetworkName": "my-vpc-network",
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/subscriptions/123/peerings"))
+        .and(body_json(&expected_body))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-gcp-keys",
+            "status": "received"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = ConnectivityHandler::new(client);
+    let request = redis_cloud::connectivity::VpcPeeringCreateRequest::for_gcp(
+        "my-gcp-project-uid",
+        "my-vpc-network",
+    );
+
+    let result = handler.create_vpc_peering(123, &request).await.unwrap();
+    assert_eq!(result.task_id, Some("task-gcp-keys".to_string()));
 }


### PR DESCRIPTION
## Summary

`VpcPeeringCreateRequest` previously serialized AWS and GCP fields with the wrong JSON keys — the API rejected/ignored these fields and `create_vpc_peering` was effectively broken for both providers.

| Rust field | Wire (before) | Wire (after / spec) |
|---|---|---|
| `aws_region` | `awsRegion` | `region` |
| `gcp_project_id` | `gcpProjectId` | `vpcProjectUid` |
| `network_name` | `networkName` | `vpcNetworkName` |

This PR is **non-breaking** — only serde wire mappings change; Rust field names and the struct shape stay the same.

## Also adds

- `VpcPeeringCreateRequest::for_aws(region, aws_account_id, vpc_id)` and `for_gcp(project_uid, network_name)` — provider-targeted constructors that pre-populate `provider` plus the spec's required fields, guiding callers to a correct body without mixing AWS+GCP fields.
- Two regression-guard tests (`test_vpc_peering_create_aws_wire_keys`, `test_vpc_peering_create_gcp_wire_keys`) using `body_json` to assert the exact JSON the SDK sends.
- Doc on `VpcPeeringCreateRequest` describing the relationship to the spec's `oneOf` and pointing to the type-safe enum split as a follow-on under #65.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass
- [x] 2 new wire-key tests green; existing `test_create_vpc_peering_gcp` still passes (renames are transparent to existing tests that don't assert outbound body)

Closes #75
Refs #40 (spec deltas), #65 (handler harmonization / enum split follow-on)