### PR TITLE
fix(subscriptions): send body when deleting Active-Active regions

### DIFF
--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -1132,13 +1132,12 @@ impl SubscriptionHandler {
         subscription_id: i32,
         request: &ActiveActiveRegionDeleteRequest,
     ) -> Result<TaskStateUpdate> {
-        // TODO: DELETE with body not yet supported by client
-        let _ = request; // Suppress unused variable warning
-        let response = self
-            .client
-            .delete_raw(&format!("/subscriptions/{subscription_id}/regions"))
-            .await?;
-        serde_json::from_value(response).map_err(Into::into)
+        self.client
+            .delete_with_body(
+                &format!("/subscriptions/{subscription_id}/regions"),
+                serde_json::to_value(request)?,
+            )
+            .await
     }
 
     /// Get regions in an Active-Active subscription

--- a/tests/subscriptions_tests.rs
+++ b/tests/subscriptions_tests.rs
@@ -1,6 +1,6 @@
 use redis_cloud::{CloudClient, SubscriptionsHandler};
 use serde_json::json;
-use wiremock::matchers::{header, method, path, query_param};
+use wiremock::matchers::{body_json, header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
@@ -424,8 +424,57 @@ async fn test_get_subscription_pricing() {
     assert_eq!(pricing[0].r#type, Some("Shards".to_string()));
 }
 
-// Skipping test_delete_regions_from_active_active_subscription
-// as the client doesn't yet support DELETE with body
+#[tokio::test]
+async fn test_delete_regions_from_active_active_subscription() {
+    // Regression guard for #59: the AA region-delete handler must send
+    // its JSON body on the wire, not drop it on the floor.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/subscriptions/123/regions"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .and(body_json(json!({
+            "regions": [{"region": "us-east-1"}],
+            "dryRun": false,
+            "commandType": "DELETE_REGION"
+        })))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-delete-region",
+            "commandType": "DELETE_REGION",
+            "status": "processing"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = SubscriptionsHandler::new(client);
+    let request = redis_cloud::subscriptions::ActiveActiveRegionDeleteRequest {
+        subscription_id: None,
+        regions: Some(vec![
+            redis_cloud::subscriptions::ActiveActiveRegionToDelete {
+                region: Some("us-east-1".to_string()),
+            },
+        ]),
+        dry_run: Some(false),
+        command_type: Some("DELETE_REGION".to_string()),
+    };
+
+    let result = handler
+        .delete_regions_from_active_active_subscription(123, &request)
+        .await
+        .unwrap();
+
+    assert_eq!(result.task_id.as_deref(), Some("task-delete-region"));
+    assert_eq!(result.command_type.as_deref(), Some("DELETE_REGION"));
+    assert_eq!(result.status.as_deref(), Some("processing"));
+}
 
 #[tokio::test]
 async fn test_get_regions_from_active_active_subscription() {


### PR DESCRIPTION
## Summary

Replaces the previous body-dropping stub in `delete_regions_from_active_active_subscription` with a `delete_with_body` call, so the `ActiveActiveRegionDeleteRequest` payload actually reaches the cluster.

Before this change the handler had a `// TODO: DELETE with body not yet supported by client` comment, dropped the request body on the floor, and called `delete_raw` which sends an empty `DELETE`. The Redis Cloud API rejects that with a 400 — the only way to actually delete AA regions was to drop down to the raw client and re-serialize the body yourself.

Adds a `body_json`-asserting regression test that pins the wire contract: the request must serialize `regions`, `dryRun`, and `commandType` as the documented camelCase keys, and the handler must return the standard `TaskStateUpdate`.

## Supersedes #61

[#61](https://github.com/redis-developer/redis-cloud-rs/pull/61) was kept as a draft against a stale base and inadvertently regressed module-level docs that had since landed via [#95](https://github.com/redis-developer/redis-cloud-rs/pull/95) / [#96](https://github.com/redis-developer/redis-cloud-rs/pull/96). This branch carries only the surgical fix on top of current main — same regression-guard test, no doc churn.

Closes #59. Closes #61.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --test subscriptions_tests test_delete_regions` — passes
