### PR TITLE
docs: README + examples refresh for v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ A comprehensive Rust client library for the Redis Cloud REST API, with Python bi
 
 ```toml
 [dependencies]
-redis-cloud = "0.8"
+redis-cloud = "0.10"
 
 # Optional: Enable Tower service integration
-redis-cloud = { version = "0.8", features = ["tower-integration"] }
+redis-cloud = { version = "0.10", features = ["tower-integration"] }
 ```
 
 ## Quick Start
@@ -41,47 +41,38 @@ use redis_cloud::CloudClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Create client using builder pattern
     let client = CloudClient::builder()
-        .api_key("your-api-key")
-        .api_secret("your-api-secret")
+        .api_key(std::env::var("REDIS_CLOUD_API_KEY")?)
+        .api_secret(std::env::var("REDIS_CLOUD_API_SECRET")?)
         .build()?;
 
-    // Get account information using fluent API
+    // Account info
     let account = client.account().get_current_account().await?;
-    println!("Account: {:?}", account);
+    if let Some(acc) = account.account {
+        println!("Account: {:?} ({:?})", acc.name, acc.id);
+    }
 
-    // List all subscriptions
-    let subscriptions = client.subscriptions().get_all_subscriptions().await?;
-    println!("Subscriptions: {:?}", subscriptions);
+    // List Pro subscriptions
+    let subs = client.subscriptions().get_all_subscriptions().await?;
+    for sub in subs.subscriptions.unwrap_or_default() {
+        println!("  - subscription {:?}: {:?}", sub.id, sub.name);
+    }
 
-    // List databases in a subscription
-    let databases = client.databases().get_subscription_databases(123, None, None).await?;
-    println!("Databases: {:?}", databases);
-
-    Ok(())
-}
-```
-
-You can also use explicit handler creation if preferred:
-
-```rust
-use redis_cloud::{CloudClient, SubscriptionHandler};
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = CloudClient::builder()
-        .api_key("your-api-key")
-        .api_secret("your-api-secret")
-        .build()?;
-
-    // Explicit handler creation
-    let handler = SubscriptionHandler::new(client.clone());
-    let subscriptions = handler.get_all_subscriptions().await?;
+    // List databases for a subscription (unwrapped helper)
+    let dbs = client.databases().list(123).await?;
+    for db in &dbs {
+        println!("  - db {:?}: {:?}", db.database_id, db.name);
+    }
 
     Ok(())
 }
 ```
+
+## Environment Variables
+
+- `REDIS_CLOUD_API_KEY` — API key
+- `REDIS_CLOUD_API_SECRET` — API secret
+- `REDIS_CLOUD_BASE_URL` — Override the API base URL (optional; defaults to the production Redis Cloud endpoint)
 
 ## Tower Integration
 
@@ -116,81 +107,43 @@ This enables composition with Tower middleware like circuit breakers, retry, rat
 
 ## Examples
 
-See the `examples/` directory for runnable examples:
+See the [`examples/`](examples) directory for runnable end-to-end programs:
 
 ```bash
-# Basic usage - connect and list subscriptions
-REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example basic
+# Basic — connect, fetch account, list Pro + Essentials subscriptions
+cargo run --example basic
 
-# Database operations
-REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example databases
+# Database operations — list databases for a subscription, paginated
+cargo run --example databases [SUBSCRIPTION_ID]
 
