### PR TITLE
docs(types): expand module header and document all variants/fields in shared types

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,26 @@
-//! Common types for Redis Cloud API
+//! Shared types for the Redis Cloud REST API.
 //!
-//! This module contains shared types used across multiple endpoints.
+//! Types in this module are referenced from many endpoints and modules in the
+//! crate. They model the cross-cutting concepts the API itself reuses:
+//!
+//! - **Task tracking** — [`TaskStateUpdate`], [`TaskStatus`],
+//!   [`TasksStateUpdate`], and [`ProcessorResponse`] surface the async
+//!   workflow the Cloud API uses for most mutating operations: a request
+//!   returns a task ID; the caller polls `GET /tasks/{taskId}` until
+//!   completion.
+//! - **HATEOAS navigation** — [`Link`] and [`Links`] capture the `links`
+//!   arrays the API returns alongside most resources.
+//! - **Tagging** — [`CloudTag`] and [`CloudTags`] model the key/value tag
+//!   pairs used for billing and resource filtering.
+//! - **Common enums** — [`CloudProvider`], [`Protocol`],
+//!   [`DataPersistence`], [`SubscriptionStatus`], [`DatabaseStatus`] are
+//!   shared across the database, subscription, and connectivity modules.
+//! - **Generic wrappers** — [`PaginatedResponse`], [`EmptyResponse`],
+//!   [`ErrorResponse`] for cross-cutting response shapes.
+//!
+//! Consolidating these shared models into a single canonical location
+//! is the goal of #64 (currently several endpoint modules redefine their
+//! own copies of `TaskStateUpdate` and tag types).
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -9,96 +29,127 @@ use serde_json::Value;
 // Task Types (Most common - appears in 37 endpoints)
 // ============================================================================
 
-/// `TaskStateUpdate` - Line 9725 in `OpenAPI` spec
-/// Represents the state of an asynchronous task
+/// State of an asynchronous Redis Cloud task.
+///
+/// Returned by most mutating operations in the API. The `task_id` can be
+/// polled via [`TasksHandler::get_task_by_id`] until `status` reaches a
+/// terminal value (see [`TaskStatus`]).
+///
+/// [`TasksHandler::get_task_by_id`]: crate::tasks::TasksHandler::get_task_by_id
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskStateUpdate {
-    /// UUID of the task
+    /// UUID of the task. Use with `TasksHandler::get_task_by_id` to poll.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
 
-    /// Type of command being executed
+    /// Type of command being executed (e.g. `"CREATE_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 
-    /// Current status of the task
+    /// Current task status. See [`TaskStatus`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<TaskStatus>,
 
-    /// Description of the task
+    /// Human-readable description of the task.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
-    /// Timestamp of the task update
+    /// Timestamp of the last task update (ISO-8601 string).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
 
-    /// Response from the processor
+    /// Result of the task once it has completed. See [`ProcessorResponse`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response: Option<ProcessorResponse>,
 
-    /// HATEOAS links for related resources
+    /// HATEOAS links for related resources (e.g. the resource the task
+    /// produced).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Vec<Link>>,
 }
 
-/// `TaskStatus` enum - Part of `TaskStateUpdate` schema
+/// Terminal and intermediate states of a Redis Cloud task.
+///
+/// Status values use kebab-case on the wire (e.g. `"processing-completed"`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum TaskStatus {
+    /// Task has been created but not yet picked up by the processor.
     Initialized,
+    /// Task has been received by the processor.
     Received,
+    /// Task is currently executing. Poll again later.
     ProcessingInProgress,
+    /// Task completed successfully. See `response.resource_id` for the
+    /// resulting resource ID.
     ProcessingCompleted,
+    /// Task failed during processing. See `response.error` for details.
     ProcessingError,
 }
 
-/// `ProcessorResponse` - Line 14268 in `OpenAPI` spec
-/// Contains the result or error from task processing
+/// Result payload included on a completed [`TaskStateUpdate`].
+///
+/// On success, `resource_id` points at the created/modified resource.
+/// On failure, `error` carries a message and the optional `additional_info`
+/// may carry more context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProcessorResponse {
-    /// ID of the primary resource created/modified
+    /// ID of the primary resource created or modified by the task.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource_id: Option<i32>,
 
-    /// ID of an additional resource if applicable
+    /// ID of an additional resource, if the operation produced one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_resource_id: Option<i32>,
 
