### PR TITLE
docs(small modules): document the remaining undocumented fields in 6 short modules

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -54,6 +54,7 @@ use serde::{Deserialize, Serialize};
 /// Database modules/capabilities response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModulesData {
+    /// Database modules supported on this account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub modules: Option<Vec<Module>>,
 
@@ -158,18 +159,23 @@ pub struct AccountApiKeyOwner {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountSystemLogEntry {
+    /// Unique log entry ID.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
 
+    /// Timestamp the event was recorded (ISO-8601).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time: Option<String>,
 
+    /// Originator of the event (user, system, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub originator: Option<String>,
 
+    /// Name of the API key that initiated the action, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key_name: Option<String>,
 
+    /// Resource category the event applies to (e.g. `"database"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource: Option<String>,
 
@@ -177,9 +183,11 @@ pub struct AccountSystemLogEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource_id: Option<i32>,
 
+    /// Event type (e.g. `"info"`, `"warning"`, `"error"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
 
+    /// Human-readable description of the event.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
@@ -187,6 +195,7 @@ pub struct AccountSystemLogEntry {
 /// Available regions response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Regions {
+    /// Regions available on the account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regions: Option<Vec<Region>>,
 
@@ -215,6 +224,7 @@ pub struct Region {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PaymentMethods {
+    /// Account ID the payment methods belong to.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_id: Option<i32>,
 
@@ -313,6 +323,7 @@ pub struct ModuleParameter {
 /// Account system log entries response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccountSystemLogEntries {
+    /// System log entries returned by the server.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entries: Option<Vec<AccountSystemLogEntry>>,
 
@@ -399,6 +410,7 @@ pub struct DataPersistenceOptions {
 /// Account session log entries response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccountSessionLogEntries {
+    /// Session log entries returned by the server.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entries: Option<Vec<AccountSessionLogEntry>>,
 

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -58,6 +58,8 @@ pub struct AclRoleCreateRequest {
     /// A list of Redis ACL rules to assign to this database access role.
     pub redis_rules: Vec<AclRoleRedisRuleSpec>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -66,6 +68,7 @@ pub struct AclRoleCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AclUserUpdateRequest {
+    /// ACL user ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<i32>,
 
@@ -77,6 +80,8 @@ pub struct AclUserUpdateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -154,6 +159,8 @@ pub struct AclRedisRuleCreateRequest {
     /// Redis ACL rule pattern. See [ACL syntax](https://redis.io/docs/latest/operate/rc/security/access-control/data-access-control/configure-acls/#define-permissions-with-acl-syntax) to learn how to define rules.
     pub redis_rule: String,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -262,6 +269,7 @@ pub struct ACLRoleDatabase {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AclRedisRuleUpdateRequest {
+    /// Redis ACL rule ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_rule_id: Option<i32>,
 
@@ -271,6 +279,8 @@ pub struct AclRedisRuleUpdateRequest {
     /// Optional. Changes the Redis ACL rule pattern. See [ACL syntax](https://redis.io/docs/latest/operate/rc/security/access-control/data-access-control/configure-acls/#define-permissions-with-acl-syntax) to learn how to define rules.
     pub redis_rule: String,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -303,6 +313,8 @@ pub struct AclUserCreateRequest {
     /// The database password for this user.
     pub password: String,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -343,9 +355,12 @@ pub struct AclRoleUpdateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_rules: Option<Vec<AclRoleRedisRuleSpec>>,
 
+    /// ACL role ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role_id: Option<i32>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }

--- a/src/cloud_accounts.rs
+++ b/src/cloud_accounts.rs
@@ -69,6 +69,7 @@ pub struct CloudAccountUpdateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
+    /// Cloud account ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud_account_id: Option<i32>,
 
@@ -88,6 +89,8 @@ pub struct CloudAccountUpdateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sign_in_login_url: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_CLOUD_ACCOUNT"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -171,6 +174,8 @@ pub struct CloudAccountCreateRequest {
     /// Cloud provider management console login URL.
     pub sign_in_login_url: String,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_CLOUD_ACCOUNT"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }

--- a/src/connectivity/psc.rs
+++ b/src/connectivity/psc.rs
@@ -10,8 +10,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PscEndpointUpdateRequest {
+    /// Subscription that owns the PSC service. Server-populated; clients
+    /// pass the value via the path parameter and may leave the default.
     pub subscription_id: i32,
+    /// PSC service ID under the subscription. Server-populated.
     pub psc_service_id: i32,
+    /// PSC endpoint ID being updated. Server-populated.
     pub endpoint_id: i32,
 
     /// Google Cloud project ID

--- a/src/connectivity/transit_gateway.rs
+++ b/src/connectivity/transit_gateway.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Cidr {
+    /// CIDR notation address (e.g. `"10.0.0.0/16"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cidr_address: Option<String>,
 }
@@ -22,6 +23,8 @@ pub struct TgwUpdateCidrsRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cidrs: Option<Vec<Cidr>>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_TGW_CIDRS"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }

--- a/src/connectivity/vpc_peering.rs
+++ b/src/connectivity/vpc_peering.rs
@@ -104,6 +104,7 @@ pub type VpcPeeringCreateBaseRequest = VpcPeeringCreateRequest;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VpcPeeringUpdateAwsRequest {
+    /// Subscription that owns the peering. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
@@ -119,6 +120,8 @@ pub struct VpcPeeringUpdateAwsRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vpc_cidrs: Option<Vec<String>>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_VPC_PEERING"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }


### PR DESCRIPTION
## Summary

Closes the missing-docs errors in the six smaller modules (everything except the four big request/response files and `users.rs`).

| Module | Errors closed |
|---|---|
| `src/account.rs` | 12 |
| `src/acl.rs` | 9 |
| `src/cloud_accounts.rs` | 3 |
| `src/connectivity/psc.rs` | 3 |
| `src/connectivity/transit_gateway.rs` | 2 |
| `src/connectivity/vpc_peering.rs` | 2 |
| **Total** | **31** |

Strict-lint missing-docs error count on main: **368 → 337**.

## Notes

- Used `replace_all` to apply a consistent doc to the 6 read-only `command_type` fields in `acl.rs` — they have the same meaning across every request struct.
- Path-mirrored ID fields (`user_id`, `role_id`, `redis_rule_id`, `subscription_id`, etc.) on update requests are all documented as "server-populated from the path".
- No code or wire-shape changes.

## Remaining #80 work

After this PR plus #91 (already merged: connectivity/mod.rs), #92 (already merged: types.rs), the remaining errors are concentrated in:

- `src/fixed/databases.rs` (70)
- `src/fixed/subscriptions.rs` (65)
- `src/flexible/databases.rs` (62)
- `src/flexible/subscriptions.rs` (52)
- `src/users.rs` (21)

These ship as separate per-module PRs.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Refs #80