### PR TITLE
docs: enforce #![deny(missing_docs)] and rustdoc::broken_intra_doc_links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 // Allow doc strings with quoted values like 'true'/'false' from OpenAPI spec
 #![allow(clippy::doc_link_with_quotes)]
+// Every public item must carry a docstring. Closed the 368 existing
+// gaps under #80; this lint keeps the bar from regressing.
+#![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 //! Redis Cloud REST API Client
 //!


### PR DESCRIPTION
## Summary

All 368 missing-docs errors surfaced by the 2026-05 review are now closed across the cloud crate. This PR promotes the two lints to compile errors so the bar can't regress without a deliberate decision.

```rust
#![deny(missing_docs)]
#![deny(rustdoc::broken_intra_doc_links)]
```

## How we got to zero

| PR | Slice | Errors closed |
|---|---|---|
| #90 | lib.rs stale-examples cleanup | — |
| #91 | ConnectivityHandler delegation methods + fields | 18 |
| #92 | types.rs: module header, all variants and fields | 48 |
| #93 | Connectivity sub-module headers (psc / transit_gateway / vpc_peering) | — |
| #94 | Small modules: account, acl, cloud_accounts, 3 connectivity sub-files | 31 |
| #95 | users.rs field coverage | 21 |
| #96 | Big request/response models: fixed/* + flexible/* (delegated mechanical pass) | 249 |
| #97 (issue) | Follow-up filed on `DatabaseBackupConfig` field aliasing |  — |
| **This** | Enforce lints | — |

`cargo doc --no-deps -- -D missing_docs -D rustdoc::broken_intra_doc_links` builds clean.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo doc --no-deps` (now strict by default)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 72 doctests + the rest, all pass

Closes #80