### PR TITLE
chore(python): sync python crate version to 0.9.5

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.8.0"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud-py"
-version = "0.1.0"
+version = "0.9.5"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud-py"
-version = "0.9.3"
+version = "0.9.5"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]


### PR DESCRIPTION
## What

Sync the `python/` binding crate to **0.9.5**, matching the root Rust crate.

- `python/Cargo.toml`: `0.9.3 → 0.9.5`
- `python/Cargo.lock`: local-crate entries `redis-cloud 0.8.0 → 0.9.5`, `redis-cloud-py 0.1.0 → 0.9.5`

## Why

`python/` lives outside the root workspace and is `publish = false`, so release-plz never sees it — its version and lockfile drift every time the Rust crate is released.

## Scope

Deliberately minimal: **only the version strings change.** An initial `cargo update --workspace` pass churned ~30 unrelated crates (reqwest 0.12→0.13, ring→aws-lc-rs, jni, …) — reverted, since that overlaps with the separate reqwest migration in #48 and isn't buildable/testable here.

## Follow-up (not in this PR)

- When the pending 0.10.0 release (#84) lands, the python crate must follow to 0.10.0.
- Permanent fix for the drift: a CI version-parity check, or pull `python/` into the root workspace so release-plz tracks it.

Closes #68