-# Streaming with pagination
-REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy cargo run --example stream_databases -- SUBSCRIPTION_ID
+# Streaming — process databases one at a time via the paginated stream
+cargo run --example stream_databases -- SUBSCRIPTION_ID
+
+# Tasks — poll an async task by ID
+cargo run --example tasks -- TASK_ID
+
+# Cost reports — fetch a cost report in FOCUS-format JSON
+cargo run --example cost_report -- START_DATE END_DATE
 ```
+
+All examples read credentials from `REDIS_CLOUD_API_KEY` / `REDIS_CLOUD_API_SECRET`.
 
 ## Python Bindings
 
-This library also provides Python bindings via PyO3:
+A thin PyO3 binding covering a subset of read operations is published at
+[redis-cloud on PyPI](https://pypi.org/project/redis-cloud/). See
+[`python/README.md`](python/README.md) for the supported API.
 
-```bash
-pip install redis-cloud
-```
-
-```python
-from redis_cloud import CloudClient
-
-# Create client
-client = CloudClient(
-    api_key="your-api-key",
-    api_secret="your-api-secret"
-)
-
-# Or from environment variables
-client = CloudClient.from_env()
-
-# Async usage
-async def main():
-    subs = await client.subscriptions()
-    for sub in subs:
-        print(sub["name"], sub["id"])
-
-# Sync usage
-subs = client.subscriptions_sync()
-```
-
-### Python API
-
-- `CloudClient(api_key, api_secret, base_url=None, timeout_secs=None)`
-- `CloudClient.from_env()` - Create from environment variables
-- `client.timeout` - Get configured timeout in seconds (property)
-
-#### Account
-- `account()` / `account_sync()` - Get current account information
-
-#### Subscriptions
-- `subscriptions()` / `subscriptions_sync()` - List all subscriptions
-- `subscription(id)` / `subscription_sync(id)` - Get subscription by ID
-
-#### Databases
-- `databases(subscription_id, offset=None, limit=None)` / `databases_sync(...)` - List databases (paginated)
-- `database(subscription_id, database_id)` / `database_sync(...)` - Get database
-- `all_databases(subscription_id)` / `all_databases_sync(...)` - Get all databases (auto-pagination)
-
-#### Raw API
-- `get(path)` / `get_sync(path)` - Raw GET request
-- `post(path, body)` / `post_sync(path, body)` - Raw POST request
-- `delete(path)` / `delete_sync(path)` - Raw DELETE request
-
-### Environment Variables
-
-- `REDIS_CLOUD_API_KEY` - API key
-- `REDIS_CLOUD_API_SECRET` - API secret
-- `REDIS_CLOUD_BASE_URL` - Base URL (optional)
+The PyPI publish workflow has been failing since the `reqwest 0.13` upgrade
+([#48](https://github.com/redis-developer/redis-cloud-rs/issues/48)) and the
+overall scope is still being scoped under
+[#66](https://github.com/redis-developer/redis-cloud-rs/issues/66) — treat
+the Python surface as experimental for now.
 
 ## API Coverage
 
-This library provides comprehensive coverage of the Redis Cloud REST API:
+The crate aims for comprehensive coverage of the documented Redis Cloud REST
+API surface. Handler organization:
 
 | Handler | Description |
 |---------|-------------|
@@ -208,6 +161,9 @@ This library provides comprehensive coverage of the Redis Cloud REST API:
 | `private_link()` | AWS PrivateLink |
 | `tasks()` | Async operation tracking |
 | `cost_reports()` | Cost reports in FOCUS format |
+
+For the authoritative per-endpoint mapping see the bundled OpenAPI spec at
+[`tests/fixtures/cloud_openapi.json`](tests/fixtures/cloud_openapi.json).
 
 ## Documentation
 

--- a/examples/cost_report.rs
+++ b/examples/cost_report.rs
@@ -1,0 +1,96 @@
+//! Generate and download a Redis Cloud cost report in FOCUS format.
+//!
+//! The cost-report endpoints are a two-step async flow:
+//!
+//! 1. `POST /cost-report` kicks off generation and returns a `taskId`.
+//! 2. Poll `tasks().get_task_by_id(...)` until the task completes; the
+//!    response payload carries the `costReportId`.
+//! 3. `GET /cost-report/{costReportId}` returns the report file.
+//!
+//! This example wires those steps together.
+//!
+//! Run with:
+//! ```bash
+//! REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy \
+//!   cargo run --example cost_report -- 2026-04-01 2026-04-30
+//! ```
+//!
+//! The maximum date range supported by the live API is 40 days.
+
+use redis_cloud::CloudClient;
+use redis_cloud::cost_report::CostReportCreateRequest;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let start = args
+        .next()
+        .ok_or("usage: cost_report START_DATE END_DATE (dates in YYYY-MM-DD)")?;
+    let end = args
+        .next()
+        .ok_or("usage: cost_report START_DATE END_DATE (dates in YYYY-MM-DD)")?;
+
+    let api_key = std::env::var("REDIS_CLOUD_API_KEY")?;
+    let api_secret = std::env::var("REDIS_CLOUD_API_SECRET")?;
+
+    let client = CloudClient::builder()
+        .api_key(api_key)
+        .api_secret(api_secret)
+        .build()?;
+
+    // Step 1 — kick off generation.
+    let request = CostReportCreateRequest::new(&start, &end);
+    let task = client.cost_reports().generate_cost_report(request).await?;
+    let task_id = task
+        .task_id
+        .clone()
+        .ok_or("server did not return a task_id")?;
+    println!("kicked off cost-report generation: task {task_id}");
+
+    // Step 2 — poll the task until it reaches a terminal state.
+    println!("polling task...");
+    let report_id = loop {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        let state = client.tasks().get_task_by_id(task_id.clone()).await?;
+        println!("  status={:?} progress={:?}", state.status, state.progress);
+        match state.status.as_deref() {
+            Some("completed") => {
+                // ProcessorResponse shape varies; raw JSON is the safest read.
+                let raw = serde_json::to_value(&state.response)?;
+                break raw
+                    .get("resourceId")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+                    .or_else(|| {
+                        raw.get("costReportId")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string)
+                    })
+                    .ok_or("task completed but did not return a costReportId")?;
+            }
+            Some("failed") | Some("error") => {
+                return Err(format!(
+                    "task ended with status {:?}: {}",
+                    state.status,
+                    serde_json::to_string(&state.response)?
+                )
+                .into());
+            }
+            _ => {}
+        }
+    };
+
+    // Step 3 — download the report bytes.
+    println!("downloading report {report_id}");
+    let bytes = client
+        .cost_reports()
+        .download_cost_report(&report_id)
+        .await?;
+
+    let out_path = format!("cost-report-{report_id}.json");
+    std::fs::write(&out_path, &bytes)?;
+    println!("wrote {} bytes to {out_path}", bytes.len());
+
+    Ok(())
+}

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -1,0 +1,64 @@
+//! Poll a Redis Cloud async task by ID and print its state.
+//!
+//! Most write operations (create subscription, create database, delete
+//! database, ...) return a `taskId`. Use this example to look the task up
+//! later and watch its state transition through `processing` → `completed`
+//! / `failed`.
+//!
+//! Run with:
+//! ```bash
+//! REDIS_CLOUD_API_KEY=xxx REDIS_CLOUD_API_SECRET=yyy \
+//!   cargo run --example tasks -- TASK_ID
+//! ```
+//!
+//! Pass `--watch` after the task id to poll every 5 seconds until the task
+//! reaches a terminal state.
+
+use redis_cloud::{CloudClient, CloudError};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let task_id = args.next().ok_or("usage: tasks TASK_ID [--watch]")?;
+    let watch = args.next().as_deref() == Some("--watch");
+
+    let api_key = std::env::var("REDIS_CLOUD_API_KEY")?;
+    let api_secret = std::env::var("REDIS_CLOUD_API_SECRET")?;
+
+    let client = CloudClient::builder()
+        .api_key(api_key)
+        .api_secret(api_secret)
+        .build()?;
+
+    loop {
+        match client.tasks().get_task_by_id(task_id.clone()).await {
+            Ok(task) => {
+                println!(
+                    "task {}: status={:?} command={:?} progress={:?}",
+                    task.task_id.as_deref().unwrap_or(&task_id),
+                    task.status,
+                    task.command_type,
+                    task.progress,
+                );
+                if let Some(desc) = task.description.as_deref() {
+                    println!("  {desc}");
+                }
+                let terminal = matches!(
+                    task.status.as_deref(),
+                    Some("completed") | Some("failed") | Some("error")
+                );
+                if !watch || terminal {
+                    break;
+                }
+            }
+            Err(CloudError::NotFound { .. }) => {
+                eprintln!("task {task_id} not found");
+                std::process::exit(1);
+            }
+            Err(e) => return Err(e.into()),
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,19 +23,17 @@
 //! ## Quick Start
 //!
 //! ```rust,no_run
-//! use redis_cloud::{CloudClient, DatabaseHandler};
+//! use redis_cloud::CloudClient;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     // Create client with API credentials
 //!     let client = CloudClient::builder()
-//!         .api_key("your-api-key")
-//!         .api_secret("your-api-secret")
+//!         .api_key(std::env::var("REDIS_CLOUD_API_KEY")?)
+//!         .api_secret(std::env::var("REDIS_CLOUD_API_SECRET")?)
 //!         .build()?;
 //!
 //!     // List all databases in subscription 123 (Vec<Database>, no wrapper)
-//!     let db_handler = DatabaseHandler::new(client.clone());
-//!     let databases = db_handler.list(123).await?;
+//!     let databases = client.databases().list(123).await?;
 //!     println!("Found {} databases", databases.len());
 //!
 //!     Ok(())


### PR DESCRIPTION
## Summary

Pre-release sweep mirroring the enterprise v0.9.0 doc refresh — aligns the user-facing surface with what the crate actually exposes after the audit + Tier-1 fixes, so v0.10.0 ships with accurate docs and examples that demonstrate the new functionality.

### README

- Bump installation snippet from `0.8` to `0.10` (the only stale version reference in the repo).
- **Quick Start** now reads credentials from env vars and demonstrates the fluent `client.databases().list(subscription_id)` helper that returns `Vec<Database>` directly.
- New top-level **Environment Variables** section (was buried under the Python subtree).
- **Trim the Python section** — the verbose API list was misleading (`CloudClient.from_env()` exists only on the Python wrapper, not the Rust client, so it was the sole reference). Point at `python/README.md` with a clear "treat as experimental" note instead, flagging the broken PyPI publish (#48) and the parity work (#66).
- Soften the coverage language and link to `tests/fixtures/cloud_openapi.json` as the authoritative per-endpoint inventory.
- Examples section now lists all five runnable examples with one-line descriptions.

### `src/lib.rs`

- Quick Start example switched from `DatabaseHandler::new(client.clone()).list(123)` to the fluent `client.databases().list(123)`, and reads credentials from env vars to match the README.

### New examples

| File | Purpose |
|---|---|
| `examples/tasks.rs` | Poll an async task by ID, optionally `--watch` to repeat every 5s until terminal. Demonstrates the `TaskStateUpdate` wrapper fix from [#85](https://github.com/redis-developer/redis-cloud-rs/pull/85). |
| `examples/cost_report.rs` | End-to-end generate → poll → download flow. Exercises the cost-report surface from [#88](https://github.com/redis-developer/redis-cloud-rs/pull/88) and validates the documented two-step async pattern. |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 72 doctests + all integration suites pass
- [x] `cargo build --examples` — `basic`, `databases`, `stream_databases`, `tasks`, `cost_report` all compile
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean

Closes #60.