### PR TITLE
fix(tasks): accept object-shaped response.error on failed tasks

### DIFF
--- a/src/testing/fixtures.rs
+++ b/src/testing/fixtures.rs
@@ -237,7 +237,7 @@ pub struct TaskFixture {
     status: String,
     description: Option<String>,
     resource_id: Option<i32>,
-    error: Option<String>,
+    error: Option<Value>,
 }
 
 impl TaskFixture {
@@ -273,7 +273,7 @@ impl TaskFixture {
             status: "processing-error".to_string(),
             description: Some("Task failed".to_string()),
             resource_id: None,
-            error: Some(error.into()),
+            error: Some(Value::String(error.into())),
         }
     }
 
@@ -303,7 +303,14 @@ impl TaskFixture {
 
     /// Set an error message
     pub fn error(mut self, error: impl Into<String>) -> Self {
-        self.error = Some(error.into());
+        self.error = Some(Value::String(error.into()));
+        self
+    }
+
+    /// Set a structured error object, mirroring the shape Redis Cloud returns
+    /// for some task failures (e.g. `{"type", "status", "description"}`).
+    pub fn error_object(mut self, error: Value) -> Self {
+        self.error = Some(error);
         self
     }
 
@@ -326,7 +333,7 @@ impl TaskFixture {
             response["resourceId"] = json!(rid);
         }
         if let Some(err) = self.error {
-            response["error"] = json!(err);
+            response["error"] = err;
         }
         if !response.as_object().unwrap().is_empty() {
             task["response"] = response;

--- a/src/types.rs
+++ b/src/types.rs
@@ -108,13 +108,41 @@ pub struct ProcessorResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource: Option<std::collections::HashMap<String, Value>>,
 
-    /// Error message, populated only when the task failed.
+    /// Error detail, populated only when the task failed.
+    ///
+    /// The Redis Cloud API returns this in two shapes depending on the
+    /// failure: sometimes a plain string, and sometimes a structured object
+    /// (e.g. `{"type": ..., "status": ..., "description": ...}`). It is kept
+    /// as a [`Value`] so both deserialize cleanly; use
+    /// [`ProcessorResponse::error_message`] to extract a human-readable string.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub error: Option<Value>,
 
     /// Free-form additional context attached by the processor.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_info: Option<String>,
+}
+
+impl ProcessorResponse {
+    /// Extract a human-readable error message from [`Self::error`], regardless
+    /// of whether the server returned a plain string or a structured object.
+    ///
+    /// For the object shape, prefers the `description`, then `message`, then
+    /// `error` keys; falls back to the compact JSON encoding if none are
+    /// present. Returns `None` when no error is set.
+    pub fn error_message(&self) -> Option<String> {
+        let error = self.error.as_ref()?;
+        match error {
+            Value::String(s) => Some(s.clone()),
+            Value::Object(map) => {
+                let field = ["description", "message", "error"]
+                    .iter()
+                    .find_map(|key| map.get(*key).and_then(Value::as_str));
+                Some(field.map_or_else(|| error.to_string(), str::to_string))
+            }
+            other => Some(other.to_string()),
+        }
+    }
 }
 
 /// Coarse subset of Redis Cloud's processor error codes.

--- a/tests/acl_tests.rs
+++ b/tests/acl_tests.rs
@@ -690,7 +690,7 @@ async fn test_task_state_update_with_error() {
     assert!(result.response.is_some());
 
     let response = result.response.unwrap();
-    assert_eq!(response.error, Some("Invalid rule pattern".to_string()));
+    assert_eq!(response.error, Some(json!("Invalid rule pattern")));
     assert_eq!(
         response.additional_info,
         Some("Rule pattern '+invalid' is not valid".to_string())

--- a/tests/cloud_accounts_tests.rs
+++ b/tests/cloud_accounts_tests.rs
@@ -650,7 +650,7 @@ async fn test_task_state_update_with_failed_status() {
     assert!(result.response.is_some());
 
     let response = result.response.unwrap();
-    assert_eq!(response.error, Some("Invalid credentials".to_string()));
+    assert_eq!(response.error, Some(json!("Invalid credentials")));
     assert_eq!(
         response.additional_info,
         Some("Access key validation failed".to_string())

--- a/tests/tasks_tests.rs
+++ b/tests/tasks_tests.rs
@@ -254,6 +254,53 @@ async fn test_get_task_by_id_failed() {
     assert!(result.response.is_some());
 }
 
+// Regression: some task failures return `response.error` as a structured
+// object rather than a string (e.g. a failed `database backup`). Previously
+// `ProcessorResponse.error` was typed `Option<String>`, so deserializing the
+// task poll response blew up with "invalid type: map, expected a string",
+// masking the real failure. The field is now `Option<Value>`.
+#[tokio::test]
+async fn test_get_task_by_id_failed_with_error_object() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/tasks/task-backup"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-backup",
+            "commandType": "DATABASE_BACKUP",
+            "status": "processing-error",
+            "description": "Failed to backup database",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "response": {
+                "error": {
+                    "type": "BACKUP_FAILED",
+                    "status": "400 BAD_REQUEST",
+                    "description": "Remote backup location is not configured"
+                }
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = TasksHandler::new(test_client(mock_server.uri()));
+    // Must not panic on deserialization.
+    let result = handler
+        .get_task_by_id("task-backup".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(result.status, Some("processing-error".to_string()));
+    let response = result.response.expect("response present");
+    // The structured object is preserved and a readable message is extracted.
+    assert!(response.error.as_ref().unwrap().is_object());
+    assert_eq!(
+        response.error_message().as_deref(),
+        Some("Remote backup location is not configured")
+    );
+}
+
 #[tokio::test]
 async fn test_error_handling_401() {
     let mock_server = MockServer::start().await;

--- a/tests/types_tests.rs
+++ b/tests/types_tests.rs
@@ -45,7 +45,7 @@ fn test_processor_response_with_error() {
         resource_id: None,
         additional_resource_id: None,
         resource: None,
-        error: Some("UNAUTHORIZED".to_string()),
+        error: Some(json!("UNAUTHORIZED")),
         additional_info: None,
     };
 
@@ -53,7 +53,27 @@ fn test_processor_response_with_error() {
     assert!(json_str.contains("\"UNAUTHORIZED\""));
 
     let parsed: ProcessorResponse = serde_json::from_str(&json_str).unwrap();
-    assert_eq!(parsed.error, Some("UNAUTHORIZED".to_string()));
+    assert_eq!(parsed.error, Some(json!("UNAUTHORIZED")));
+    assert_eq!(parsed.error_message().as_deref(), Some("UNAUTHORIZED"));
+}
+
+#[test]
+fn test_processor_response_with_error_object() {
+    // The Cloud API returns a structured error object on some task failures.
+    let parsed: ProcessorResponse = serde_json::from_value(json!({
+        "error": {
+            "type": "BACKUP_FAILED",
+            "status": "400 BAD_REQUEST",
+            "description": "Remote backup location is not configured"
+        }
+    }))
+    .unwrap();
+
+    assert!(parsed.error.as_ref().unwrap().is_object());
+    assert_eq!(
+        parsed.error_message().as_deref(),
+        Some("Remote backup location is not configured")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Some task failures (e.g. a failed `database backup`) return `response.error` as a **structured object** — `{type, status, description}` — rather than a plain string. `ProcessorResponse.error` was typed `Option<String>`, so deserializing the task poll response failed with:

```
Failed to deserialize field 'response.error': invalid type: map, expected a string
```

This masked the real failure entirely. Surfaced via `redisctl cloud database backup <id> --wait`, where the error was reported (misleadingly) as a "Connection error".

## Fix

- Type `ProcessorResponse.error` as `Option<Value>` so both the string and object shapes deserialize cleanly.
- Add `ProcessorResponse::error_message()` to extract a human-readable string from either form (prefers `description` → `message` → `error` keys on the object; falls back to the JSON encoding).

## Tests

- `tasks_tests::test_get_task_by_id_failed_with_error_object` — reproduces the exact object-shaped failure (would panic before this change).
- `types_tests::test_processor_response_with_error_object` — round-trip + `error_message()` extraction.
- Updated existing tests/fixtures for the new field type.

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and the full test suite all pass.