### PR TITLE
chore(spec): refresh bundled cloud_openapi.json from upstream

### DIFF
--- a/tests/fixtures/cloud_openapi.json
+++ b/tests/fixtures/cloud_openapi.json
@@ -22,7 +22,8 @@
   "security": [
     {
       "x-api-key": [],
-      "x-api-secret-key": []
+      "x-api-secret-key": [],
+      "x-auth-token": []
     }
   ],
   "tags": [
@@ -99,11 +100,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -165,11 +166,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -227,11 +228,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -291,11 +292,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -357,11 +358,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -419,11 +420,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -503,11 +504,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -575,11 +576,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -650,11 +651,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -724,11 +725,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -798,11 +799,85 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
           "412": {
             "description": "Precondition Failed - Feature flag for this flow is off"
           },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with new updated name)"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resource-tags": {
+      "put": {
+        "tags": [
+          "Subscriptions - Pro"
+        ],
+        "summary": "Update Pro subscription resource tags",
+        "description": "Updates the resource tags for the specified Pro subscription. This replaces all existing tags with the provided tags.",
+        "operationId": "updateSubscriptionResourceTags",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscriptionResourceTagsUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -893,11 +968,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -976,11 +1051,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -1062,11 +1137,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -1147,11 +1222,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -1251,11 +1326,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -1343,11 +1418,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -1433,11 +1508,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -1505,11 +1580,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -1599,11 +1674,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -1681,11 +1756,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -1771,11 +1846,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -1843,11 +1918,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -1907,11 +1982,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -1973,11 +2048,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2049,11 +2124,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2142,11 +2217,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2214,11 +2289,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2288,11 +2363,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2364,11 +2439,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2446,11 +2521,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2542,11 +2617,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2624,11 +2699,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2728,11 +2803,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2812,11 +2887,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -2861,7 +2936,7 @@
           "Subscriptions - Pro"
         ],
         "summary": "Get Pro subscription CIDR whitelist",
-        "description": "(Self-hosted AWS subscriptions only) Gets a Pro subscription's CIDR whitelist.",
+        "description": "(Bring your own Cloud only) Gets a Pro subscription's CIDR whitelist. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getCidrWhiteList",
         "parameters": [
           {
@@ -2876,11 +2951,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -2917,7 +2992,7 @@
           "Subscriptions - Pro"
         ],
         "summary": "Update Pro subscription CIDR whitelist",
-        "description": "(Self-hosted AWS subscriptions only) Updates a Pro subscription's CIDR whitelist.",
+        "description": "(Bring your own Cloud only) Updates a Pro subscription's CIDR whitelist.",
         "operationId": "updateSubscriptionCidrWhiteList",
         "parameters": [
           {
@@ -2942,11 +3017,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -3027,11 +3102,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -3091,11 +3166,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3156,11 +3231,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -3218,11 +3293,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3294,11 +3369,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3383,11 +3458,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3455,11 +3530,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3529,11 +3604,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3605,11 +3680,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3687,11 +3762,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3783,11 +3858,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3865,11 +3940,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3930,11 +4005,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -3997,11 +4072,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -4060,11 +4135,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -4125,11 +4200,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -4191,11 +4266,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -4253,11 +4328,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -4327,11 +4402,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -4389,11 +4464,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -4463,11 +4538,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -4525,11 +4600,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -4577,11 +4652,11 @@
         "description": "Gets a list of all Pro subscriptions in the current account.",
         "operationId": "getAllSubscriptions",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -4632,6 +4707,7 @@
                 "deploymentType": "single-region",
                 "paymentMethod": "credit-card",
                 "paymentMethodId": 12345,
+                "publicEndpointAccess": true,
                 "memoryStorage": "ram",
                 "cloudProviders": [
                   {
@@ -4673,11 +4749,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -4740,11 +4816,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -4806,11 +4882,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -4878,11 +4954,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -4927,7 +5003,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get Private Service Connect for a single region",
-        "description": "(Active-Active subscriptions only) Gets Private Service Connect details for a single region in an Active-Active subscription.",
+        "description": "(Active-Active subscriptions only) Gets Private Service Connect details for a single region in an Active-Active subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getActiveActivePscService",
         "parameters": [
           {
@@ -4952,11 +5028,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5018,11 +5094,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5093,11 +5169,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5142,7 +5218,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get Private Service Connect endpoints for a single region",
-        "description": "(Active-Active subscriptions only) Gets endpoint details for the specified Private Service Connect in a single region in an Active-Active subscription.",
+        "description": "(Active-Active subscriptions only) Gets endpoint details for the specified Private Service Connect in a single region in an Active-Active subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getActiveActivePscServiceEndpoints",
         "parameters": [
           {
@@ -5177,11 +5253,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5263,11 +5339,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5309,13 +5385,497 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/regions/{regionId}/private-link": {
+      "get": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Get Private Link configuration for a specific region",
+        "description": "(Active-Active subscriptions only) Gets the Private Link configuration for a specific region. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
+        "operationId": "getActiveActivePrivateLink",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "regionId",
+            "in": "path",
+            "description": "Region ID - required for Active-Active subscription",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Create a Private Link for a specific region",
+        "description": "(Active-Active subscriptions only) Creates a new Private Link for a specific region.",
+        "operationId": "createActiveActivePrivateLink",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "regionId",
+            "in": "path",
+            "description": "Region ID - required for Active-Active subscription",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateLinkActiveActiveCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to create requested resource (primarily due to not active resource)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with the new name"
+          },
+          "422": {
+            "description": "Unprocessable Entity - The server understands the request, and the syntax of the request is correct, but it was unable to process the contained instructions"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Delete Private Link for a specific region",
+        "description": "(Active-Active subscriptions only) Deletes the Private Link configuration for a specific region.",
+        "operationId": "deleteActiveActivePrivateLink",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "regionId",
+            "in": "path",
+            "description": "Region ID - required for Active-Active subscription",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with new updated name)"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/regions/{regionId}/private-link/principals": {
+      "post": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Add principal to Private Link for a specific region",
+        "description": "(Active-Active subscriptions only) Adds a principal (AWS ARN) to the Private Link configuration for a specific region.",
+        "operationId": "createActiveActivePrivateLinkPrincipal",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "regionId",
+            "in": "path",
+            "description": "Region ID - required for Active-Active subscription",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateLinkActiveActivePrincipalsCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to create requested resource (primarily due to not active resource)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with the new name"
+          },
+          "422": {
+            "description": "Unprocessable Entity - The server understands the request, and the syntax of the request is correct, but it was unable to process the contained instructions"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Remove a principal from Private Link for a specific region",
+        "description": "(Active-Active subscriptions only) Removes one principal (AWS ARNs) from the Private Link configuration for a specific region.",
+        "operationId": "deleteActiveActivePrivateLinkPrincipals",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "regionId",
+            "in": "path",
+            "description": "Region ID - required for Active-Active subscription",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateLinkActiveActivePrincipalsDeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with new updated name)"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/regions/{regionId}/private-link/connections/disassociate": {
+      "post": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Disassociate connections from Private Link for a specific region",
+        "description": "(Active-Active subscriptions only) Disassociates one or more VPC endpoint connections from the Private Link configuration for a specific region.",
+        "operationId": "disassociateActiveActivePrivateLinkConnections",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "regionId",
+            "in": "path",
+            "description": "Region ID - required for Active-Active subscription",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateLinkActiveActiveConnectionsDisassociateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with new updated name)"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/regions/peerings": {
       "get": {
         "tags": [
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get Active-Active VPC peering details",
-        "description": "(Active-Active subscriptions only) Gets VPC peering details for an Active-Active subscription.",
+        "description": "(Active-Active subscriptions only) Gets VPC peering details for an Active-Active subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getActiveActiveVpcPeerings",
         "parameters": [
           {
@@ -5330,11 +5890,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -5406,11 +5966,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -5458,7 +6018,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get Private Service Connect",
-        "description": "Gets Private Service Connect details for a subscription.",
+        "description": "Gets Private Service Connect details for a subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getPscService",
         "parameters": [
           {
@@ -5473,11 +6033,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5529,11 +6089,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5594,11 +6154,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5643,7 +6203,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get Private Service Connect endpoints",
-        "description": "Gets endpoint details for the specified Private Service Connect.",
+        "description": "Gets endpoint details for the specified Private Service Connect. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getPscServiceEndpoints",
         "parameters": [
           {
@@ -5668,11 +6228,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5744,11 +6304,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5790,13 +6350,431 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/private-link": {
+      "get": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Get Private Link configuration",
+        "description": "Gets the Private Link configuration for a subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
+        "operationId": "getPrivateLink",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Create a Private Link",
+        "description": "Creates a new Private Link.",
+        "operationId": "createPrivateLink",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateLinkCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to create requested resource (primarily due to not active resource)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with the new name"
+          },
+          "422": {
+            "description": "Unprocessable Entity - The server understands the request, and the syntax of the request is correct, but it was unable to process the contained instructions"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Delete Private Link",
+        "description": "Deletes the Private Link configuration for a subscription.",
+        "operationId": "deletePrivateLink",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with new updated name)"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/private-link/principals": {
+      "post": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Add principal to Private Link",
+        "description": "Adds a principal (AWS ARN) to the Private Link configuration.",
+        "operationId": "createPrivateLinkPrincipal",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateLinkPrincipalsCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to create requested resource (primarily due to not active resource)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with the new name"
+          },
+          "422": {
+            "description": "Unprocessable Entity - The server understands the request, and the syntax of the request is correct, but it was unable to process the contained instructions"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Remove a principal from Private Link",
+        "description": "Removes a principal (AWS ARNs) from the Private Link configuration.",
+        "operationId": "deletePrivateLinkPrincipals",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateLinkPrincipalsDeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with new updated name)"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/private-link/connections/disassociate": {
+      "post": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Disassociate connections from Private Link",
+        "description": "Disassociates one or more VPC endpoint connections from the Private Link configuration.",
+        "operationId": "disassociatePrivateLinkConnections",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateLinkConnectionsDisassociateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with new updated name)"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/peerings": {
       "get": {
         "tags": [
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get VPC peering details",
-        "description": "Gets VPC peering details for the specified subscription.",
+        "description": "Gets VPC peering details for the specified subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getVpcPeering",
         "parameters": [
           {
@@ -5811,11 +6789,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5888,11 +6866,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -5978,11 +6956,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6062,11 +7040,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -6139,11 +7117,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6215,11 +7193,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6230,6 +7208,75 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with new updated name)"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/databases/{databaseId}/traffic/resume": {
+      "post": {
+        "tags": [
+          "Databases - Pro"
+        ],
+        "summary": "Resume Pro database traffic",
+        "description": "Resumes traffic for the specified Pro database.",
+        "operationId": "resumeBdbTraffic",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "databaseId",
+            "in": "path",
+            "description": "Database ID.",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "204": {
+            "description": "Traffic resumed"
           },
           "401": {
             "description": "Unauthorized - Authentication failed for requested resource"
@@ -6289,11 +7336,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6365,11 +7412,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6448,11 +7495,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6523,11 +7570,11 @@
           }
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6575,11 +7622,11 @@
         "description": "Gets a list of all Essentials subscriptions in the current account.",
         "operationId": "getAllSubscriptions_1",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6629,11 +7676,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -6719,11 +7766,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6798,11 +7845,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6831,6 +7878,225 @@
           },
           "422": {
             "description": "Unprocessable Entity - The server understands the request, and the syntax of the request is correct, but it was unable to process the contained instructions"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/fixed/subscriptions/{subscriptionId}/databases/{databaseId}/upgrade": {
+      "get": {
+        "tags": [
+          "Databases - Essentials"
+        ],
+        "summary": "Get Essentials database version upgrade status",
+        "description": "Gets information on the latest upgrade attempt for this Essentials database.",
+        "operationId": "getEssentialsDatabaseRedisVersionUpgradeStatus",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "databaseId",
+            "in": "path",
+            "description": "Database ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BdbVersionUpgradeStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Databases - Essentials"
+        ],
+        "summary": "Upgrade Essentials database version",
+        "description": "Upgrades the specified Essentials database to a later Redis version.",
+        "operationId": "upgradeEssentialsDatabaseRedisVersion",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "databaseId",
+            "in": "path",
+            "description": "Database ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FixedDatabaseUpgradeRedisVersionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with new updated name)"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/fixed/subscriptions/{subscriptionId}/databases/{databaseId}/traffic/resume": {
+      "post": {
+        "tags": [
+          "Databases - Essentials"
+        ],
+        "summary": "Resume Essentials database traffic",
+        "description": "Resumes traffic for the specified Essentials database.",
+        "operationId": "resumeBdbTraffic_1",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "databaseId",
+            "in": "path",
+            "description": "Database ID.",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "204": {
+            "description": "Traffic resumed"
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with new updated name)"
           },
           "429": {
             "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
@@ -6875,11 +8141,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -6951,11 +8217,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7025,11 +8291,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7100,11 +8366,11 @@
           }
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7143,6 +8409,71 @@
         }
       }
     },
+    "/cost-report": {
+      "post": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Generate cost report",
+        "description": "Generates a cost report in FOCUS format for the specified time period (max 40 days range) and filters. [Read more about focus here](https://focus.finops.org/).\n",
+        "operationId": "createCostReport",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CostReportCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to create requested resource (primarily due to not active resource)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "408": {
+            "description": "Request Timeout - The server didn't receive a complete request message within the server's allotted timeout period"
+          },
+          "409": {
+            "description": "Conflict - request could not be processed because of a conflict (primarily due to another resource that exist with the new name"
+          },
+          "422": {
+            "description": "Unprocessable Entity - The server understands the request, and the syntax of the request is correct, but it was unable to process the contained instructions"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
     "/cloud-accounts": {
       "get": {
         "tags": [
@@ -7152,11 +8483,11 @@
         "description": "Gets a list of all configured cloud accounts.",
         "operationId": "getCloudAccounts",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7206,11 +8537,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -7261,11 +8592,11 @@
         "description": "Gets a list of all access control users for this account.",
         "operationId": "getAllUsers_1",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7315,11 +8646,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -7370,11 +8701,11 @@
         "description": "Gets a list of all database access roles for this account.",
         "operationId": "getRoles",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7424,11 +8755,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -7479,11 +8810,11 @@
         "description": "Gets a list of all Redis ACL rules for this account.",
         "operationId": "getAllRedisRules",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7533,11 +8864,11 @@
           "required": true
         },
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -7588,11 +8919,11 @@
         "description": "Gets a list of all account users.",
         "operationId": "getAllUsers",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7634,11 +8965,11 @@
         "description": "Gets a list of all currently running tasks for this account.",
         "operationId": "getAllTasks",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7691,11 +9022,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7734,7 +9065,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get transit gateways for a subscription",
-        "description": "Gets all AWS transit gateway details for the specified subscription.",
+        "description": "Gets all AWS transit gateway details for the specified subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getTgws",
         "parameters": [
           {
@@ -7749,11 +9080,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7792,7 +9123,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get transit gateway invitations for a subscription",
-        "description": "Gets all AWS transit gateway invitations for the specified subscription.",
+        "description": "Gets all AWS transit gateway invitations for the specified subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getTgwSharedInvitations",
         "parameters": [
           {
@@ -7807,11 +9138,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7850,7 +9181,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get transit gateways for a single region",
-        "description": "(Active-Active subscriptions only) Gets all AWS transit gateway details for the specified region in an Active-Active subscription.",
+        "description": "(Active-Active subscriptions only) Gets all AWS transit gateway details for the specified region in an Active-Active subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getActiveActiveTgws",
         "parameters": [
           {
@@ -7876,11 +9207,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7919,7 +9250,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get transit gateway invitations for a single region",
-        "description": "(Active-Active subscriptions only) Gets AWS transit gateway invitations for the specified region in an Active-Active subscription.",
+        "description": "(Active-Active subscriptions only) Gets AWS transit gateway invitations for the specified region in an Active-Active subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getActiveActiveTgwSharedInvitations",
         "parameters": [
           {
@@ -7945,11 +9276,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -7988,7 +9319,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get Private Service Connect endpoint deletion script for a single region",
-        "description": "(Active-Active subscriptions only) Gets the gcloud script to delete the specified Private Service Connect endpoint on Google Cloud.",
+        "description": "(Active-Active subscriptions only) Gets the gcloud script to delete the specified Private Service Connect endpoint on Google Cloud. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getActiveActivPscServiceEndpointDeletionScript",
         "parameters": [
           {
@@ -8033,11 +9364,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -8076,7 +9407,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get Private Service Connect endpoint creation script for a single region",
-        "description": "(Active-Active subscriptions only) Gets the gcloud script to create the specified Private Service Connect endpoint on Google Cloud.",
+        "description": "(Active-Active subscriptions only) Gets the gcloud script to create the specified Private Service Connect endpoint on Google Cloud. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getActiveActivPscServiceEndpointCreationScript",
         "parameters": [
           {
@@ -8121,11 +9452,79 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
           "412": {
             "description": "Precondition Failed - Feature flag for this flow is off"
           },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/regions/{regionId}/private-link/endpoint-script": {
+      "get": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Get Private Link endpoint script for a single region",
+        "description": "(Active-Active subscriptions only) Gets the Private Link endpoint script for a single region in an Active-Active subscription. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
+        "operationId": "getActiveActivePrivateLinkEndpointScript",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "regionId",
+            "in": "path",
+            "description": "Region ID - required for Active-Active subscription",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -8164,7 +9563,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get Private Service Connect endpoint deletion script",
-        "description": "Gets the gcloud script to delete the specified Private Service Connect endpoint on Google Cloud.",
+        "description": "Gets the gcloud script to delete the specified Private Service Connect endpoint on Google Cloud. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getPscServiceEndpointDeletionScript",
         "parameters": [
           {
@@ -8199,11 +9598,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -8242,7 +9641,7 @@
           "Subscriptions - Pro - Connectivity"
         ],
         "summary": "Get Private Service Connect endpoint creation script",
-        "description": "Gets the gcloud script to create the specified Private Service Connect endpoint on Google Cloud.",
+        "description": "Gets the gcloud script to create the specified Private Service Connect endpoint on Google Cloud. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
         "operationId": "getPscServiceEndpointCreationScript",
         "parameters": [
           {
@@ -8277,11 +9676,69 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
           "412": {
             "description": "Precondition Failed - Feature flag for this flow is off"
           },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateUpdate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/private-link/endpoint-script": {
+      "get": {
+        "tags": [
+          "Subscriptions - Pro - Connectivity"
+        ],
+        "summary": "Get Private Link endpoint script",
+        "description": "Gets the Python discovery script for Private Link. Internal users can optionally request a Terraform snippet. [Asynchronous operation](https://redis.io/docs/latest/operate/rc/api/get-started/process-lifecycle/) - Query [GET /tasks/{taskId}](#tag/Tasks/operation/getTaskById) with the returned taskId.",
+        "operationId": "getPrivateLinkEndpointScript",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "202": {
             "description": "Accepted",
@@ -8335,11 +9792,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -8347,6 +9804,76 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SubscriptionPricings"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/databases/{databaseId}/traffic": {
+      "get": {
+        "tags": [
+          "Databases - Pro"
+        ],
+        "summary": "Get Pro database traffic",
+        "description": "Gets traffic information for the specified Pro database. If the database was not a source in a redirect endpoints operation, a not found error will be returned.",
+        "operationId": "getDatabaseTraffic",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "databaseId",
+            "in": "path",
+            "description": "Database ID.",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseTrafficStateResponse"
                 }
               }
             }
@@ -8412,11 +9939,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -8482,11 +10009,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -8494,6 +10021,74 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatabaseCertificate"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/databases/{databaseId}/available-target-versions": {
+      "get": {
+        "tags": [
+          "Databases - Pro"
+        ],
+        "summary": "Get available upgrade versions for Pro database",
+        "description": "Gets a list of available Redis versions that the specified Pro database can be upgraded to.",
+        "operationId": "getDatabaseAvailableVersions",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "databaseId",
+            "in": "path",
+            "description": "Database ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BdbAvailableVersionsResponse"
                 }
               }
             }
@@ -8540,11 +10135,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -8609,14 +10204,34 @@
               "format": "int32"
             },
             "example": 100
+          },
+          {
+            "name": "startTime",
+            "in": "query",
+            "description": "Filter session logs with time >= startTime (UTC)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2025-01-01T00:00:00Z"
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "description": "Filter session logs with time <= endTime (UTC)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2025-01-31T23:59:59Z"
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -8655,7 +10270,7 @@
           "Account"
         ],
         "summary": "Get available Pro plan regions",
-        "description": "Gets a list of available regions for Pro subscriptions. For Essentials subscriptions, use 'GET /fixed/plans'.",
+        "description": "Gets a list of available regions for Pro subscriptions. For Essentials subscriptions, use [GET /fixed/plans](#tag/Subscriptions-Essentials/operation/getAllFixedSubscriptionsPlans).",
         "operationId": "getSupportedRegions",
         "parameters": [
           {
@@ -8673,11 +10288,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -8719,11 +10334,11 @@
         "description": "Gets a list of available [query performance factors](https://redis.io/docs/latest/operate/rc/databases/configuration/advanced-capabilities/#query-performance-factor).",
         "operationId": "getSupportedSearchScalingFactors",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -8765,11 +10380,11 @@
         "description": "Gets a list of all payment methods for this account.",
         "operationId": "getAccountPaymentMethods",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -8834,14 +10449,45 @@
               "format": "int32"
             },
             "example": 100
+          },
+          {
+            "name": "startTime",
+            "in": "query",
+            "description": "Filter logs with time >= startTime (UTC)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2025-01-01T00:00:00Z"
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "description": "Filter logs with time <= endTime (UTC)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2025-01-31T23:59:59Z"
+          },
+          {
+            "name": "resourceId",
+            "in": "query",
+            "description": "Filter logs by resourceId",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "example": 1234
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -8849,6 +10495,76 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AccountSystemLogEntries"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/fixed/subscriptions/{subscriptionId}/databases/{databaseId}/traffic": {
+      "get": {
+        "tags": [
+          "Databases - Essentials"
+        ],
+        "summary": "Get Essentials database traffic",
+        "description": "Gets traffic information for the specified Essentials database. If the database was not a source in a redirect endpoints operation, a not found error will be returned.",
+        "operationId": "getDatabaseTraffic_1",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "databaseId",
+            "in": "path",
+            "description": "Database ID.",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseTrafficStateResponse"
                 }
               }
             }
@@ -8905,11 +10621,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -8917,6 +10633,74 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatabaseSlowLogEntries"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
+    "/fixed/subscriptions/{subscriptionId}/databases/{databaseId}/available-target-versions": {
+      "get": {
+        "tags": [
+          "Databases - Essentials"
+        ],
+        "summary": "Get available upgrade versions for Essentials database",
+        "description": "Gets a list of available Redis versions that the specified Essentials database can be upgraded to.",
+        "operationId": "getEssentialsDatabaseAvailableVersions",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "databaseId",
+            "in": "path",
+            "description": "Database ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BdbAvailableVersionsResponse"
                 }
               }
             }
@@ -8963,11 +10747,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -9034,11 +10818,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -9092,11 +10876,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -9150,11 +10934,11 @@
           }
         ],
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -9193,14 +10977,14 @@
           "Account"
         ],
         "summary": "Get advanced capabilities",
-        "description": "Gets a list of Redis [advanced capabilities](https://redis.io/docs/latest/operate/rc/databases/configuration/advanced-capabilities/) (also known as modules) available for this account. Advanced capability support may differ based on subscription and database settings.",
+        "description": "Gets a list of Redis [advanced capabilities](https://redis.io/docs/latest/operate/rc/databases/configuration/advanced-capabilities/) (also known as modules) available for databases prior to Redis 8. Advanced capability support may differ based on subscription and database settings.",
         "operationId": "getSupportedDatabaseModules",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -9242,11 +11026,11 @@
         "description": "Gets a list of all [data persistence](https://redis.io/docs/latest/operate/rc/databases/configuration/data-persistence/) options for this account.",
         "operationId": "getDataPersistenceOptions",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -9279,6 +11063,60 @@
         }
       }
     },
+    "/cost-report/{costReportId}": {
+      "get": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Get cost report",
+        "description": "Returns the generated cost report file in FOCUS format using the costReportId returned from the cost report generation task. The file is downloaded as an attachment with the filename set to the costReportId.",
+        "operationId": "getCostReport",
+        "parameters": [
+          {
+            "name": "costReportId",
+            "in": "path",
+            "description": "Cost Report ID. Returned from a Cost Report generation task.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "cost-report-12345-abcdef"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
+          },
+          "200": {
+            "description": "Returns the cost report file",
+            "content": {
+              "application/octet-stream": {}
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication failed for requested resource"
+          },
+          "403": {
+            "description": "Forbidden - Not allowed to access requested resource (primarily due to client source IP API Key restrictions)"
+          },
+          "404": {
+            "description": "Not Found - The resource you were trying to reach was not found or does not exist"
+          },
+          "429": {
+            "description": "Too Many Requests - Too many resources are concurrently created / updated / deleted in the account. Please re-submit API requests after resource changes are completed)"
+          },
+          "500": {
+            "description": "Internal system error - If this error persists, please contact customer support"
+          },
+          "503": {
+            "description": "Service Unavailable - Server is temporarily unable to handle the request, please try again later. If this error persists, please contact customer support "
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "tags": [
@@ -9288,11 +11126,11 @@
         "description": "Gets information on this account.",
         "operationId": "getCurrentAccount",
         "responses": {
-          "412": {
-            "description": "Precondition Failed - Feature flag for this flow is off"
-          },
           "400": {
             "description": "Bad Request - The server cannot process the request due to something that is perceived to be a client error"
+          },
+          "412": {
+            "description": "Precondition Failed - Feature flag for this flow is off"
           },
           "200": {
             "description": "OK",
@@ -9328,6 +11166,14 @@
   },
   "components": {
     "schemas": {
+      "TargetVersion": {
+        "type": "object",
+        "properties": {
+          "redisVersion": {
+            "type": "string"
+          }
+        }
+      },
       "AclUserCreateRequest": {
         "required": [
           "name",
@@ -9344,12 +11190,12 @@
           "role": {
             "type": "string",
             "description": "Name of the database access role to assign to this user. Use GET '/acl/roles' to get a list of database access roles.",
-            "example": "Redis-role-example"
+            "example": "ACL-role-example"
           },
           "password": {
             "type": "string",
             "description": "The database password for this user.",
-            "example": "some-random-password"
+            "example": "ab123AB$%^"
           },
           "commandType": {
             "type": "string",
@@ -9430,7 +11276,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -9510,7 +11356,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -9518,7 +11364,7 @@
         "example": {
           "account": {
             "id": 1001,
-            "name": "Redis Labs",
+            "name": "Redis",
             "createdTimestamp": "2018-12-23T15:15:31Z",
             "updatedTimestamp": "2022-10-12T10:54:10Z",
             "pocStatus": "inactive",
@@ -9526,7 +11372,7 @@
             "key": {
               "name": "capi-api-key-name",
               "accountId": 1001,
-              "accountName": "Redis Labs",
+              "accountName": "Redis",
               "allowedSourceIps": [
                 "0.0.0.0/0"
               ],
@@ -9540,6 +11386,63 @@
             }
           }
         }
+      },
+      "PrivateLinkActiveActiveCreateRequest": {
+        "required": [
+          "principal",
+          "regionId",
+          "shareName",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "regionId": {
+            "type": "integer",
+            "description": "Deployment region id as defined by cloud provider",
+            "format": "int32",
+            "readOnly": true
+          },
+          "shareName": {
+            "maxLength": 64,
+            "minLength": 0,
+            "type": "string",
+            "description": "Name for the resource share",
+            "example": "my-private-link-share"
+          },
+          "principal": {
+            "type": "string",
+            "description": "AWS account ID or ARN of the principal (IAM user, role, or account)",
+            "example": "123456789012"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the principal",
+            "example": "aws_account",
+            "enum": [
+              "aws_account",
+              "organization",
+              "organization_unit",
+              "iam_role",
+              "iam_user",
+              "service_principal"
+            ]
+          },
+          "alias": {
+            "type": "string",
+            "description": "Alias or friendly name for the principal",
+            "example": "Production Account"
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Request to create a private link for Active-Active subscription"
       },
       "ActiveActiveVpcPeeringCreateAwsRequest": {
         "required": [
@@ -9617,16 +11520,20 @@
           },
           "paymentMethodId": {
             "type": "integer",
-            "description": "Optional. The payment method ID you'd like to use for this subscription. Must be a valid payment method ID for this account. Use GET /payment-methods to get all payment methods for your account. This value is optional if ‘paymentMethod’ is ‘marketplace’, but required if 'paymentMethod' is 'credit-card'.",
+            "description": "Optional. The payment method ID you'd like to use for this subscription. Must be a valid payment method ID for this account. Use GET /payment-methods to get all payment methods for your account. This value is optional if \u2018paymentMethod\u2019 is \u2018marketplace\u2019, but required if 'paymentMethod' is 'credit-card'.",
             "format": "int32"
           },
           "paymentMethod": {
             "type": "string",
-            "description": "Optional. The payment method for the subscription. If set to ‘credit-card’ , ‘paymentMethodId’ must be defined.",
+            "description": "Optional. The payment method for the subscription. If set to \u2018credit-card\u2019 , \u2018paymentMethodId\u2019 must be defined.",
             "enum": [
               "credit-card",
               "marketplace"
             ]
+          },
+          "publicEndpointAccess": {
+            "type": "boolean",
+            "description": "Optional. When 'false', all databases on this subscription will reject any connection attempt to the public endpoint and any connection attempt to the private endpoint that does not come from an IP address in the private address space defined in [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918#section-3 ). You must use a [private connectivity method](https://redis.io/docs/latest/operate/rc/security/database-security/block-public-endpoints/#private-connectivity-methods ) to connect to a database with a blocked public endpoint."
           },
           "commandType": {
             "type": "string",
@@ -9757,7 +11664,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -9775,7 +11682,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -9878,6 +11785,12 @@
               "memcached"
             ]
           },
+          "port": {
+            "type": "integer",
+            "description": "Optional. TCP port on which the database is available (10000-19999). Generated automatically if not set.",
+            "format": "int32",
+            "example": 10000
+          },
           "memoryLimitInGb": {
             "minimum": 0.1,
             "exclusiveMinimum": false,
@@ -9891,7 +11804,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb.If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
+            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb.If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -9928,7 +11841,7 @@
           },
           "modules": {
             "type": "array",
-            "description": "Optional. Redis advanced capabilities (also known as modules) to be provisioned in the database. Use GET /database-modules to get a list of available advanced capabilities.",
+            "description": "Optional. Redis advanced capabilities (also known as modules) to be provisioned in the database. Use GET /database-modules to get a list of available advanced capabilities. Don't specify modules for database versions 8 and above. All capabilities are bundled in the database by default.",
             "items": {
               "$ref": "#/components/schemas/DatabaseModuleSpec"
             }
@@ -9941,8 +11854,15 @@
           },
           "averageItemSizeInBytes": {
             "type": "integer",
-            "description": "Optional. Relevant only to ram-and-flash (also known as Auto Tiering) subscriptions. Estimated average size in bytes of the items stored in the database. Default: 1000",
-            "format": "int64"
+            "description": "Optional. Relevant only to ram-and-flash (also known as Redis-Flex/Auto-Tiering) subscriptions. Estimated average size in bytes of the items stored in the database. Default: 1000",
+            "format": "int64",
+            "deprecated": true
+          },
+          "ramPercentage": {
+            "type": "integer",
+            "description": "Optional. Relevant only to ram-and-flash (also known as Redis-Flex/Auto-Tiering) subscriptions. The percentage of data to be stored in RAM. Must be between 10 and 50 in steps of 10 (10, 20, 30, 40, 50). Default: 20",
+            "format": "int32",
+            "example": 20
           },
           "respVersion": {
             "type": "string",
@@ -9957,6 +11877,10 @@
             "type": "string",
             "description": "Optional. If specified, redisVersion defines the Redis database version. If omitted, the Redis version will be set to the default version (available in 'GET /subscriptions/redis-versions')",
             "example": "7.2"
+          },
+          "autoMinorVersionUpgrade": {
+            "type": "boolean",
+            "description": "Optional. Automatically upgrades the database to newer minor versions within the same major release. Applies to version 8.4 and above. Default: true."
           },
           "shardingType": {
             "type": "string",
@@ -9992,6 +11916,9 @@
           "status": {
             "type": "string"
           },
+          "publicEndpointAccess": {
+            "type": "boolean"
+          },
           "memoryStorage": {
             "type": "string",
             "enum": [
@@ -10015,7 +11942,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           },
@@ -10036,6 +11963,7 @@
           "status": "active",
           "deploymentType": "single-region",
           "paymentMethodId": 2,
+          "publicEndpointAccess": true,
           "memoryStorage": "ram",
           "numberOfDatabases": 6,
           "paymentMethodType": "credit-card",
@@ -10152,7 +12080,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "(Pay-as-you-go subscriptions only) Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb. If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
+            "description": "(Pay-as-you-go subscriptions only) Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb. If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -10209,9 +12137,11 @@
             "enum": [
               "allkeys-lru",
               "allkeys-lfu",
+              "allkeys-lrm",
               "allkeys-random",
               "volatile-lru",
               "volatile-lfu",
+              "volatile-lrm",
               "volatile-random",
               "volatile-ttl",
               "noeviction"
@@ -10283,7 +12213,7 @@
           },
           "modules": {
             "type": "array",
-            "description": "Optional. Redis advanced capabilities (also known as modules) to be provisioned in the database. Use GET /database-modules to get a list of available advanced capabilities. Can only be set if 'protocol' is 'redis'.",
+            "description": "Optional. Redis advanced capabilities (also known as modules) to be provisioned in the database. Use GET /database-modules to get a list of available advanced capabilities. Can only be set if 'protocol' is 'redis'. Don't specify modules for database versions 8 and above. All capabilities are bundled in the database by default.",
             "items": {
               "$ref": "#/components/schemas/DatabaseModuleSpec"
             }
@@ -10331,7 +12261,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb.If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
+            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb.If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -10365,9 +12295,11 @@
             "enum": [
               "allkeys-lru",
               "allkeys-lfu",
+              "allkeys-lrm",
               "allkeys-random",
               "volatile-lru",
               "volatile-lfu",
+              "volatile-lrm",
               "volatile-random",
               "volatile-ttl",
               "noeviction"
@@ -10466,6 +12398,16 @@
               "$ref": "#/components/schemas/DatabaseAlertSpec"
             }
           },
+          "ramPercentage": {
+            "type": "integer",
+            "description": "Optional. Relevant only to ram-and-flash (also known as Redis-Flex/Auto-Tiering) subscriptions. The percentage of data to be stored in RAM. Must be between 10 and 50 in steps of 10 (10, 20, 30, 40, 50).",
+            "format": "int32",
+            "example": 20
+          },
+          "autoMinorVersionUpgrade": {
+            "type": "boolean",
+            "description": "Optional. Automatically upgrades the database to newer minor versions within the same major release. Applies to version 8.4 and above."
+          },
           "commandType": {
             "type": "string",
             "readOnly": true
@@ -10531,6 +12473,10 @@
               "resp2",
               "resp3"
             ]
+          },
+          "enableDefaultUser": {
+            "type": "boolean",
+            "description": "Optional. When 'true', allows connecting to the database with the 'default' user. When 'false', only defined access control users can connect to the database. If set, 'globalEnableDefaultUser' will not apply to this region."
           }
         },
         "description": "Optional. A list of regions and local settings to update."
@@ -10653,7 +12599,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -10661,147 +12607,288 @@
         "example": {
           "regions": [
             {
+              "id": 1,
               "name": "us-east-1",
               "provider": "AWS"
             },
             {
+              "id": 2,
               "name": "us-west-1",
               "provider": "AWS"
             },
             {
+              "id": 3,
               "name": "us-west-2",
               "provider": "AWS"
             },
             {
+              "id": 4,
               "name": "eu-west-1",
               "provider": "AWS"
             },
             {
+              "id": 29,
               "name": "eu-central-1",
               "provider": "AWS"
             },
             {
-              "name": "ap-northeast-1",
-              "provider": "AWS"
-            },
-            {
-              "name": "ap-southeast-1",
-              "provider": "AWS"
-            },
-            {
-              "name": "ap-southeast-2",
-              "provider": "AWS"
-            },
-            {
+              "id": 7,
               "name": "sa-east-1",
               "provider": "AWS"
             },
             {
-              "name": "us-east-2",
-              "provider": "AWS"
-            },
-            {
-              "name": "eu-west-2",
-              "provider": "AWS"
-            },
-            {
-              "name": "eu-west-3",
-              "provider": "AWS"
-            },
-            {
-              "name": "eu-north-1",
-              "provider": "AWS"
-            },
-            {
+              "id": 63,
               "name": "ca-central-1",
               "provider": "AWS"
             },
             {
+              "id": 62,
+              "name": "eu-north-1",
+              "provider": "AWS"
+            },
+            {
+              "id": 61,
+              "name": "eu-west-3",
+              "provider": "AWS"
+            },
+            {
+              "id": 60,
+              "name": "eu-west-2",
+              "provider": "AWS"
+            },
+            {
+              "id": 59,
+              "name": "us-east-2",
+              "provider": "AWS"
+            },
+            {
+              "id": 64,
               "name": "ap-east-1",
               "provider": "AWS"
             },
             {
+              "id": 146,
+              "name": "ap-southeast-5",
+              "provider": "AWS"
+            },
+            {
+              "id": 30,
               "name": "ap-south-1",
               "provider": "AWS"
             },
             {
+              "id": 117,
+              "name": "ap-northeast-3",
+              "provider": "AWS"
+            },
+            {
+              "id": 116,
+              "name": "ap-northeast-2",
+              "provider": "AWS"
+            },
+            {
+              "id": 145,
+              "name": "ap-southeast-7",
+              "provider": "AWS"
+            },
+            {
+              "id": 6,
+              "name": "ap-northeast-1",
+              "provider": "AWS"
+            },
+            {
+              "id": 5,
+              "name": "ap-southeast-1",
+              "provider": "AWS"
+            },
+            {
+              "id": 15,
+              "name": "ap-southeast-2",
+              "provider": "AWS"
+            },
+            {
+              "id": 132,
+              "name": "il-central-1",
+              "provider": "AWS"
+            },
+            {
+              "id": 144,
+              "name": "mx-central-1",
+              "provider": "AWS"
+            },
+            {
+              "id": 32,
               "name": "asia-east1",
               "provider": "GCP"
             },
             {
+              "id": 67,
               "name": "asia-east2",
               "provider": "GCP"
             },
             {
+              "id": 33,
               "name": "asia-northeast1",
               "provider": "GCP"
             },
             {
+              "id": 104,
               "name": "asia-northeast2",
               "provider": "GCP"
             },
             {
+              "id": 69,
               "name": "asia-south1",
               "provider": "GCP"
             },
             {
+              "id": 34,
               "name": "asia-southeast1",
               "provider": "GCP"
             },
             {
+              "id": 71,
               "name": "australia-southeast1",
               "provider": "GCP"
             },
             {
+              "id": 72,
               "name": "europe-north1",
               "provider": "GCP"
             },
             {
+              "id": 35,
               "name": "europe-west1",
               "provider": "GCP"
             },
             {
+              "id": 74,
               "name": "europe-west2",
               "provider": "GCP"
             },
             {
+              "id": 128,
+              "name": "asia-southeast2",
+              "provider": "GCP"
+            },
+            {
+              "id": 75,
               "name": "europe-west3",
               "provider": "GCP"
             },
             {
+              "id": 36,
               "name": "europe-west4",
               "provider": "GCP"
             },
             {
+              "id": 133,
+              "name": "europe-west10",
+              "provider": "GCP"
+            },
+            {
+              "id": 130,
+              "name": "europe-southwest1",
+              "provider": "GCP"
+            },
+            {
+              "id": 134,
+              "name": "europe-west8",
+              "provider": "GCP"
+            },
+            {
+              "id": 113,
               "name": "europe-west6",
               "provider": "GCP"
             },
             {
+              "id": 129,
+              "name": "me-west1",
+              "provider": "GCP"
+            },
+            {
+              "id": 135,
+              "name": "europe-west9",
+              "provider": "GCP"
+            },
+            {
+              "id": 77,
               "name": "northamerica-northeast1",
               "provider": "GCP"
             },
             {
-              "name": "southamerica-east1",
+              "id": 136,
+              "name": "europe-west12",
               "provider": "GCP"
             },
             {
+              "id": 137,
+              "name": "europe-central2",
+              "provider": "GCP"
+            },
+            {
+              "id": 131,
+              "name": "northamerica-northeast2",
+              "provider": "GCP"
+            },
+            {
+              "id": 138,
+              "name": "me-central2",
+              "provider": "GCP"
+            },
+            {
+              "id": 139,
+              "name": "me-central1",
+              "provider": "GCP"
+            },
+            {
+              "id": 140,
+              "name": "us-east5",
+              "provider": "GCP"
+            },
+            {
+              "id": 141,
+              "name": "us-south1",
+              "provider": "GCP"
+            },
+            {
+              "id": 27,
               "name": "us-central1",
               "provider": "GCP"
             },
             {
+              "id": 38,
               "name": "us-east1",
               "provider": "GCP"
             },
             {
+              "id": 39,
               "name": "us-east4",
               "provider": "GCP"
             },
             {
+              "id": 40,
               "name": "us-west1",
               "provider": "GCP"
             },
             {
+              "id": 82,
               "name": "us-west2",
+              "provider": "GCP"
+            },
+            {
+              "id": 142,
+              "name": "southamerica-west1",
+              "provider": "GCP"
+            },
+            {
+              "id": 95,
+              "name": "southamerica-east1",
+              "provider": "GCP"
+            },
+            {
+              "id": 143,
+              "name": "africa-south1",
               "provider": "GCP"
             }
           ]
@@ -10815,7 +12902,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -10931,6 +13018,31 @@
         },
         "description": "Active-Active VPC peering update request message"
       },
+      "DatabaseTrafficStateResponse": {
+        "type": "object",
+        "properties": {
+          "bdbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trafficStatus": {
+            "type": "string"
+          },
+          "canResume": {
+            "type": "boolean"
+          },
+          "resumeInProgress": {
+            "type": "boolean"
+          },
+          "stopReason": {
+            "type": "string"
+          },
+          "resumeEligibleAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
       "DataPersistenceEntry": {
         "type": "object",
         "properties": {
@@ -10955,7 +13067,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -10966,7 +13078,7 @@
           "cloudAccounts": [
             {
               "id": 1,
-              "name": "Redis Labs Internal Resources",
+              "name": "Redis Internal Resources",
               "provider": "AWS",
               "status": "active",
               "links": []
@@ -10996,6 +13108,85 @@
             }
           ]
         }
+      },
+      "PrivateLinkActiveActivePrincipalsCreateRequest": {
+        "required": [
+          "principal",
+          "regionId"
+        ],
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "regionId": {
+            "type": "integer",
+            "description": "Deployment region id as defined by cloud provider",
+            "format": "int32",
+            "readOnly": true
+          },
+          "principal": {
+            "type": "string",
+            "description": "AWS account ID or ARN of the principal (IAM user, role, or account)",
+            "example": "123456789012"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the principal",
+            "example": "aws_account",
+            "enum": [
+              "aws_account",
+              "organization",
+              "organization_unit",
+              "iam_role",
+              "iam_user",
+              "service_principal"
+            ]
+          },
+          "alias": {
+            "type": "string",
+            "description": "Alias or friendly name for the principal",
+            "example": "Production Account"
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Request to add a principal to private link for Active-Active subscription"
+      },
+      "PrivateLinkActiveActiveConnectionsDisassociateRequest": {
+        "required": [
+          "connections"
+        ],
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "regionId": {
+            "type": "integer",
+            "description": "Deployment region id as defined by cloud provider",
+            "format": "int32",
+            "readOnly": true
+          },
+          "connections": {
+            "type": "array",
+            "description": "List of connections to disassociate from the private link. Each connection must include associationId, type, and principalId.",
+            "items": {
+              "$ref": "#/components/schemas/PrivateLinkConnectionDisassociate"
+            }
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Request to disassociate connections from private link for Active-Active subscription"
       },
       "VpcPeeringUpdateAwsRequest": {
         "type": "object",
@@ -11048,7 +13239,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -11196,7 +13387,8 @@
           },
           "redisRule": {
             "type": "string",
-            "description": "Optional. Changes the Redis ACL rule pattern. See [ACL syntax](https://redis.io/docs/latest/operate/rc/security/access-control/data-access-control/configure-acls/#define-permissions-with-acl-syntax) to learn how to define rules."
+            "description": "Optional. Changes the Redis ACL rule pattern. See [ACL syntax](https://redis.io/docs/latest/operate/rc/security/access-control/data-access-control/configure-acls/#define-permissions-with-acl-syntax) to learn how to define rules.",
+            "example": "+set allkeys allchannels"
           },
           "commandType": {
             "type": "string",
@@ -11246,12 +13438,18 @@
           "signInLoginUrl": {
             "type": "string"
           },
+          "awsUserArn": {
+            "type": "string"
+          },
+          "awsConsoleRoleArn": {
+            "type": "string"
+          },
           "links": {
             "type": "array",
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           },
@@ -11266,7 +13464,7 @@
         "description": "RedisLabs Cloud Account information",
         "example": {
           "id": 1,
-          "name": "Redis Labs Internal Resources",
+          "name": "Redis Internal Resources",
           "provider": "AWS",
           "status": "active",
           "links": [
@@ -11277,6 +13475,47 @@
             }
           ]
         }
+      },
+      "PrivateLinkPrincipalsCreateRequest": {
+        "required": [
+          "principal"
+        ],
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "principal": {
+            "type": "string",
+            "description": "AWS account ID or ARN of the principal (IAM user, role, or account)",
+            "example": "123456789012"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the principal",
+            "example": "aws_account",
+            "enum": [
+              "aws_account",
+              "organization",
+              "organization_unit",
+              "iam_role",
+              "iam_user",
+              "service_principal"
+            ]
+          },
+          "alias": {
+            "type": "string",
+            "description": "Alias or friendly name for the principal",
+            "example": "Production Account"
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Private Link principals create request"
       },
       "FixedSubscriptionUpdateRequest": {
         "type": "object",
@@ -11298,7 +13537,7 @@
           },
           "paymentMethod": {
             "type": "string",
-            "description": "Optional. The payment method for the subscription. If set to ‘credit-card’ , ‘paymentMethodId’ must be defined.",
+            "description": "Optional. The payment method for the subscription. If set to \u2018credit-card\u2019 , \u2018paymentMethodId\u2019 must be defined.",
             "enum": [
               "credit-card",
               "marketplace"
@@ -11306,7 +13545,7 @@
           },
           "paymentMethodId": {
             "type": "integer",
-            "description": "Optional. The payment method ID you'd like to use for this subscription. Must be a valid payment method ID for this account. Use GET /payment-methods to get a list of payment methods for your account. This value is optional if ‘paymentMethod’ is ‘marketplace’, but required if 'paymentMethod' is 'credit-card'.",
+            "description": "Optional. The payment method ID you'd like to use for this subscription. Must be a valid payment method ID for this account. Use GET /payment-methods to get a list of payment methods for your account. This value is optional if \u2018paymentMethod\u2019 is \u2018marketplace\u2019, but required if 'paymentMethod' is 'credit-card'.",
             "format": "int32"
           },
           "commandType": {
@@ -11330,7 +13569,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -11353,7 +13592,7 @@
           },
           "deletionGracePeriod": {
             "type": "string",
-            "description": "Optional. The grace period for deleting the subscription. If not set, will default to immediate deletion grace period.",
+            "description": "Optional. The grace period for deleting the subscription if Redis cannot access the provided key. Required when applying customer managed keys for a new subscription.",
             "example": "alerts-only",
             "enum": [
               "alerts-only",
@@ -11377,6 +13616,97 @@
         },
         "description": "Subscription update request message"
       },
+      "CostReportCreateRequest": {
+        "required": [
+          "endDate",
+          "startDate"
+        ],
+        "type": "object",
+        "properties": {
+          "startDate": {
+            "type": "string",
+            "description": "Filter for usage starting on or after this date. Must be in format YYYY-MM-DD",
+            "format": "YYYY-MM-DD",
+            "example": "2025-10-01"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "Filter for usage ending on or before this date. Must be in format YYYY-MM-DD and must be after start date",
+            "format": "YYYY-MM-DD",
+            "example": "2025-11-06"
+          },
+          "format": {
+            "type": "string",
+            "description": "Output format for the cost report",
+            "example": "csv",
+            "default": "csv",
+            "enum": [
+              "json",
+              "csv"
+            ]
+          },
+          "subscriptionIds": {
+            "type": "array",
+            "description": "Array of subscriptionIDs to filter by",
+            "example": [
+              123,
+              456
+            ],
+            "items": {
+              "type": "integer",
+              "description": "Array of subscriptionIDs to filter by",
+              "format": "int32"
+            }
+          },
+          "databaseIds": {
+            "type": "array",
+            "description": "Array of database IDs to filter by",
+            "example": [
+              789,
+              101112
+            ],
+            "items": {
+              "type": "integer",
+              "description": "Array of database IDs to filter by",
+              "format": "int32"
+            }
+          },
+          "subscriptionType": {
+            "type": "string",
+            "description": "Filter by plan type",
+            "example": "pro",
+            "enum": [
+              "pro",
+              "essentials"
+            ]
+          },
+          "regions": {
+            "type": "array",
+            "description": "Array of regions to filter by",
+            "example": [
+              "us-east-1",
+              "eu-west-1"
+            ],
+            "items": {
+              "type": "string",
+              "description": "Array of regions to filter by",
+              "example": "[\"us-east-1\",\"eu-west-1\"]"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "description": "Array of key-value pairs for tag filtering",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Cost report generation request"
+      },
       "AccountSubscriptionDatabases": {
         "type": "object",
         "properties": {
@@ -11389,7 +13719,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -11832,6 +14162,10 @@
           "resource": {
             "type": "string"
           },
+          "resourceId": {
+            "type": "integer",
+            "format": "int32"
+          },
           "type": {
             "type": "string"
           },
@@ -11849,7 +14183,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           },
@@ -11893,7 +14227,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -12017,7 +14351,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           },
@@ -12132,7 +14466,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -12144,7 +14478,7 @@
               "time": "2022-10-12T10:54:31Z",
               "originator": "example-value",
               "type": "Account",
-              "description": "example-value (example.value@redislabs.com)'s user name was changed to Example Value"
+              "description": "example-value (example.value@redis.com)'s user name was changed to Example Value"
             },
             {
               "id": 2900348,
@@ -12253,6 +14587,18 @@
           }
         }
       },
+      "ResourceTag": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "description": "List of resource tags to apply to the subscription. This will replace all existing tags."
+      },
       "CustomerManagedKeyAccessDetails": {
         "type": "object",
         "properties": {
@@ -12331,7 +14677,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -12368,11 +14714,31 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
         }
+      },
+      "Tag": {
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Tag key",
+            "example": "environment"
+          },
+          "value": {
+            "type": "string",
+            "description": "Tag value",
+            "example": "production"
+          }
+        },
+        "description": "Tag filter for cost report"
       },
       "AccountSubscriptions": {
         "type": "object",
@@ -12386,7 +14752,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -12401,6 +14767,7 @@
               "status": "active",
               "deploymentType": "single-region",
               "paymentMethodId": 123,
+              "publicEndpointAccess": true,
               "memoryStorage": "ram",
               "numberOfDatabases": 6,
               "paymentMethodType": "credit-card",
@@ -12419,6 +14786,7 @@
               "cloudDetails": [
                 {
                   "provider": "AWS",
+                  "awsAccountId": "550680565604",
                   "cloudAccountId": 1666,
                   "totalSizeInGb": 0.0272,
                   "regions": [
@@ -12539,7 +14907,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "(Pay-as-you-go subscriptions only) Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb. If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
+            "description": "(Pay-as-you-go subscriptions only) Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb. If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -12591,9 +14959,11 @@
             "enum": [
               "allkeys-lru",
               "allkeys-lfu",
+              "allkeys-lrm",
               "allkeys-random",
               "volatile-lru",
               "volatile-lfu",
+              "volatile-lrm",
               "volatile-random",
               "volatile-ttl",
               "noeviction"
@@ -12745,7 +15115,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -12826,7 +15196,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -12879,7 +15249,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -12960,7 +15330,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -13265,7 +15635,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -13471,7 +15841,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -13522,7 +15892,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -13577,6 +15947,17 @@
         },
         "description": "Database tag"
       },
+      "BdbAvailableVersionsResponse": {
+        "type": "object",
+        "properties": {
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TargetVersion"
+            }
+          }
+        }
+      },
       "SubscriptionSpec": {
         "required": [
           "regions"
@@ -13603,6 +15984,13 @@
             "description": "The cloud provider region or list of regions (Active-Active only) and networking details.",
             "items": {
               "$ref": "#/components/schemas/SubscriptionRegionSpec"
+            }
+          },
+          "resourceTags": {
+            "type": "array",
+            "description": "Optional. A list of resource tags to apply to the subscription. (max. 30 tags).",
+            "items": {
+              "$ref": "#/components/schemas/ResourceTag"
             }
           }
         },
@@ -13654,7 +16042,7 @@
             "example": {}
           }
         },
-        "description": "Optional. Redis advanced capabilities (also known as modules) to be provisioned in the database. Use GET /database-modules to get a list of available advanced capabilities."
+        "description": "Optional. Redis advanced capabilities (also known as modules) to be provisioned in the database. Use GET /database-modules to get a list of available advanced capabilities. Don't specify modules for database versions 8 and above. All capabilities are bundled in the database by default."
       },
       "FixedSubscriptionCreateRequest": {
         "required": [
@@ -13675,7 +16063,7 @@
           },
           "paymentMethod": {
             "type": "string",
-            "description": "Optional. The payment method for the subscription. If set to ‘credit-card’, ‘paymentMethodId’ must be defined. Default: 'credit-card'",
+            "description": "Optional. The payment method for the subscription. If set to \u2018credit-card\u2019, \u2018paymentMethodId\u2019 must be defined. Default: 'credit-card'",
             "enum": [
               "credit-card",
               "marketplace"
@@ -13683,7 +16071,7 @@
           },
           "paymentMethodId": {
             "type": "integer",
-            "description": "Optional. A valid payment method ID for this account. Use GET /payment-methods to get a list of all payment methods for your account. This value is optional if ‘paymentMethod’ is ‘marketplace’, but required for all other account types.",
+            "description": "Optional. A valid payment method ID for this account. Use GET /payment-methods to get a list of all payment methods for your account. This value is optional if \u2018paymentMethod\u2019 is \u2018marketplace\u2019, but required for all other account types.",
             "format": "int32"
           },
           "commandType": {
@@ -13709,20 +16097,42 @@
           "subnetIds": {
             "type": "array",
             "description": "Optional. Enter a list of subnets identifiers that exists in the hosted AWS account. Subnet Identifier must exist within the hosting account.",
-            "example": "<subnet-identifier>",
             "items": {
               "type": "string",
-              "description": "Optional. Enter a list of subnets identifiers that exists in the hosted AWS account. Subnet Identifier must exist within the hosting account.",
-              "example": "<subnet-identifier>"
+              "description": "Optional. Enter a list of subnets identifiers that exists in the hosted AWS account. Subnet Identifier must exist within the hosting account."
             }
           },
           "securityGroupId": {
             "type": "string",
-            "description": "Optional. Enter a security group identifier that exists in the hosted AWS account. Security group Identifier must be in a valid format (for example: 'sg-0125be68a4625884ad') and must exist within the hosting account.",
-            "example": "<security-group-identifier>"
+            "description": "Optional. Enter a security group identifier that exists in the hosted AWS account. Security group Identifier must be in a valid format (for example: 'sg-0125be68a4625884ad') and must exist within the hosting account."
           }
         },
         "description": "Optional. Cloud networking details, per region. Required if creating an Active-Active subscription."
+      },
+      "SubscriptionResourceTagsUpdateRequest": {
+        "required": [
+          "resourceTags"
+        ],
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "resourceTags": {
+            "type": "array",
+            "description": "List of resource tags to apply to the subscription. This will replace all existing tags.",
+            "items": {
+              "$ref": "#/components/schemas/ResourceTag"
+            }
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Resource tags update request"
       },
       "DatabaseTagsUpdateRequest": {
         "required": [
@@ -13754,6 +16164,31 @@
         },
         "description": "Database tags update request message"
       },
+      "PrivateLinkConnectionsDisassociateRequest": {
+        "required": [
+          "connections"
+        ],
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "connections": {
+            "type": "array",
+            "description": "List of connections to disassociate from the private link. Each connection must include associationId, type, and principalId.",
+            "items": {
+              "$ref": "#/components/schemas/PrivateLinkConnectionDisassociate"
+            }
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Private Link connections disassociate request"
+      },
       "AccountUsers": {
         "type": "object",
         "properties": {
@@ -13782,6 +16217,34 @@
             }
           ]
         }
+      },
+      "FixedDatabaseUpgradeRedisVersionRequest": {
+        "required": [
+          "targetRedisVersion"
+        ],
+        "type": "object",
+        "properties": {
+          "databaseId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "targetRedisVersion": {
+            "type": "string",
+            "description": "The target Redis version the database will be upgraded to. Use GET /subscriptions/redis-versions to get a list of available Redis versions.",
+            "example": "7.4"
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Upgrades the specified Essentials database to a later Redis version."
       },
       "CrdbUpdatePropertiesRequest": {
         "type": "object",
@@ -13819,7 +16282,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb.If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
+            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb.If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -13864,6 +16327,10 @@
             "type": "string",
             "description": "Optional. Changes the password used to access the database in all regions that don't set a local 'password'."
           },
+          "globalEnableDefaultUser": {
+            "type": "boolean",
+            "description": "Optional. When 'true', allows connecting to the database with the 'default' user in all regions that don't set local 'enableDefaultUser'. When 'false', only defined access control users can connect to the database."
+          },
           "globalSourceIp": {
             "type": "array",
             "description": "Optional. List of source IP addresses or subnet masks to whitelist in all regions that don't set local 'sourceIp' settings. If set, Redis clients will be able to connect to this database only from within the specified source IP addresses ranges. Example: ['192.168.10.0/32', '192.168.12.0/24']",
@@ -13892,13 +16359,19 @@
             "enum": [
               "allkeys-lru",
               "allkeys-lfu",
+              "allkeys-lrm",
               "allkeys-random",
               "volatile-lru",
               "volatile-lfu",
+              "volatile-lrm",
               "volatile-random",
               "volatile-ttl",
               "noeviction"
             ]
+          },
+          "autoMinorVersionUpgrade": {
+            "type": "boolean",
+            "description": "Optional. Automatically upgrades the database to newer minor versions within the same major release. Applies to version 8.4 and above."
           },
           "commandType": {
             "type": "string",
@@ -13921,7 +16394,8 @@
           },
           "redisRule": {
             "type": "string",
-            "description": "Redis ACL rule pattern. See [ACL syntax](https://redis.io/docs/latest/operate/rc/security/access-control/data-access-control/configure-acls/#define-permissions-with-acl-syntax) to learn how to define rules."
+            "description": "Redis ACL rule pattern. See [ACL syntax](https://redis.io/docs/latest/operate/rc/security/access-control/data-access-control/configure-acls/#define-permissions-with-acl-syntax) to learn how to define rules.",
+            "example": "+set allkeys allchannels"
           },
           "commandType": {
             "type": "string",
@@ -13961,10 +16435,10 @@
           },
           "preferredAvailabilityZones": {
             "type": "array",
-            "description": "Optional. List the zone ID(s) for your preferred availability zone(s) for the cloud provider and region. If ‘multipleAvailabilityZones’ is set to 'true', you must list three availability zones. Otherwise, list one availability zone.",
+            "description": "Optional. List the zone ID(s) for your preferred availability zone(s) for the cloud provider and region. If \u2018multipleAvailabilityZones\u2019 is set to 'true', you must list three availability zones. Otherwise, list one availability zone.",
             "items": {
               "type": "string",
-              "description": "Optional. List the zone ID(s) for your preferred availability zone(s) for the cloud provider and region. If ‘multipleAvailabilityZones’ is set to 'true', you must list three availability zones. Otherwise, list one availability zone."
+              "description": "Optional. List the zone ID(s) for your preferred availability zone(s) for the cloud provider and region. If \u2018multipleAvailabilityZones\u2019 is set to 'true', you must list three availability zones. Otherwise, list one availability zone."
             }
           },
           "networking": {
@@ -14048,7 +16522,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb. If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
+            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb. If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -14056,6 +16530,10 @@
             "type": "string",
             "description": "Optional. If specified, redisVersion defines the Redis database version. If omitted, the Redis version will be set to the default version (available in 'GET /subscriptions/redis-versions')",
             "example": "7.2"
+          },
+          "autoMinorVersionUpgrade": {
+            "type": "boolean",
+            "description": "Optional. Automatically upgrades the database to newer minor versions within the same major release. Applies to version 8.4 and above. Default: true."
           },
           "respVersion": {
             "type": "string",
@@ -14094,9 +16572,11 @@
             "enum": [
               "allkeys-lru",
               "allkeys-lfu",
+              "allkeys-lrm",
               "allkeys-random",
               "volatile-lru",
               "volatile-lfu",
+              "volatile-lrm",
               "volatile-random",
               "volatile-ttl",
               "noeviction"
@@ -14130,8 +16610,15 @@
           },
           "averageItemSizeInBytes": {
             "type": "integer",
-            "description": "Optional. Relevant only to ram-and-flash (also known as Auto Tiering) subscriptions. Estimated average size in bytes of the items stored in the database. Default: 1000",
-            "format": "int64"
+            "description": "Optional. Relevant only to ram-and-flash (also known as Redis-Flex/Auto-Tiering) subscriptions. Estimated average size in bytes of the items stored in the database. Default: 1000",
+            "format": "int64",
+            "deprecated": true
+          },
+          "ramPercentage": {
+            "type": "integer",
+            "description": "Optional. Relevant only to ram-and-flash (also known as Redis-Flex/Auto-Tiering) subscriptions. The percentage of data to be stored in RAM. Must be between 10 and 50 in steps of 10 (10, 20, 30, 40, 50). Default: 20",
+            "format": "int32",
+            "example": 20
           },
           "periodicBackupPath": {
             "type": "string",
@@ -14187,7 +16674,7 @@
           },
           "modules": {
             "type": "array",
-            "description": "Optional. Redis advanced capabilities (also known as modules) to be provisioned in the database. Use GET /database-modules to get a list of available advanced capabilities.",
+            "description": "Optional. Redis advanced capabilities (also known as modules) to be provisioned in the database. Use GET /database-modules to get a list of available advanced capabilities. Don't specify modules for database versions 8 and above. All capabilities are bundled in the database by default.",
             "items": {
               "$ref": "#/components/schemas/DatabaseModuleSpec"
             }
@@ -14216,6 +16703,10 @@
       "Region": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
           "name": {
             "type": "string"
           },
@@ -14251,12 +16742,12 @@
           "role": {
             "type": "string",
             "description": "Optional. Changes the ACL role assigned to the user. Use GET '/acl/roles' to get a list of database access roles.",
-            "example": "Redis-role-example"
+            "example": "ACL-role-example"
           },
           "password": {
             "type": "string",
             "description": "Optional. Changes the user's database password.",
-            "example": "some-random-password"
+            "example": "ab123AB$%^"
           },
           "commandType": {
             "type": "string",
@@ -14264,6 +16755,37 @@
           }
         },
         "description": "ACL user update request"
+      },
+      "PrivateLinkConnectionDisassociate": {
+        "required": [
+          "associationId",
+          "principalId",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "associationId": {
+            "type": "string",
+            "description": "Resource share association ID",
+            "example": "rsa-12345678"
+          },
+          "connectionId": {
+            "type": "string",
+            "description": "VPC endpoint connection ID",
+            "example": "vpce-con-12345678"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the connection",
+            "example": "vpc_endpoint"
+          },
+          "principalId": {
+            "type": "string",
+            "description": "Principal ID that owns the connection, e.g. AWS account ID",
+            "example": "123456789012"
+          }
+        },
+        "description": "Private link connection information for disassociation request"
       },
       "ProcessorResponse": {
         "type": "object",
@@ -14300,21 +16822,21 @@
               "SUBSCRIPTION_IN_USE",
               "SUBSCRIPTION_CA_PROVIDER_MISMATCH",
               "SUBSCRIPTION_NETWORKING_MISSING",
-              "SUBSCRIPTION_NETWORKING_CIDR_MISSING",
+              "NETWORKING_CIDR_MISSING",
               "SUBSCRIPTION_INVALID_CIDR",
-              "SUBSCRIPTION_NETWORKING_SECURITY_GROUP_MISSING",
-              "SUBSCRIPTION_NETWORKING_SUBNET_IDS_MISSING",
-              "SUBSCRIPTION_NETWORKING_VPC_ID_MISSING",
-              "SUBSCRIPTION_NETWORKING_CIDR_IS_NOT_SUPPORTED",
-              "SUBSCRIPTION_NETWORKING_VPC_WITH_SUBNETS_AND_SECURITY_GROUP_IS_NOT_SUPPORTED",
-              "SUBSCRIPTION_INVALID_NUMBER_OF_SUBNET_IDS",
+              "NETWORKING_SECURITY_GROUP_MISSING",
+              "NETWORKING_SUBNET_IDS_MISSING",
+              "NETWORKING_VPC_ID_MISSING",
+              "NETWORKING_CIDR_IS_NOT_SUPPORTED",
+              "NETWORKING_VPC_WITH_SUBNETS_AND_SECURITY_GROUP_IS_NOT_SUPPORTED",
+              "NETWORKING_VPC_WITH_SUBNETS_AND_SECURITY_GROUP_IS_NOT_SUPPORTED_FOR_INTERNAL_CLOUD_ACCOUNT",
+              "INVALID_NUMBER_OF_SUBNET_IDS",
               "SUBSCRIPTION_PI_NOT_FOUND",
               "SUBSCRIPTION_INVALID_REGION_NAME",
               "SUBSCRIPTION_INVALID_REGION_ID",
               "SUBSCRIPTION_BAD_PREFERRED_AZ_SIZE",
               "SUBSCRIPTION_PREFERRED_AZ_INVALID_VALUE",
               "SUBSCRIPTION_PREFERRED_AZ_MUST_BE_DEFINED_ONCE",
-              "ACTIVE_ACTIVE_SUBSCRIPTION_PREFERRED_AZ_NOT_SUPPORTED",
               "SUBSCRIPTION_PREFERRED_AZ_IS_DISABLED",
               "SUBSCRIPTION_MUST_HAVE_AT_LEAST_ONE_DATABASE",
               "SUBSCRIPTION_REDIS_VERSION_INVALID_VALUE",
@@ -14323,6 +16845,15 @@
               "SUBSCRIPTION_GCP_ALLOW_ONLY_INTERNAL",
               "CLUSTER_UNDER_MAINTENANCE",
               "ACTIVE_ACTIVE_SUBSCRIPTION_IS_NOT_SUPPORTED",
+              "RESOURCE_TAGS_EXCEEDS_MAXIMUM_COUNT",
+              "RESOURCE_TAG_KEY_EXCEEDS_MAXIMUM_LENGTH",
+              "RESOURCE_TAG_VALUE_EXCEEDS_MAXIMUM_LENGTH",
+              "RESOURCE_TAGS_NOT_ALLOWED_WITH_INTERNAL_CLOUD_ACCOUNT",
+              "RESOURCE_TAGS_NOT_ALLOWED",
+              "RESOURCE_TAGS_NAME_NOT_ALLOWED",
+              "RESOURCE_TAGS_EMPTY_KEY",
+              "RESOURCE_TAGS_DUPLICATE_KEY",
+              "RESOURCE_TAGS_MISSING_VALUE",
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_IS_NOT_SUPPORTED",
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_MISSING_USAGE_PERMISSIONS",
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_MISSING_GET_KEY_PERMISSIONS",
@@ -14330,7 +16861,10 @@
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_DISABLED_KEY",
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_INVALID_KEY_NAME",
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_WRONG_REGION",
-              "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_NOT_PENDING",
+              "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_NOT_ALLOWED_WITH_CLOUD_PROVIDER_MANAGED_KEY",
+              "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_NOT_ALLOWED_WITH_INTERNAL_CLOUD_ACCOUNT",
+              "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_REQUIRED_FOR_EXTERNAL_CLOUD_ACCOUNT",
+              "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_DELETION_GRACE_PERIOD_REQUIRED",
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_INVALID_NUMBER_OF_KEYS",
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_REGION_NOT_REQUIRED",
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_REGION_REQUIRED",
@@ -14338,7 +16872,8 @@
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_INVALID_REGION",
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_DUPLICATE_REGIONS",
               "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_INVALID_FORMAT",
-              "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_CREATE_FAILED",
+              "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_UPDATE_IS_NOT_SUPPORTED",
+              "CUSTOMER_MANAGED_PERSISTENT_STORAGE_ENCRYPTION_KEY_SUBSCRIPTION_INVALID_STATUS",
               "ACTIVE_ACTIVE_CREATE_A_REGION_CUSTOMER_MANAGED_KEY_RESOURCE_NAME_SUBSCRIPTION_IS_NOT_CUSTOMER_MANAGED",
               "ACTIVE_ACTIVE_CREATE_A_REGION_CUSTOMER_MANAGED_KEY_RESOURCE_NAME_IS_NOT_SET",
               "PLANNED_SUBSCRIPTION_INVALID_PLAN_ID",
@@ -14371,11 +16906,8 @@
               "DATABASE_QUERY_PERFORMANCE_FACTOR_IS_NOT_SUPPORTED_ON_ACTIVE_ACTIVE",
               "REDISEARCH_SUPPORTS_ONLY_OPERATIONS_PER_SECOND_AS_THROUGHPUT_MEASUREMENT",
               "REDIS_GRAPH_SUPPORTS_ONLY_OPS_PER_SECOND_AS_THROUGHPUT_MEASUREMENT",
-              "DATABASE_MULTI_MODULES_IS_DISABLED",
               "DATABASE_RESP_VERSION_IS_NOT_SUPPORTED",
               "DATABASE_RESP_VERSION_IS_NOT_SUPPORTED_ON_CREATE_SUBSCRIPTION",
-              "CLUSTER_MULTI_MODULES_IS_NOT_SUPPORTED",
-              "DATABASE_INVALID_MULTI_MODULES_COMBINATION",
               "DATABASE_ROF_NOT_SUPPORTED",
               "DATABASE_REDISGRAPH_OVERSIZED",
               "DATABASE_BACKUP_NOT_SUPPORTED",
@@ -14403,6 +16935,7 @@
               "DATABASE_MODULE_MUST_BE_DEFINED_ONCE",
               "DATABASE_MEMCACHED_CONTAINS_MODULES",
               "DATABASE_MEMCACHED_NOT_SUPPORT_OSS_CLUSTER_API",
+              "REDIS_ON_FLASH_DATABASE_MEMCACHED_PROTOCOL_IS_NOT_ALLOWED",
               "DATABASE_MEMCACHED_CONTAINS_REDIS_PASSWORD",
               "DATABASE_MEMCACHED_CONTAINS_REDIS_DEFAULT_USER",
               "DATABASE_MEMCACHED_SASL_USERNAME_IS_BLANK",
@@ -14410,6 +16943,12 @@
               "DATABASE_MEMCACHED_SASL_PASSWORD_MAX_LENGTH",
               "DATABASE_REDIS_FLEX_CONTAINS_MODULES",
               "DATABASE_AVERAGE_ITEM_SIZE_NOT_ALLOWED",
+              "DATABASE_RAM_PERCENTAGE_NOT_ALLOWED",
+              "DATABASE_RAM_PERCENTAGE_NOT_SUPPORTED",
+              "DATABASE_RAM_PERCENTAGE_IS_INVALID",
+              "DATABASE_AVERAGE_ITEM_SIZE_IS_DEPRECATED",
+              "DATABASE_MEMORY_LIMIT_IS_INVALID_FOR_ROF",
+              "DATABASE_DATASET_SIZE_IS_INVALID_FOR_ROF",
               "DATABASE_SIZE_SMALLER_THAN_USAGE",
               "DATABASE_USAGE_EXCEEDS_GLOBAL_LIMIT",
               "DATABASE_USAGE_EXCEEDS_LOCAL_LIMIT",
@@ -14420,10 +16959,12 @@
               "DATABASE_CLIENT_SSL_CERTIFICATE_MORE_THAN_1_ACTIVE",
               "DATABASE_SIP_OVER_LIMIT",
               "DATABASE_INVALID_SIP",
+              "DATABASE_INVALID_SIP_FREE_PLAN",
               "DATABASE_INVALID_ALERTS",
               "DATABASE_INVALID_MODULE",
               "DATABASE_INVALID_MODULE_PARAMETER",
               "DATABASE_INVALID_MODULE_PARAMETER_VALUE",
+              "DATABASE_EXPLICIT_MODULES_NOT_SUPPORTED_FOR_THIS_REDIS_VERSION",
               "DATABASE_INVALID_ALERT_VALUE",
               "DATABASE_SHARDING_TYPE_IS_IMMUTABLE",
               "DATABASE_SHARDING_TYPE_IS_NOT_SUPPORTED",
@@ -14455,6 +16996,7 @@
               "DATABASE_INVALID_REGEX_RULES",
               "DATABASE_INVALID_QUANTITY",
               "DATABASE_REPLICA_OF_VERSION_NOT_COMPATIBLE",
+              "DATABASE_REPLICA_OF_SOURCE_INCOMPATIBLE",
               "DATABASE_IMPORT_FAILED",
               "DATABASE_IMPORT_FROM_NON_OSS",
               "DATABASE_IMPORT_SOURCE_NOT_FOUND",
@@ -14473,11 +17015,16 @@
               "DATABASE_PORT_INVALID_VALUE",
               "DATABASE_PORT_IS_UNAVAILABLE",
               "DATABASE_CUSTOM_PORT_NOT_SUPPORTED",
+              "DATABASE_CUSTOM_PORT_NOT_UNIQUE",
               "DATABASE_AVERAGE_ITEM_SIZE_INVALID_VALUE",
               "DATABASE_REDIS_VERSION_IS_NOT_SUPPORTED",
+              "DATABASE_REDIS_VERSION_IS_NOT_SUPPORTED_FOR_REGION",
               "DATABASE_REDIS_VERSION_IS_NOT_SUPPORTED_FOR_MEMCACHED",
               "DATABASE_REDIS_VERSION_IS_REQUIRED",
               "DATABASE_REDIS_VERSION_INVALID_VALUE",
+              "INCOMPATIBLE_TF_PROVIDER",
+              "DESIRED_SOFTWARE_VERSION_IS_NOT_SUPPORTED",
+              "CONNECTIVITY_REQUESTS_ON_CUSTOMER_MANAGED_VPC_SUBSCRIPTION",
               "VPC_PEERING_NOT_ACTIVE",
               "VPC_PEERING_GENERAL_ERROR",
               "VPC_PEERING_INVALID_ACCOUNT",
@@ -14560,6 +17107,10 @@
               "CIDR_WHITELIST_DUPLICATE_CIDRS",
               "CIDR_WHITELIST_DUPLICATE_SG",
               "CIDR_WHITELIST_NOT_ALLOWED",
+              "CLIENT_PUBLIC_ACCESS_INVALID_SOURCE_IPS",
+              "CLIENT_PUBLIC_ACCESS_NOT_SUPPORTED",
+              "CLIENT_PUBLIC_ACCESS_ALREADY_SET",
+              "CLIENT_PUBLIC_ACCESS_ON_NON_HOSTED",
               "AWS_ERROR_INSTANCE_LIMIT_EXCEEDED",
               "AWS_ERROR_VPC_LIMIT_EXCEEDED",
               "AWS_ERROR_INSUFFICIENT_INSTANCE_CAPACITY",
@@ -14573,6 +17124,7 @@
               "PAYMENT_INFO_NOT_ALLOWED_IN_GCP_ACCOUNT",
               "CLOUD_PROVIDER_IS_NOT_GCP_IN_GCP_ACCOUNT",
               "PAYMENT_INFO_NOT_ALLOWED_IN_CONTRACT_ASSOCIATED_ACCOUNT",
+              "PAYMENT_INFO_CHANGE_PROHIBITED_FOR_PRO_UNDER_CONTRACT",
               "LOCAL_THROUGHPUT_READ_AND_WRITE_OPERATIONS_PER_SECOND_VALUES_MUST_BE_IN_INCREMENTS_OF_500_OR_MINIMUM",
               "MISSING_REGIONS_BETWEEN_CLOUD_PROVIDERS_AND_DATABASES_LOCAL_THROUGHPUT_MEASUREMENTS",
               "MISSING_REGIONS_BETWEEN_LOCAL_THROUGHPUT_MEASUREMENTS_AND_SUBSCRIPTION_REGIONS",
@@ -14666,7 +17218,10 @@
               "FIXED_DATABASE_NO_EVICTION_IS_NOT_SUPPORTED_BY_CLUSTER",
               "FIXED_DATABASE_DATA_EVICTION_POLICY_IS_NOT_SUPPORTED_BY_CLUSTER",
               "FIXED_DATABASE_DATA_EVICTION_POLICY_IS_NOT_SUPPORTED_BY_SELECTED_MODULES",
-              "FIXED_DATABASE_EVICTION_POLICY_IS_NOT_SUPPORTED_BY_REDIS_FLEX_PLAN",
+              "FIXED_DATABASE_EVICTION_POLICY_NOT_COMPATIBLE_WITH_REDIS_VERSION",
+              "DATABASE_EVICTION_POLICY_NOT_COMPATIBLE_WITH_REDIS_VERSION",
+              "DATABASE_EVICTION_POLICY_NOT_COMPATIBLE_WITH_REDIS_FLEX",
+              "FIXED_DATABASE_EVICTION_POLICY_NOT_COMPATIBLE_WITH_REDIS_FLEX",
               "FIXED_DATABASE_REPLICA_OF_IS_NOT_SUPPORTED_BY_SELECTED_MODULES",
               "FIXED_DATABASE_DATA_PERSISTENCE_VALUE_NOT_SUPPORTED_FOR_FIXED",
               "FIXED_DATABASE_DATA_EVICTION_POLICY_IS_NOT_SUPPORTED_BY_ALL_MODULES_IN_SELECTED_PLAN_OR_CLUSTER",
@@ -14693,6 +17248,7 @@
               "PAYMENT_INVALID_CARD_TYPE",
               "PAYMENT_CVV_MISSING",
               "PAYMENT_GENERAL_ERROR",
+              "PAYMENT_HOLD_FAILED",
               "ACL_USER_NAME_ALREADY_EXISTS",
               "ACL_USER_NAME_NOT_VALID",
               "ACL_USER_NOT_FOUND",
@@ -14817,7 +17373,38 @@
               "ACTIVE_ACTIVE_GCP_EXTERNAL_CLOUD_ACCOUNT_NOT_SUPPORTED",
               "DEDICATED_SUBSCRIPTION_PREFERRED_AZ_INVALID_VALUE",
               "DEDICATED_SUBSCRIPTION_INVALID_INSTANCE_NAME",
-              "DEDICATED_SUBSCRIPTION_INVALID_REPLICATION"
+              "DEDICATED_SUBSCRIPTION_INVALID_REPLICATION",
+              "PRIVATE_LINK_NOT_FOUND",
+              "PRIVATE_LINK_ALREADY_EXISTS",
+              "PRIVATE_LINK_PRINCIPAL_ALREADY_EXISTS",
+              "PRIVATE_LINK_PRINCIPAL_NOT_FOUND",
+              "PRIVATE_LINK_PRINCIPAL_INVALID_PRINCIPLE",
+              "PRIVATE_LINK_CLOUD_PROVIDER_NOT_SUPPORTED",
+              "PRIVATE_LINK_GET_A_FLEXIBLE_SUBSCRIPTION_PRIVATE_LINK_IS_NOT_ALLOWED_WITH_AN_ACTIVE_ACTIVE_SUBSCRIPTION",
+              "PRIVATE_LINK_GET_AN_ACTIVE_ACTIVE_SUBSCRIPTION_PRIVATE_LINK_IS_NOT_ALLOWED_WITH_A_SINGLE_REGION_SUBSCRIPTION",
+              "PRIVATE_LINK_CREATING_PRINCIPLES_IS_NOT_ALLOWED_WITH_AN_ACTIVE_ACTIVE_SUBSCRIPTION",
+              "PRIVATE_LINK_CREATING_PRINCIPLES_IS_NOT_ALLOWED_WITH_A_SINGLE_REGION_SUBSCRIPTION",
+              "PRIVATE_LINK_DELETING_A_FLEXIBLE_SUBSCRIPTION_PRINCIPALS_IS_NOT_ALLOWED_WITH_AN_ACTIVE_ACTIVE_SUBSCRIPTION",
+              "PRIVATE_LINK_DELETING_AN_ACTIVE_ACTIVE_SUBSCRIPTION_PRINCIPALS_IS_NOT_ALLOWED_WITH_A_SINGLE_REGION_SUBSCRIPTION",
+              "PRIVATE_LINK_CREATE_A_FLEXIBLE_SUBSCRIPTION_PRIVATE_LINK_IS_NOT_ALLOWED_WITH_AN_ACTIVE_ACTIVE_SUBSCRIPTION",
+              "PRIVATE_LINK_CREATE_AN_ACTIVE_ACTIVE_SUBSCRIPTION_PRIVATE_LINK_IS_NOT_ALLOWED_WITH_A_SINGLE_REGION_SUBSCRIPTION",
+              "PRIVATE_LINK_DELETING_A_FLEXIBLE_SUBSCRIPTION_PRIVATE_LINK_IS_NOT_ALLOWED_WITH_AN_ACTIVE_ACTIVE_SUBSCRIPTION",
+              "PRIVATE_LINK_DELETING_AN_ACTIVE_ACTIVE_SUBSCRIPTION_PRIVATE_LINK_IS_NOT_ALLOWED_WITH_A_SINGLE_REGION_SUBSCRIPTION",
+              "PRIVATE_LINK_IS_NOT_SUPPORTED",
+              "PRIVATE_LINK_SERVICE_ERROR",
+              "PRIVATE_LINK_SUBSCRIPTION_REACHED_MAX_DATABASES_COUNT",
+              "PRIVATE_LINK_ALL_PRINCIPALS_MUST_BE_DELETED_BEFORE_DELETING_RESOURCE_LINK",
+              "PRIVATE_LINK_DISASSOCIATE_CONNECTIONS_A_FLEXIBLE_SUBSCRIPTION_PRIVATE_LINK_IS_NOT_ALLOWED_WITH_AN_ACTIVE_ACTIVE_SUBSCRIPTION",
+              "PRIVATE_LINK_DISASSOCIATE_CONNECTIONS_AN_ACTIVE_ACTIVE_SUBSCRIPTION_PRIVATE_LINK_IS_NOT_ALLOWED_WITH_A_SINGLE_REGION_SUBSCRIPTION",
+              "COST_REPORT_IS_NOT_SUPPORTED",
+              "COST_REPORT_START_DATE_IS_MISSING",
+              "COST_REPORT_END_DATE_IS_MISSING",
+              "COST_REPORT_INVALID_DATE_FORMAT",
+              "COST_REPORT_END_DATE_BEFORE_START_DATE",
+              "COST_REPORT_DATE_RANGE_EXCEEDS_LIMIT",
+              "COST_REPORT_TAG_KEY_EMPTY",
+              "COST_REPORT_TAG_VALUE_EMPTY",
+              "COST_REPORT_FUTURE_DATES_NOT_ALLOWED"
             ]
           },
           "additionalInfo": {
@@ -14833,7 +17420,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           },
@@ -14943,6 +17530,20 @@
         },
         "description": "Database backup request message"
       },
+      "ReplicaAsSourceEndpoints": {
+        "type": "object",
+        "properties": {
+          "public": {
+            "type": "string",
+            "description": "Public cluster endpoint that can be used as source for replication"
+          },
+          "private": {
+            "type": "string",
+            "description": "Private cluster endpoint that can be used as source for replication"
+          }
+        },
+        "description": "Endpoints to use when configuring another database to replicate from this database (Make sure to use this instead of the dynamic endpoints)."
+      },
       "DataPersistenceOptions": {
         "type": "object",
         "properties": {
@@ -14957,7 +17558,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -15232,7 +17833,7 @@
           },
           "paymentMethod": {
             "type": "string",
-            "description": "Optional. The payment method for the subscription. If set to ‘credit-card’, ‘paymentMethodId’ must be defined. Default: 'credit-card'",
+            "description": "Optional. The payment method for the subscription. If set to \u2018credit-card\u2019, \u2018paymentMethodId\u2019 must be defined. Default: 'credit-card'",
             "enum": [
               "credit-card",
               "marketplace"
@@ -15240,7 +17841,7 @@
           },
           "paymentMethodId": {
             "type": "integer",
-            "description": "Optional. A valid payment method ID for this account. Use GET /payment-methods to get a list of all payment methods for your account. This value is optional if ‘paymentMethod’ is ‘marketplace’, but required for all other account types.",
+            "description": "Optional. A valid payment method ID for this account. Use GET /payment-methods to get a list of all payment methods for your account. This value is optional if \u2018paymentMethod\u2019 is \u2018marketplace\u2019, but required for all other account types.",
             "format": "int32"
           },
           "memoryStorage": {
@@ -15254,12 +17855,15 @@
           },
           "persistentStorageEncryptionType": {
             "type": "string",
-            "description": "Optional. Persistent storage encryption secures data-at-rest for database persistence. You can use 'cloud-provider-managed-key' or 'customer-managed-key'.  Default: 'cloud-provider-managed-key'",
+            "description": "Optional. Persistent storage encryption secures data at rest for database persistence. By default, disk storage is encrypted by keys managed by the cloud provider. Use 'customer-managed-key' if you want to use self-managed persistent storage encryption keys. Default: 'cloud-provider-managed-key'",
             "example": "cloud-provider-managed-key",
             "enum": [
               "cloud-provider-managed-key",
               "customer-managed-key"
             ]
+          },
+          "persistentStorageEncryptionKeys": {
+            "$ref": "#/components/schemas/CustomerManagedKeyProperties"
           },
           "cloudProviders": {
             "type": "array",
@@ -15280,6 +17884,10 @@
             "description": "Optional. Defines the Redis version of the databases created in this specific request. It doesn't determine future databases associated with this subscription. If not set, databases will use the default Redis version. This field is deprecated and will be removed in a future API version - use the database-level redisVersion property instead.",
             "example": "7.2",
             "deprecated": true
+          },
+          "publicEndpointAccess": {
+            "type": "boolean",
+            "description": "Optional. When 'false', all databases on this subscription will reject any connection attempt to the public endpoint and any connection attempt to the private endpoint that does not come from an IP address in the private address space defined in [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918#section-3 ). You must use a [private connectivity method](https://redis.io/docs/latest/operate/rc/security/database-security/block-public-endpoints/#private-connectivity-methods ) to connect to a database with a blocked public endpoint. Default: 'true'."
           },
           "commandType": {
             "type": "string",
@@ -15350,6 +17958,56 @@
         },
         "description": "Cloud Account definition"
       },
+      "PrivateLinkCreateRequest": {
+        "required": [
+          "principal",
+          "shareName",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "shareName": {
+            "maxLength": 64,
+            "minLength": 0,
+            "type": "string",
+            "description": "Name of the resource share",
+            "example": "my-redis-share"
+          },
+          "principal": {
+            "type": "string",
+            "description": "AWS account ID or ARN of the principal (IAM user, role, or account)",
+            "example": "123456789012"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the principal",
+            "example": "aws_account",
+            "enum": [
+              "aws_account",
+              "organization",
+              "organization_unit",
+              "iam_role",
+              "iam_user",
+              "service_principal"
+            ]
+          },
+          "alias": {
+            "type": "string",
+            "description": "Alias or friendly name for the principal",
+            "example": "Production Account"
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Private Link create request"
+      },
       "SubscriptionPricings": {
         "type": "object",
         "properties": {
@@ -15407,6 +18065,36 @@
           }
         },
         "description": "Optional. Changes Replica Of (also known as Active-Passive) configuration details."
+      },
+      "PrivateLinkActiveActivePrincipalsDeleteRequest": {
+        "required": [
+          "principal",
+          "regionId"
+        ],
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "regionId": {
+            "type": "integer",
+            "description": "Deployment region id as defined by cloud provider",
+            "format": "int32",
+            "readOnly": true
+          },
+          "principal": {
+            "type": "string",
+            "description": "An AWS account ID or ARN to remove from the private link",
+            "example": "123456789012"
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Request to remove principals from private link for Active-Active subscription"
       },
       "DatabaseThroughputSpec": {
         "required": [
@@ -15535,9 +18223,11 @@
             "enum": [
               "allkeys-lru",
               "allkeys-lfu",
+              "allkeys-lrm",
               "allkeys-random",
               "volatile-lru",
               "volatile-lfu",
+              "volatile-lrm",
               "volatile-random",
               "volatile-ttl",
               "noeviction"
@@ -15560,12 +18250,15 @@
           "dynamicEndpoints": {
             "$ref": "#/components/schemas/DynamicEndpoints"
           },
+          "replicaAsSourceEndpoints": {
+            "$ref": "#/components/schemas/ReplicaAsSourceEndpoints"
+          },
           "links": {
             "type": "array",
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "object"
+                "type": "string"
               }
             }
           }
@@ -15734,20 +18427,17 @@
         "properties": {
           "resourceName": {
             "type": "string",
-            "description": "Required. Resource name of the customer managed key as defined by the cloud provider.",
+            "description": "The resource name of the customer managed key.",
             "example": "projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY_NAME"
           },
           "region": {
             "type": "string",
-            "description": "Name of region to for the customer managed key as defined by the cloud provider. Required for active-active subscriptions."
+            "description": "(Required for Active-Active subscriptions only) Region for the customer managed key as defined by the cloud provider."
           }
         },
         "description": "Object representing a customer managed key (CMK), along with the region it is associated to."
       },
       "ActiveActiveRegionCreateRequest": {
-        "required": [
-          "deploymentCIDR"
-        ],
         "type": "object",
         "properties": {
           "subscriptionId": {
@@ -15768,6 +18458,29 @@
             "type": "string",
             "description": "Deployment CIDR mask. Must be a valid CIDR format with a range of 256 IP addresses.",
             "example": "10.0.0.0/24"
+          },
+          "subnetIds": {
+            "type": "array",
+            "description": "Optional. Enter a list of subnets identifiers that exists in the hosted AWS account. Subnet Identifier must exist within the hosting account.",
+            "example": "['subnet-0125be68a4625884ad', 'subnet-0125be68a4625884ad','subnet-0125be68a4625884ad']",
+            "items": {
+              "type": "string",
+              "description": "Optional. Enter a list of subnets identifiers that exists in the hosted AWS account. Subnet Identifier must exist within the hosting account.",
+              "example": "['subnet-0125be68a4625884ad', 'subnet-0125be68a4625884ad','subnet-0125be68a4625884ad']"
+            }
+          },
+          "securityGroupId": {
+            "type": "string",
+            "description": "Optional. Enter a security group identifier that exists in the hosted AWS account. Security group Identifier must be in a valid format (for example: 'sg-0125be68a4625884ad') and must exist within the hosting account.",
+            "example": "sg-0125be68a4625884ad"
+          },
+          "preferredAvailabilityZones": {
+            "type": "array",
+            "description": "Optional. List the zone IDs for your preferred availability zones for the cloud provider and region.",
+            "items": {
+              "type": "string",
+              "description": "Optional. List the zone IDs for your preferred availability zones for the cloud provider and region."
+            }
           },
           "dryRun": {
             "type": "boolean",
@@ -15793,7 +18506,7 @@
           },
           "customerManagedKeyResourceName": {
             "type": "string",
-            "description": "Optional. Resource name of the customer managed key as defined by the cloud provider for customer managed subscriptions.",
+            "description": "Required for subscriptions where 'persistentStorageEncryptionType' is 'customer-managed-key'. The resource name of the customer-managed encryption key for the region.",
             "example": "projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY_NAME"
           },
           "commandType": {
@@ -15848,6 +18561,61 @@
         },
         "description": "Database import request"
       },
+      "PrivateLinkPrincipalsDeleteRequest": {
+        "required": [
+          "principal"
+        ],
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "principal": {
+            "type": "string",
+            "description": "An AWS account ID or ARN to remove from the private link",
+            "example": "123456789012"
+          },
+          "commandType": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "description": "Private Link principals delete request"
+      },
+      "CustomerManagedKeyProperties": {
+        "required": [
+          "customerManagedKeys"
+        ],
+        "type": "object",
+        "properties": {
+          "customerManagedKeys": {
+            "type": "array",
+            "description": "The customer managed keys (CMK) to use for this subscription. If is active-active subscription, must set a key for each region.",
+            "items": {
+              "$ref": "#/components/schemas/CustomerManagedKey"
+            }
+          },
+          "deletionGracePeriod": {
+            "type": "string",
+            "description": "Optional. The grace period for deleting the subscription if Redis cannot access the provided key. Required when applying customer managed keys for a new subscription.",
+            "example": "alerts-only",
+            "enum": [
+              "alerts-only",
+              "immediate",
+              "15-minutes",
+              "30-minutes",
+              "1-hour",
+              "4-hours",
+              "8-hours",
+              "12-hours",
+              "24-hours"
+            ]
+          }
+        },
+        "description": "Optional. Contains information about the keys used for each region. Can be used only with external cloud account"
+      },
       "VpcPeeringCreateBaseRequest": {
         "type": "object",
         "properties": {
@@ -15879,6 +18647,11 @@
       "x-api-secret-key": {
         "type": "apiKey",
         "name": "x-api-secret-key",
+        "in": "header"
+      },
+      "x-auth-token": {
+        "type": "apiKey",
+        "name": "x-auth-token",
         "in": "header"
       }
     }

--- a/tests/openapi_validation.rs
+++ b/tests/openapi_validation.rs
@@ -36,11 +36,13 @@ fn test_all_endpoints_documented() {
         }
     }
 
-    // The OpenAPI spec in our repo has 130 endpoints
-    // (Note: The spec we analyzed from redis.io had 140, but this is the version we have)
+    // The bundled fixture currently exposes 155 operations across 93 paths
+    // (matches upstream `https://api.redislabs.com/v1/cloud-api-docs` as of
+    // the last refresh; see #69). Use a floor so future refreshes that add
+    // endpoints don't break this gate.
     assert!(
-        endpoint_count >= 130,
-        "Expected at least 130 endpoints in OpenAPI spec, found {}",
+        endpoint_count >= 150,
+        "Expected at least 150 endpoints in OpenAPI spec, found {}",
         endpoint_count
     );
 }


### PR DESCRIPTION
## Summary

Re-fetched `tests/fixtures/cloud_openapi.json` from `https://api.redislabs.com/v1/cloud-api-docs` (the URL [#40](https://github.com/redis-developer/redis-cloud-rs/issues/40) cites as the authoritative source).

| | Old | New | Δ |
|---|---|---|---|
| Paths | 75 | 93 | **+18** |
| Schemas | 119 | 138 | +19 |
| Operations | 130 | 155 | +25 |

**Zero removals or renames** — the refresh is purely additive.

## What's new in the fixture

| Category | Paths |
|---|---|
| `cost-report` (already implemented) | `/cost-report`, `/cost-report/{costReportId}` |
| Pro database lifecycle | `/traffic`, `/traffic/resume`, `/upgrade`, `/available-target-versions` |
| Fixed database lifecycle | same set on `/fixed/...` |
| Private Link (per-subscription) | 4 endpoints under `/subscriptions/{id}/private-link` |
| Private Link (per-region) | 4 endpoints under `/subscriptions/{id}/regions/{regionId}/private-link` |
| Resource tags | `/subscriptions/{id}/resource-tags` |

## Drive-by

Nudged `tests/openapi_validation.rs::test_all_endpoints_documented` floor from 130 → 150 and rewrote the comment that referenced "the spec we analyzed from redis.io had 140" (the live spec now has 155). The assertion remains a floor so additive refreshes don't break it.

## Why now

Two open issues depend on a fresh fixture:

- [#67](https://github.com/redis-developer/redis-cloud-rs/issues/67) — executable route-coverage check needs an authoritative spec to test against
- [#72](https://github.com/redis-developer/redis-cloud-rs/issues/72) — reconciliation between typed handlers and the spec. The previously-quoted "29 spec ops without handler, 22 handlers without spec path" numbers will shift now that the spec has caught up

Closes #69.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all 72 doctests + every integration suite green; the new fixture is purely additive