### PR TITLE
docs(models): document fields in the four large request/response modules

### DIFF
--- a/src/fixed/databases.rs
+++ b/src/fixed/databases.rs
@@ -108,9 +108,11 @@ pub struct FixedSubscriptionDatabasesInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedDatabaseImportRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
@@ -120,6 +122,8 @@ pub struct FixedDatabaseImportRequest {
     /// One or more paths to source data files or Redis databases, as appropriate to specified source type.
     pub import_from_uri: Vec<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"IMPORT_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -128,18 +132,23 @@ pub struct FixedDatabaseImportRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseTagUpdateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
+    /// Tag key being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
     /// Database tag value
     pub value: String,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_DATABASE_TAG"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -147,9 +156,11 @@ pub struct DatabaseTagUpdateRequest {
 /// `DynamicEndpoints`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DynamicEndpoints {
+    /// Public endpoint for the database (if available).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public: Option<String>,
 
+    /// Private endpoint for the database (if available).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub private: Option<String>,
 }
@@ -164,6 +175,8 @@ pub struct Tag {
     /// Database tag value.
     pub value: String,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_DATABASE_TAG"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -172,15 +185,19 @@ pub struct Tag {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseTagsUpdateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
     /// List of database tags.
     pub tags: Vec<Tag>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_DATABASE_TAGS"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -213,15 +230,19 @@ pub struct DatabaseCertificateSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CloudTag {
+    /// Database tag key.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
+    /// Database tag value.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 
+    /// Timestamp when the tag was created.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
 
+    /// Timestamp when the tag was last updated.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
 
@@ -234,15 +255,19 @@ pub struct CloudTag {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseSlowLogEntry {
+    /// Slowlog entry identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
 
+    /// Timestamp when the command began executing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<String>,
 
+    /// Execution duration in microseconds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<i32>,
 
+    /// Command arguments captured for this slowlog entry.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<String>,
 }
@@ -257,12 +282,16 @@ pub struct DatabaseTagCreateRequest {
     /// Database tag value.
     pub value: String,
 
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_DATABASE_TAG"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -271,9 +300,11 @@ pub struct DatabaseTagCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedDatabaseBackupRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
@@ -281,6 +312,8 @@ pub struct FixedDatabaseBackupRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub adhoc_backup_path: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"BACKUP_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -344,6 +377,7 @@ pub struct DatabaseAlertSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CloudTags {
+    /// Account ID owning the tags.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_id: Option<i32>,
 
@@ -356,87 +390,115 @@ pub struct CloudTags {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedDatabase {
+    /// Database identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
+    /// Database name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
+    /// Database protocol (e.g. `"redis"`, `"stack"`, `"memcached"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub protocol: Option<String>,
 
+    /// Cloud provider (e.g. `"AWS"`, `"GCP"`, `"Azure"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
 
+    /// Cloud region where the database is hosted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
 
+    /// Redis version currently running on the database.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_version: Option<String>,
 
+    /// Redis version compliance level (e.g. `"latest"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_version_compliance: Option<String>,
 
+    /// Redis Serialization Protocol (RESP) version in use.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resp_version: Option<String>,
 
+    /// Current database status (e.g. `"active"`, `"pending"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 
+    /// Memory limit from the plan, in the plan's measurement unit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_memory_limit: Option<f64>,
 
+    /// Dataset size from the plan, in the plan's measurement unit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_dataset_size: Option<f64>,
 
+    /// Measurement unit for memory limits (e.g. `"GB"`, `"MB"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_limit_measurement_unit: Option<String>,
 
+    /// Total memory limit in GB, including replication and other overhead.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_limit_in_gb: Option<f64>,
 
+    /// Maximum dataset size for this database in GB.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dataset_size_in_gb: Option<f64>,
 
+    /// Currently used memory, in MB.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_used_in_mb: Option<f64>,
 
+    /// Network usage so far this month, in bytes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_monthly_usage_in_byte: Option<f64>,
 
+    /// Memory storage type (e.g. `"ram"`, `"ram-and-flash"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_storage: Option<String>,
 
+    /// Whether Redis Flex (auto-tiering) is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_flex: Option<bool>,
 
+    /// Whether Redis OSS Cluster API support is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub support_oss_cluster_api: Option<bool>,
 
+    /// Whether the external endpoint is used for OSS Cluster API.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_external_endpoint_for_oss_cluster_api: Option<bool>,
 
+    /// Data persistence type (e.g. `"none"`, `"aof-every-1-second"`, `"snapshot-every-1-hour"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_persistence: Option<String>,
 
+    /// Whether replication is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replication: Option<bool>,
 
+    /// Data eviction policy (e.g. `"allkeys-lru"`, `"noeviction"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_eviction_policy: Option<String>,
 
+    /// Timestamp when the database was activated.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub activated_on: Option<String>,
 
+    /// Timestamp when the database was last modified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_modified: Option<String>,
 
+    /// Public endpoint hostname/port for connecting from the internet.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public_endpoint: Option<String>,
 
+    /// Private endpoint hostname/port for connecting from inside the VPC.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub private_endpoint: Option<String>,
 
+    /// Additional dynamic endpoints. See [`DynamicEndpoints`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dynamic_endpoints: Option<DynamicEndpoints>,
 
@@ -500,6 +562,7 @@ pub struct FixedDatabase {
 /// `DatabaseSlowLogEntries`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatabaseSlowLogEntries {
+    /// Slowlog entries returned for the database.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entries: Option<Vec<DatabaseSlowLogEntry>>,
 
@@ -512,21 +575,28 @@ pub struct DatabaseSlowLogEntries {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskStateUpdate {
+    /// Task identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 
+    /// Current task status (e.g. `"processing-in-progress"`, `"processing-completed"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 
+    /// Human-readable description of the current task state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Timestamp of the latest task state update.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
 
+    /// Task response payload from the processor.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response: Option<ProcessorResponse>,
 
@@ -550,6 +620,7 @@ pub struct TaskStateUpdate {
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedDatabaseCreateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub subscription_id: Option<i32>,
@@ -638,6 +709,7 @@ pub struct FixedDatabaseCreateRequest {
     #[builder(default, setter(strip_option))]
     pub replica_of: Option<Vec<String>>,
 
+    /// Optional. Replica-of (Active-Passive) configuration. See [`ReplicaOfSpec`].
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub replica: Option<ReplicaOfSpec>,
@@ -672,6 +744,8 @@ pub struct FixedDatabaseCreateRequest {
     #[builder(default, setter(strip_option))]
     pub modules: Option<Vec<DatabaseModuleSpec>>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_FIXED_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub command_type: Option<String>,
@@ -691,10 +765,12 @@ pub struct FixedDatabaseCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedDatabaseUpdateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub database_id: Option<i32>,
@@ -769,6 +845,7 @@ pub struct FixedDatabaseUpdateRequest {
     #[builder(default, setter(strip_option))]
     pub replica_of: Option<Vec<String>>,
 
+    /// Optional. Replica-of (Active-Passive) configuration. See [`ReplicaOfSpec`].
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub replica: Option<ReplicaOfSpec>,
@@ -808,6 +885,8 @@ pub struct FixedDatabaseUpdateRequest {
     #[builder(default, setter(strip_option))]
     pub alerts: Option<Vec<DatabaseAlertSpec>>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_FIXED_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub command_type: Option<String>,

--- a/src/fixed/subscriptions.rs
+++ b/src/fixed/subscriptions.rs
@@ -62,6 +62,7 @@ use typed_builder::TypedBuilder;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RedisVersions {
+    /// List of Redis versions available for the account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_versions: Option<Vec<RedisVersion>>,
 }
@@ -88,6 +89,7 @@ pub struct FixedSubscriptionsPlans {
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedSubscriptionUpdateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub subscription_id: Option<i32>,
@@ -112,6 +114,8 @@ pub struct FixedSubscriptionUpdateRequest {
     #[builder(default, setter(strip_option))]
     pub payment_method_id: Option<i32>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_FIXED_SUBSCRIPTION"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub command_type: Option<String>,
@@ -121,72 +125,95 @@ pub struct FixedSubscriptionUpdateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedSubscriptionsPlan {
+    /// Plan identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
 
+    /// Plan name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
+    /// Total memory size of the plan in the plan's measurement unit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<f64>,
 
+    /// Dataset size of the plan in the plan's measurement unit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dataset_size: Option<f64>,
 
+    /// Measurement unit for `size`/`dataset_size` (e.g. `"GB"`, `"MB"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size_measurement_unit: Option<String>,
 
+    /// Cloud provider (e.g. `"AWS"`, `"GCP"`, `"Azure"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
 
+    /// Cloud region for the plan.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
 
+    /// Region identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region_id: Option<i32>,
 
+    /// Plan price in the plan's currency.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price: Option<i32>,
 
+    /// ISO currency code for the plan price (e.g. `"USD"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price_currency: Option<String>,
 
+    /// Billing period for the plan price (e.g. `"Month"`, `"Hour"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price_period: Option<String>,
 
+    /// Maximum number of databases allowed under this plan.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum_databases: Option<i32>,
 
+    /// Maximum throughput (ops/sec) allowed under this plan.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum_throughput: Option<i32>,
 
+    /// Maximum monthly bandwidth, in GB.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum_bandwidth_gb: Option<i32>,
 
+    /// Availability tier (e.g. `"Single-zone"`, `"Multi-zone"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub availability: Option<String>,
 
+    /// Connection limit description for this plan.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connections: Option<String>,
 
+    /// Number of CIDR allow rules supported by this plan.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cidr_allow_rules: Option<i32>,
 
+    /// Whether the plan supports data persistence.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub support_data_persistence: Option<bool>,
 
+    /// Whether the plan supports Redis Flex (auto-tiering).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_flex: Option<bool>,
 
+    /// Whether the plan supports instant and daily backups.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub support_instant_and_daily_backups: Option<bool>,
 
+    /// Whether the plan supports replication.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub support_replication: Option<bool>,
 
+    /// Whether the plan supports clustering.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub support_clustering: Option<bool>,
 
+    /// Whether the plan supports SSL/TLS connections.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub support_ssl: Option<bool>,
 
@@ -194,6 +221,7 @@ pub struct FixedSubscriptionsPlan {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_alerts: Option<Vec<String>>,
 
+    /// Customer support tier included with this plan.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub customer_support: Option<String>,
 
@@ -234,6 +262,8 @@ pub struct FixedSubscriptionCreateRequest {
     #[builder(default, setter(strip_option))]
     pub payment_method_id: Option<i32>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_FIXED_SUBSCRIPTION"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub command_type: Option<String>,
@@ -243,6 +273,7 @@ pub struct FixedSubscriptionCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedSubscriptions {
+    /// Account identifier owning these subscriptions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_id: Option<i32>,
 
@@ -259,15 +290,19 @@ pub struct FixedSubscriptions {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RedisVersion {
+    /// Redis version string (e.g. `"7.2"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 
+    /// End-of-life date for this Redis version.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eol_date: Option<String>,
 
+    /// Whether this Redis version is a preview/early-access release.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_preview: Option<bool>,
 
+    /// Whether this Redis version is the default for new databases.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_default: Option<bool>,
 }
@@ -276,81 +311,107 @@ pub struct RedisVersion {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedSubscription {
+    /// Subscription identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
 
+    /// Subscription name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
+    /// Current subscription status (e.g. `"active"`, `"pending"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 
+    /// Payment method identifier for this subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method_id: Option<i32>,
 
+    /// Payment method type (e.g. `"credit-card"`, `"marketplace"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method_type: Option<String>,
 
+    /// Identifier of the Essentials plan for this subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_id: Option<i32>,
 
+    /// Name of the Essentials plan for this subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_name: Option<String>,
 
+    /// Plan type (e.g. `"single-region"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_type: Option<String>,
 
+    /// Plan size in the plan's measurement unit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<f64>,
 
+    /// Measurement unit for `size` (e.g. `"GB"`, `"MB"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size_measurement_unit: Option<String>,
 
+    /// Cloud provider (e.g. `"AWS"`, `"GCP"`, `"Azure"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
 
+    /// Cloud region for the subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
 
+    /// Subscription price in the configured currency.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price: Option<i32>,
 
+    /// Billing period for the subscription price (e.g. `"Month"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price_period: Option<String>,
 
+    /// ISO currency code for the subscription price (e.g. `"USD"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price_currency: Option<String>,
 
+    /// Maximum number of databases allowed under this subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum_databases: Option<i32>,
 
+    /// Availability tier (e.g. `"Single-zone"`, `"Multi-zone"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub availability: Option<String>,
 
+    /// Connection limit description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connections: Option<String>,
 
+    /// Number of CIDR allow rules supported by this subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cidr_allow_rules: Option<i32>,
 
+    /// Whether data persistence is supported.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub support_data_persistence: Option<bool>,
 
+    /// Whether instant and daily backups are supported.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub support_instant_and_daily_backups: Option<bool>,
 
+    /// Whether replication is supported.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub support_replication: Option<bool>,
 
+    /// Whether clustering is supported.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub support_clustering: Option<bool>,
 
+    /// Customer support tier included with this subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub customer_support: Option<String>,
 
+    /// Timestamp when the subscription was created.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub creation_date: Option<String>,
 
+    /// Aggregate status of databases in this subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_status: Option<String>,
 
@@ -363,21 +424,28 @@ pub struct FixedSubscription {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskStateUpdate {
+    /// Task identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_FIXED_SUBSCRIPTION"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 
+    /// Current task status (e.g. `"processing-in-progress"`, `"processing-completed"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 
+    /// Human-readable description of the current task state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Timestamp of the latest task state update.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
 
+    /// Task response payload from the processor.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response: Option<ProcessorResponse>,
 

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -152,18 +152,23 @@ pub struct LocalThroughput {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseTagUpdateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
+    /// Tag key being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
     /// Database tag value
     pub value: String,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_DATABASE_TAG"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -178,6 +183,8 @@ pub struct Tag {
     /// Database tag value.
     pub value: String,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_DATABASE_TAG"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -186,12 +193,16 @@ pub struct Tag {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CrdbFlushRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"FLUSH_CRDB"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -209,15 +220,19 @@ pub struct DatabaseCertificate {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseTagsUpdateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
     /// List of database tags.
     pub tags: Vec<Tag>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_DATABASE_TAGS"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -250,15 +265,19 @@ pub struct DatabaseCertificateSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CloudTag {
+    /// Database tag key.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
+    /// Database tag value.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 
+    /// Timestamp when the tag was created.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
 
+    /// Timestamp when the tag was last updated.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
 
@@ -271,15 +290,19 @@ pub struct CloudTag {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BdbVersionUpgradeStatus {
+    /// Database identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
+    /// Target Redis version of the upgrade.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_redis_version: Option<String>,
 
+    /// Upgrade progress (0.0 - 100.0).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub progress: Option<f64>,
 
+    /// Current upgrade status (e.g. `"in-progress"`, `"completed"`, `"failed"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upgrade_status: Option<String>,
 }
@@ -288,9 +311,11 @@ pub struct BdbVersionUpgradeStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CrdbUpdatePropertiesRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
@@ -354,6 +379,8 @@ pub struct CrdbUpdatePropertiesRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_eviction_policy: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_CRDB"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -362,15 +389,19 @@ pub struct CrdbUpdatePropertiesRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseSlowLogEntry {
+    /// Slowlog entry identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
 
+    /// Timestamp when the command began executing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<String>,
 
+    /// Execution duration in microseconds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<i32>,
 
+    /// Command arguments captured for this slowlog entry.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<String>,
 }
@@ -385,12 +416,16 @@ pub struct DatabaseTagCreateRequest {
     /// Database tag value.
     pub value: String,
 
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_DATABASE_TAG"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -417,6 +452,7 @@ pub struct DatabaseBackupConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval: Option<String>,
 
+    /// Server-returned alias for `interval` (e.g. `"every-4-hours"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup_interval: Option<String>,
 
@@ -424,6 +460,7 @@ pub struct DatabaseBackupConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_utc: Option<String>,
 
+    /// Server-returned alias for `time_utc` (24-hour UTC time, e.g. `"14:00"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_backup_time_utc: Option<String>,
 
@@ -431,6 +468,7 @@ pub struct DatabaseBackupConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_type: Option<String>,
 
+    /// Server-returned alias for `storage_type`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup_storage_type: Option<String>,
 
@@ -710,10 +748,12 @@ pub struct CrdbDatabase {
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseBackupRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub database_id: Option<i32>,
@@ -728,6 +768,8 @@ pub struct DatabaseBackupRequest {
     #[builder(default, setter(strip_option, into))]
     pub adhoc_backup_path: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"BACKUP_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub command_type: Option<String>,
@@ -969,6 +1011,7 @@ pub struct DatabaseAlertSpec {
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseCreateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub subscription_id: Option<i32>,
@@ -1042,10 +1085,12 @@ pub struct DatabaseCreateRequest {
     #[builder(default, setter(strip_option))]
     pub replica_of: Option<Vec<String>>,
 
+    /// Optional. Replica-of (Active-Passive) configuration. See [`ReplicaOfSpec`].
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub replica: Option<ReplicaOfSpec>,
 
+    /// Optional. Throughput measurement spec. See [`DatabaseThroughputSpec`].
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub throughput_measurement: Option<DatabaseThroughputSpec>,
@@ -1065,6 +1110,7 @@ pub struct DatabaseCreateRequest {
     #[builder(default, setter(strip_option, into))]
     pub periodic_backup_path: Option<String>,
 
+    /// Optional. Remote backup configuration. See [`DatabaseBackupConfig`].
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub remote_backup: Option<DatabaseBackupConfig>,
@@ -1119,6 +1165,8 @@ pub struct DatabaseCreateRequest {
     #[builder(default, setter(strip_option, into))]
     pub sharding_type: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub command_type: Option<String>,
@@ -1144,10 +1192,12 @@ pub struct DatabaseCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseImportRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub database_id: Option<i32>,
@@ -1159,6 +1209,8 @@ pub struct DatabaseImportRequest {
     /// One or more paths to source data files or Redis databases, as appropriate to specified source type.
     pub import_from_uri: Vec<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"IMPORT_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub command_type: Option<String>,
@@ -1168,6 +1220,7 @@ pub struct DatabaseImportRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CloudTags {
+    /// Account ID owning the tags.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_id: Option<i32>,
 
@@ -1180,15 +1233,19 @@ pub struct CloudTags {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseUpgradeRedisVersionRequest {
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_id: Option<i32>,
 
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
     /// The target Redis version the database will be upgraded to. Use GET /subscriptions/redis-versions to get a list of available Redis versions.
     pub target_redis_version: String,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPGRADE_DATABASE_REDIS_VERSION"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -1196,6 +1253,7 @@ pub struct DatabaseUpgradeRedisVersionRequest {
 /// `DatabaseSlowLogEntries`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatabaseSlowLogEntries {
+    /// Slowlog entries returned for the database.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entries: Option<Vec<DatabaseSlowLogEntry>>,
 
@@ -1212,9 +1270,11 @@ pub struct LocalRegionProperties {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
 
+    /// Optional. Remote backup configuration for this region. See [`DatabaseBackupConfig`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote_backup: Option<DatabaseBackupConfig>,
 
+    /// Optional. Local throughput settings for this region. See [`LocalThroughput`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub local_throughput_measurement: Option<LocalThroughput>,
 
@@ -1243,21 +1303,28 @@ pub struct LocalRegionProperties {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskStateUpdate {
+    /// Task identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 
+    /// Current task status (e.g. `"processing-in-progress"`, `"processing-completed"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 
+    /// Human-readable description of the current task state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Timestamp of the latest task state update.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
 
+    /// Task response payload from the processor.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response: Option<ProcessorResponse>,
 
@@ -1281,10 +1348,12 @@ pub struct TaskStateUpdate {
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseUpdateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub subscription_id: Option<i32>,
 
+    /// Database ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub database_id: Option<i32>,
@@ -1314,6 +1383,7 @@ pub struct DatabaseUpdateRequest {
     #[builder(default, setter(strip_option, into))]
     pub resp_version: Option<String>,
 
+    /// Optional. Throughput measurement spec. See [`DatabaseThroughputSpec`].
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub throughput_measurement: Option<DatabaseThroughputSpec>,
@@ -1343,6 +1413,7 @@ pub struct DatabaseUpdateRequest {
     #[builder(default, setter(strip_option))]
     pub replica_of: Option<Vec<String>>,
 
+    /// Optional. Replica-of (Active-Passive) configuration. See [`ReplicaOfSpec`].
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub replica: Option<ReplicaOfSpec>,
@@ -1402,6 +1473,7 @@ pub struct DatabaseUpdateRequest {
     #[builder(default, setter(strip_option, into))]
     pub periodic_backup_path: Option<String>,
 
+    /// Optional. Remote backup configuration. See [`DatabaseBackupConfig`].
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub remote_backup: Option<DatabaseBackupConfig>,
@@ -1411,6 +1483,8 @@ pub struct DatabaseUpdateRequest {
     #[builder(default, setter(strip_option))]
     pub alerts: Option<Vec<DatabaseAlertSpec>>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_DATABASE"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub command_type: Option<String>,

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -66,9 +66,12 @@ use typed_builder::TypedBuilder;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BaseSubscriptionUpdateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_SUBSCRIPTION"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -87,6 +90,7 @@ pub struct BaseSubscriptionUpdateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionUpdateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub subscription_id: Option<i32>,
@@ -106,6 +110,8 @@ pub struct SubscriptionUpdateRequest {
     #[builder(default, setter(strip_option, into))]
     pub payment_method: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_SUBSCRIPTION"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub command_type: Option<String>,
@@ -164,6 +170,7 @@ pub struct CrdbRegionSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
+    /// Optional. Local throughput settings for this region. See [`LocalThroughput`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub local_throughput_measurement: Option<LocalThroughput>,
 }
@@ -172,9 +179,12 @@ pub struct CrdbRegionSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionUpdateCMKRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_SUBSCRIPTION_CMK"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 
@@ -189,6 +199,7 @@ pub struct SubscriptionUpdateCMKRequest {
 /// `SubscriptionPricings`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubscriptionPricings {
+    /// Pricing breakdown entries for the subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pricing: Option<Vec<SubscriptionPricing>>,
 }
@@ -218,6 +229,7 @@ pub struct DatabaseModuleSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CidrAllowlistUpdateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
@@ -229,6 +241,8 @@ pub struct CidrAllowlistUpdateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub security_group_ids: Option<Vec<String>>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"UPDATE_SUBSCRIPTION_CIDR_ALLOWLIST"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -248,9 +262,11 @@ pub struct SubscriptionMaintenanceWindowsSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MaintenanceWindowSkipStatus {
+    /// Number of remaining maintenance-window skips available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remaining_skips: Option<i32>,
 
+    /// Timestamp marking the end of the currently skipped window, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_skip_end: Option<String>,
 }
@@ -259,6 +275,7 @@ pub struct MaintenanceWindowSkipStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActiveActiveSubscriptionRegions {
+    /// Subscription identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
@@ -275,27 +292,35 @@ pub struct SubscriptionPricing {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_name: Option<String>,
 
+    /// Pricing line type (e.g. `"Shards"`, `"EBSVolume"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
 
+    /// Additional details about the pricing line type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_details: Option<String>,
 
+    /// Quantity of the priced unit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<i32>,
 
+    /// Unit used to measure `quantity` (e.g. `"shards"`, `"GB"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity_measurement: Option<String>,
 
+    /// Price per unit in the configured currency.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price_per_unit: Option<f64>,
 
+    /// ISO currency code for `price_per_unit` (e.g. `"USD"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price_currency: Option<String>,
 
+    /// Billing period for the price (e.g. `"Month"`, `"Hour"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price_period: Option<String>,
 
+    /// Cloud region this pricing entry applies to.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
 }
@@ -395,6 +420,8 @@ pub struct SubscriptionCreateRequest {
     #[builder(default, setter(strip_option, into))]
     pub redis_version: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_SUBSCRIPTION"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub command_type: Option<String>,
@@ -404,21 +431,27 @@ pub struct SubscriptionCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CustomerManagedKeyAccessDetails {
+    /// Redis service account that requires CMK access (GCP).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_service_account: Option<String>,
 
+    /// GCP predefined roles the service account must be granted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub google_predefined_roles: Option<Vec<String>>,
 
+    /// GCP custom permissions required on the customer managed key.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub google_custom_permissions: Option<Vec<String>>,
 
+    /// AWS IAM role used by Redis to access the customer managed key.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_iam_role: Option<String>,
 
+    /// AWS KMS key-policy statements required for Redis to use the CMK.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required_key_policy_statements: Option<HashMap<String, Value>>,
 
+    /// Supported deletion grace period options for the CMK.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deletion_grace_period_options: Option<Vec<String>>,
 }
@@ -453,6 +486,7 @@ pub struct SubscriptionDatabaseSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replication: Option<bool>,
 
+    /// Optional. Throughput measurement spec. See [`DatabaseThroughputSpec`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub throughput_measurement: Option<DatabaseThroughputSpec>,
 
@@ -514,15 +548,19 @@ pub struct SubscriptionRegionNetworkingSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RedisVersion {
+    /// Redis version string (e.g. `"7.2"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 
+    /// End-of-life date for this Redis version.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eol_date: Option<String>,
 
+    /// Whether this Redis version is a preview/early-access release.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_preview: Option<bool>,
 
+    /// Whether this Redis version is the default for new databases.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_default: Option<bool>,
 }
@@ -531,12 +569,15 @@ pub struct RedisVersion {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MaintenanceWindow {
+    /// Days of the week the window is active (e.g. `["Monday", "Wednesday"]`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub days: Option<Vec<String>>,
 
+    /// Window start hour in 24-hour UTC time (0-23).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_hour: Option<i32>,
 
+    /// Window duration in hours.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration_in_hours: Option<i32>,
 }
@@ -726,6 +767,7 @@ pub struct AccountSubscriptions {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActiveActiveRegionCreateRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
@@ -756,6 +798,8 @@ pub struct ActiveActiveRegionCreateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub customer_managed_key_resource_name: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_ACTIVE_ACTIVE_REGION"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -764,6 +808,7 @@ pub struct ActiveActiveRegionCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RedisVersions {
+    /// List of Redis versions available for the account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_versions: Option<Vec<RedisVersion>>,
 }
@@ -772,6 +817,7 @@ pub struct RedisVersions {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActiveActiveRegionDeleteRequest {
+    /// Subscription ID being updated. Server-populated from the path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<i32>,
 
@@ -783,6 +829,8 @@ pub struct ActiveActiveRegionDeleteRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dry_run: Option<bool>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"DELETE_ACTIVE_ACTIVE_REGION"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 }
@@ -799,21 +847,28 @@ pub struct ActiveActiveRegionToDelete {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskStateUpdate {
+    /// Task identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
 
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_SUBSCRIPTION"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_type: Option<String>,
 
+    /// Current task status (e.g. `"processing-in-progress"`, `"processing-completed"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 
+    /// Human-readable description of the current task state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Timestamp of the latest task state update.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
 
+    /// Task response payload from the processor.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response: Option<ProcessorResponse>,
 
@@ -837,6 +892,7 @@ pub struct SubscriptionRegionSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferred_availability_zones: Option<Vec<String>>,
 
+    /// Optional. Per-region networking configuration. See [`SubscriptionRegionNetworkingSpec`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub networking: Option<SubscriptionRegionNetworkingSpec>,
 }
@@ -845,15 +901,19 @@ pub struct SubscriptionRegionSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionMaintenanceWindows {
+    /// Maintenance window mode (e.g. `"manual"`, `"automatic"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<String>,
 
+    /// Time zone used to interpret window times (e.g. `"UTC"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_zone: Option<String>,
 
+    /// Configured maintenance windows when `mode` is `"manual"`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub windows: Option<Vec<MaintenanceWindow>>,
 
+    /// Current skip status for upcoming maintenance windows. See [`MaintenanceWindowSkipStatus`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub skip_status: Option<MaintenanceWindowSkipStatus>,
 }


### PR DESCRIPTION
## Summary

Field-level rustdoc pass on the four largest model modules so the crate compiles cleanly under `RUSTDOCFLAGS="-D missing_docs"`:

- `src/fixed/databases.rs` (~70 fields)
- `src/fixed/subscriptions.rs` (~65 fields)
- `src/flexible/databases.rs` (~62 fields)
- `src/flexible/subscriptions.rs` (~52 fields)

Approximately 249 missing-docs errors across these four files reduced to 0. Uses the conventions established in #92 (types) and #94 (small modules):

- Short, factual one-liners (no paragraphs, no `# Errors` / `# Examples` sections on fields)
- `subscription_id` / `database_id` on request bodies documented as "Server-populated from the path"
- `command_type` documented as the read-only server-set operation discriminator
- Nested struct fields link to their type via intra-doc references (e.g. `See [`ReplicaOfSpec`].`)
- `links: Option<Vec<Link>>` left as the existing `HATEOAS links` convention

This PR is **docs-only**: no struct fields, types, serde renames, or wire shapes were modified.

Refs #80.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` passes (all tests green, including wiremock-based integration tests)
- [x] `RUSTDOCFLAGS="-D missing_docs" cargo doc --no-deps --workspace` reports 0 errors in the four target files (remaining 22 errors live in `users.rs`, covered by #95)