### PR TITLE
docs(lib.rs): refresh stale examples in crate-level docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@
 //!         .api_secret("your-api-secret")
 //!         .build()?;
 //!
-//!     // List all databases
+//!     // List all databases in subscription 123 (Vec<Database>, no wrapper)
 //!     let db_handler = DatabaseHandler::new(client.clone());
-//!     let databases = db_handler.get_subscription_databases(123, None, None).await?;
-//!     println!("Found databases: {:?}", databases);
+//!     let databases = db_handler.list(123).await?;
+//!     println!("Found {} databases", databases.len());
 //!
 //!     Ok(())
 //! }
@@ -155,8 +155,8 @@
 //!
 //! #### VPC Peering
 //! ```rust,no_run
-//! use redis_cloud::{CloudClient, ConnectivityHandler};
-//! use serde_json::json;
+//! use redis_cloud::{CloudClient, VpcPeeringHandler};
+//! use redis_cloud::connectivity::VpcPeeringCreateRequest;
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -165,15 +165,19 @@
 //!     .api_secret("secret")
 //!     .build()?;
 //!
-//! let peering_handler = ConnectivityHandler::new(client.clone());
+//! let handler = VpcPeeringHandler::new(client);
 //!
-//! let peering_request = json!({
-//!     "aws_account_id": "123456789012",
-//!     "vpc_id": "vpc-12345678",
-//!     "vpc_cidr": "10.0.0.0/16",
-//!     "region": "us-east-1"
-//! });
-//! let peering = client.post_raw("/subscriptions/123/peerings", peering_request).await?;
+//! // Construct a provider-targeted body — `for_aws` pre-populates the
+//! // spec's required AWS fields with the correct wire names.
+//! let mut request = VpcPeeringCreateRequest::for_aws(
+//!     "us-east-1",
+//!     "123456789012",
+//!     "vpc-12345678",
+//! );
+//! request.vpc_cidr = Some("10.0.0.0/16".to_string());
+//!
+//! let task = handler.create(123, &request).await?;
+//! println!("Peering create task: {:?}", task.task_id);
 //! # Ok(())
 //! # }
 //! ```
@@ -202,10 +206,9 @@
 //! # }
 //! ```
 //!
-//! #### API Keys (Typed)
+//! #### Account Information (Typed)
 //! ```rust,no_run
-//! use redis_cloud::{CloudClient, AccountHandler};
-//! use serde_json::json;
+//! use redis_cloud::{AccountHandler, CloudClient};
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -216,6 +219,7 @@
 //!
 //! let account = AccountHandler::new(client.clone());
 //! let account_info = account.get_current_account().await?;
+//! # let _ = account_info;
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
## Summary

Three stale examples in the crate-level docs:

1. **Quick Start** used the legacy wrapper-returning `get_subscription_databases(123, None, None)`. Switched to the harmonized `list(123) -> Vec<Database>` and updated the printout to reflect the unwrapped shape.
2. **VPC Peering** built a raw JSON body and called `client.post_raw(...)`, despite the docs four paragraphs above saying "Prefer typed handlers". Now uses `VpcPeeringHandler::create` plus `VpcPeeringCreateRequest::for_aws(...)` — the provider-targeted constructor added in #89.
3. **"API Keys (Typed)" heading** was misleading — the example fetches account info via `get_current_account()`, not API keys. Renamed to "Account Information (Typed)" to match what the code does.

No source changes; only crate-level doc comments. All 70 doctests compile and pass.

This is a focused slice of the broader rustdoc work in #80. The remaining P0/P1/P2 items (strict-lint enablement, `# Errors` sections, missing field docs, `ConnectivityHandler` delegation method docs) ship as separate PRs.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --doc` — 70 pass, 0 fail (the VPC peering doctest now compiles against `for_aws` per #89)

Refs #80