-    /// The resource object itself
+    /// Free-form resource details. Shape varies by operation type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource: Option<std::collections::HashMap<String, Value>>,
 
-    /// Error message if the operation failed
+    /// Error message, populated only when the task failed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 
-    /// Additional information about the operation
+    /// Free-form additional context attached by the processor.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_info: Option<String>,
 }
 
-/// `ProcessorError` - Subset of massive error enum for common errors
-/// Full enum has 600+ values, we'll add as needed
+/// Coarse subset of Redis Cloud's processor error codes.
+///
+/// The full server-side enumeration has 600+ values; this type captures the
+/// few that callers typically branch on. Unknown codes fall through to
+/// [`Self::Other`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProcessorError {
+    /// Authentication failed for the requested operation.
     #[serde(rename = "UNAUTHORIZED")]
     Unauthorized,
+    /// The target resource was not found.
     #[serde(rename = "NOT_FOUND")]
     NotFound,
+    /// The request was malformed or missing required fields.
     #[serde(rename = "BAD_REQUEST")]
     BadRequest,
+    /// Unspecified processor failure.
     #[serde(rename = "GENERAL_ERROR")]
     GeneralError,
+    /// Catch-all for codes not enumerated here.
     #[serde(other)]
     Other,
 }
 
-/// `TasksStateUpdate` - Collection of task updates
+/// Wrapper for the `GET /tasks` response (`{tasks: [...]}`).
+///
+/// See [`TasksHandler::get_all_tasks`] for the public ergonomic API that
+/// unwraps to `Vec<TaskStateUpdate>`.
+///
+/// [`TasksHandler::get_all_tasks`]: crate::tasks::TasksHandler::get_all_tasks
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TasksStateUpdate {
+    /// Tasks returned by the server.
     pub tasks: Vec<TaskStateUpdate>,
 }
 
@@ -106,16 +157,19 @@ pub struct TasksStateUpdate {
 // Tag Types (Used in database and subscription endpoints)
 // ============================================================================
 
-/// `CloudTag` - Individual tag with key-value
+/// Key-value tag attached to a database or subscription.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloudTag {
+    /// Tag name.
     pub key: String,
+    /// Tag value.
     pub value: String,
 }
 
-/// `CloudTags` - Collection of tags
+/// Collection wrapper for a list of [`CloudTag`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloudTags {
+    /// Tags in the collection.
     pub tags: Vec<CloudTag>,
 }
 
@@ -123,40 +177,50 @@ pub struct CloudTags {
 // Common Response Types
 // ============================================================================
 
-/// Generic paginated response wrapper
+/// Generic paginated-response wrapper.
+///
+/// The `data` field is flattened so the inner shape's fields appear at the
+/// same JSON level as the pagination metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaginatedResponse<T> {
-    /// The actual data items
+    /// Inner page payload.
     #[serde(flatten)]
     pub data: T,
 
-    /// Pagination metadata
+    /// Zero-based offset of the first item in this page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<u32>,
 
+    /// Maximum number of items returned per page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
 
+    /// Total number of items across all pages.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total: Option<u32>,
 }
 
-/// HATEOAS Link object for API navigation
+/// HATEOAS link to a related API resource.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Link {
+    /// Relationship name (e.g. `"self"`, `"databases"`).
     pub rel: String,
+    /// Absolute URL the link points to.
     pub href: String,
 
+    /// HTTP method to use when following the link, if specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
 
+    /// Media type the linked resource will return.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
 }
 
-/// Links collection
+/// Collection wrapper for a list of [`Link`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Links {
+    /// Links in the collection.
     pub links: Vec<Link>,
 }
 
@@ -164,61 +228,87 @@ pub struct Links {
 // Common Enums used across multiple endpoints
 // ============================================================================
 
-/// Cloud provider enum
+/// Cloud provider hosting a Redis Cloud resource.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum CloudProvider {
+    /// Amazon Web Services.
     Aws,
+    /// Google Cloud Platform.
     Gcp,
+    /// Microsoft Azure.
     Azure,
 }
 
-/// Database protocol
+/// Redis protocol exposed by a database endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Protocol {
+    /// Standard Redis protocol.
     Redis,
+    /// Memcached-compatible protocol.
     Memcached,
