### PR TITLE
docs(connectivity): expand thin module headers (psc, transit_gateway, vpc_peering)

### DIFF
--- a/src/connectivity/psc.rs
+++ b/src/connectivity/psc.rs
@@ -1,7 +1,41 @@
-//! Private Service Connect (PSC) operations
+//! Google Cloud Private Service Connect (PSC) operations.
 //!
-//! Manages Google Cloud Private Service Connect endpoints for secure connectivity
-//! to Redis Cloud databases without traversing the public internet.
+//! Manages Private Service Connect services and endpoints so Redis Cloud
+//! databases can be reached from a GCP VPC without traversing the public
+//! internet.
+//!
+//! # When to use this module
+//!
+//! - The subscription is on GCP and you want connectivity that does not
+//!   require a VPC peering connection or a public endpoint.
+//! - You manage multiple client projects and want each to attach via its
+//!   own consumer endpoint.
+//!
+//! For AWS connectivity see [`crate::connectivity::vpc_peering`] (general
+//! VPC peering) or [`crate::connectivity::private_link`] (AWS PrivateLink).
+//! For AWS hub-and-spoke topologies see
+//! [`crate::connectivity::transit_gateway`].
+//!
+//! # Endpoint surface
+//!
+//! Service-level (one per subscription / region):
+//!
+//! - `GET    /subscriptions/{subscriptionId}/private-service-connect`
+//! - `POST   /subscriptions/{subscriptionId}/private-service-connect`
+//! - `DELETE /subscriptions/{subscriptionId}/private-service-connect`
+//!
+//! Endpoint-level (consumer endpoints under the service):
+//!
+//! - `POST /subscriptions/{subscriptionId}/private-service-connect/.../endpoints`
+//! - `PUT  /subscriptions/{subscriptionId}/private-service-connect/.../endpoints/{endpointId}`
+//!
+//! Active-Active subscriptions expose the same surface scoped to a region
+//! id via `/subscriptions/{subscriptionId}/regions/{regionId}/...`.
+//!
+//! # Errors
+//!
+//! All operations return [`crate::Result`]; transport, auth, and 4xx/5xx
+//! responses surface as the corresponding [`crate::CloudError`] variant.
 
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};

--- a/src/connectivity/transit_gateway.rs
+++ b/src/connectivity/transit_gateway.rs
@@ -1,7 +1,36 @@
-//! AWS Transit Gateway operations
+//! AWS Transit Gateway (TGW) attachment operations.
 //!
-//! Manages AWS Transit Gateway attachments for hub-and-spoke network topologies,
-//! enabling centralized connectivity management for Redis Cloud subscriptions.
+//! Manages AWS Transit Gateway attachments and CIDR allow-lists so a Redis
+//! Cloud subscription can ride a hub-and-spoke topology you already
+//! operate, rather than terminating its own VPC peering connection.
+//!
+//! # When to use this module
+//!
+//! - You already run a Transit Gateway and want Redis Cloud subscriptions
+//!   to attach to it for centralized routing and segmentation.
+//! - You need to extend or update the CIDRs a subscription is allowed to
+//!   reach through its TGW attachment.
+//!
+//! For direct point-to-point AWS peering see
+//! [`crate::connectivity::vpc_peering`]; for endpoint-style PrivateLink
+//! connectivity see [`crate::connectivity::private_link`].
+//!
+//! # Endpoint surface
+//!
+//! Standard subscriptions:
+//!
+//! - `GET    /subscriptions/{subscriptionId}/transitGateways`
+//! - `POST   /subscriptions/{subscriptionId}/transitGateways/{tgwId}`
+//! - `DELETE /subscriptions/{subscriptionId}/transitGateways/{tgwId}`
+//! - `PUT    /subscriptions/{subscriptionId}/transitGateways/{tgwId}/attachment`
+//!
+//! Active-Active subscriptions expose the same surface under
+//! `/subscriptions/{subscriptionId}/regions/{regionId}/...`.
+//!
+//! # Errors
+//!
+//! All operations return [`crate::Result`]; transport, auth, and 4xx/5xx
+//! responses surface as the corresponding [`crate::CloudError`] variant.
 
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};

--- a/src/connectivity/vpc_peering.rs
+++ b/src/connectivity/vpc_peering.rs
@@ -1,7 +1,61 @@
-//! VPC Peering connectivity operations
+//! VPC peering operations for AWS and GCP Pro subscriptions.
 //!
-//! Manages VPC peering connections between Redis Cloud VPCs and customer VPCs
-//! for both standard and Active-Active subscriptions.
+//! Manages VPC peering connections between a Redis Cloud subscription's
+//! VPC and a customer-owned VPC, covering both standard subscriptions and
+//! Active-Active (CRDB) subscriptions where each region is peered
+//! independently.
+//!
+//! # When to use this module
+//!
+//! - You want direct VPC-to-VPC private connectivity (no public
+//!   endpoint, no shared TGW).
+//! - The subscription is on **AWS** or **GCP**. Azure connectivity is
+//!   handled separately by the Redis Cloud console; the SDK does not
+//!   yet expose Azure-specific endpoints here.
+//!
+//! For AWS hub-and-spoke topologies see
+//! [`crate::connectivity::transit_gateway`]; for AWS endpoint-style
+//! private connectivity see [`crate::connectivity::private_link`]; for
+//! GCP endpoint-style private connectivity see
+//! [`crate::connectivity::psc`].
+//!
+//! # Endpoint surface
+//!
+//! - `GET    /subscriptions/{subscriptionId}/peerings`
+//! - `POST   /subscriptions/{subscriptionId}/peerings`
+//! - `PUT    /subscriptions/{subscriptionId}/peerings/{peeringId}`
+//! - `DELETE /subscriptions/{subscriptionId}/peerings/{peeringId}`
+//!
+//! Active-Active subscriptions expose the same surface scoped to a
+//! region under `/subscriptions/{subscriptionId}/regions/{regionId}/...`.
+//!
+//! # Example
+//!
+//! Construct a provider-targeted body and create a peering:
+//!
+//! ```rust,no_run
+//! use redis_cloud::{CloudClient, VpcPeeringHandler};
+//! use redis_cloud::connectivity::VpcPeeringCreateRequest;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = CloudClient::builder()
+//!     .api_key("k").api_secret("s").build()?;
+//! let handler = VpcPeeringHandler::new(client);
+//!
+//! let mut request = VpcPeeringCreateRequest::for_aws(
+//!     "us-east-1", "123456789012", "vpc-12345678",
+//! );
+//! request.vpc_cidr = Some("10.0.0.0/16".to_string());
+//! let task = handler.create(123, &request).await?;
+//! # let _ = task;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Errors
+//!
+//! All operations return [`crate::Result`]; transport, auth, and 4xx/5xx
+//! responses surface as the corresponding [`crate::CloudError`] variant.
 
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary

`psc.rs`, `transit_gateway.rs`, and `vpc_peering.rs` had three-line module headers despite each hosting 9–19 public methods. This PR brings them up to the same depth as `private_link.rs` (which already has a multi-paragraph Overview).

## What each module header now carries

- A one-paragraph summary of what the module is for
- A **"When to use this module"** section distinguishing it from the three sibling connectivity modules (so a reader picking between VPC peering / PSC / Transit Gateway / PrivateLink has a single place to disambiguate)
- The full REST endpoint surface (standard + Active-Active variants)
- A blanket `# Errors` note pointing at `CloudError`
- A runnable example on `vpc_peering` using the `for_aws` constructor from #75

`private_link.rs` is left untouched — its header was already fine.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass; 71 doctests (was 70: the new `vpc_peering` example)

Refs #80