+    /// Redis Stack — Redis with bundled modules (JSON, Search, etc.).
     Stack,
 }
 
-/// Data persistence options
+/// Database persistence policy.
+///
+/// Variant wire names follow the Redis Cloud convention (e.g.
+/// `"aof-every-1-sec"`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DataPersistence {
+    /// No persistence; data lives only in memory.
     #[serde(rename = "none")]
     None,
+    /// Append-only file flushed every second.
     #[serde(rename = "aof-every-1-sec")]
     AofEvery1Sec,
+    /// Append-only file flushed on every write.
     #[serde(rename = "aof-every-write")]
     AofEveryWrite,
+    /// RDB snapshot every hour.
     #[serde(rename = "snapshot-every-1-hour")]
     SnapshotEvery1Hour,
+    /// RDB snapshot every six hours.
     #[serde(rename = "snapshot-every-6-hours")]
     SnapshotEvery6Hours,
+    /// RDB snapshot every twelve hours.
     #[serde(rename = "snapshot-every-12-hours")]
     SnapshotEvery12Hours,
 }
 
-/// Subscription status
+/// Lifecycle status of a Pro subscription.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SubscriptionStatus {
+    /// Subscription is being created; not yet ready for use.
     Pending,
+    /// Subscription is operational.
     Active,
+    /// Subscription is in the process of being deleted.
     Deleting,
+    /// Subscription is in an error state and may require operator action.
     Error,
 }
 
-/// Database status
+/// Lifecycle status of a database.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DatabaseStatus {
+    /// Database is being created; not yet ready for connections.
     Pending,
+    /// Database is operational.
     Active,
+    /// Database is operational but has pending configuration changes.
     ActiveChangePending,
+    /// Database is being populated from an import source.
     ImportPending,
+    /// Database is queued for deletion.
     DeletePending,
+    /// Database is in recovery from a failure.
     Recovery,
+    /// Database is in an error state.
     Error,
 }
 
@@ -226,24 +316,30 @@ pub enum DatabaseStatus {
 // Utility Types
 // ============================================================================
 
-/// Empty response for successful operations with no body
+/// Empty response body. Returned by operations that succeed without payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmptyResponse {}
 
-/// Generic error response structure
-/// Note: The actual API may return different error formats,
-/// this is a common structure we'll adapt as needed
+/// Generic error response body.
+///
+/// The Redis Cloud API uses several different error shapes; this struct
+/// captures the most common keys and leaves all of them optional so callers
+/// can match on whichever fields the server returned.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorResponse {
+    /// Short error code or category (e.g. `"NOT_FOUND"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 
+    /// Human-readable error message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 
+    /// Additional free-form context about the error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// HTTP status code echoed in the body.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_code: Option<u16>,
 }


### PR DESCRIPTION
## Summary

`src/types.rs` is the canonical home for cross-cutting types every handler touches (`TaskStateUpdate`, `TaskStatus`, `Link`, `CloudTag`, the shared enums), but the module-level header was three lines and many variants/fields had zero docstring.

## What this PR adds

- Module header rewritten as a structured overview organized by domain (task tracking, HATEOAS, tagging, common enums, generic wrappers), with a pointer to #64 for the consolidation work.
- Per-variant docs for: `TaskStatus` (5), `ProcessorError` (5), `CloudProvider` (3), `Protocol` (3), `DataPersistence` (6), `SubscriptionStatus` (4), `DatabaseStatus` (7) — **33 variants total**.
- Per-field docs for: `TaskStateUpdate`, `TasksStateUpdate.tasks`, `CloudTag.{key,value}`, `CloudTags.tags`, `PaginatedResponse.{offset,limit,total}`, `Link.{rel,href,method,type}`, `Links.links`, `ErrorResponse.{error,message,description,status_code}`.
- Intra-doc links between related types.
- Removed the brittle "Line 9725 in OpenAPI spec" comments that drift with every spec refresh.

## What this PR is NOT

- Not a code change. Wire shapes are unchanged.
- Not the full #80 work. The remaining handler modules (`acl`, `users`, `account`, the four `flexible`/`fixed` submodules, `connectivity/{psc,transit_gateway,vpc_peering,private_link}`) still have hundreds of undocumented fields. They ship as separate PRs.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass; 70 doctests; 5 unit tests; full suite green

Refs #80, #64