### PR TITLE
refactor(types): consolidate shared task/tag models onto canonical types (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** consolidated shared task and tag models onto canonical types in
+  `crate::types` ([#64](https://github.com/redis-developer/redis-cloud-rs/issues/64)).
+  The per-module `TaskStateUpdate` copies (in `tasks`, `users`, `cloud_accounts`,
+  `acl`, `flexible::{subscriptions,databases}`, `fixed::{subscriptions,databases}`)
+  are now re-exports of `types::TaskStateUpdate`.
+  - `TaskStateUpdate::status` is now the typed `Option<TaskStatus>` enum instead
+    of `Option<String>`. Unrecognized wire values deserialize to
+    `TaskStatus::Unknown` rather than failing. `TaskStateUpdate` also gains a
+    `progress: Option<f64>` field.
+  - `types::CloudTag` and `types::CloudTags` now match the wire shapes the
+    database tag endpoints actually return (`CloudTag` carries
+    `created_at`/`updated_at`/`links`; `CloudTags` is the `account_id`/`links`
+    HATEOAS envelope). The key/value request pair is now `types::Tag`.
+    `flexible::databases` and `fixed::databases` re-export these.
+
 ## [0.9.5](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.4...v0.9.5) - 2026-02-06
 
 ### Fixed

--- a/examples/cost_report.rs
+++ b/examples/cost_report.rs
@@ -19,6 +19,7 @@
 
 use redis_cloud::CloudClient;
 use redis_cloud::cost_report::CostReportCreateRequest;
+use redis_cloud::types::TaskStatus;
 use std::time::Duration;
 
 #[tokio::main]
@@ -54,8 +55,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tokio::time::sleep(Duration::from_secs(5)).await;
         let state = client.tasks().get_task_by_id(task_id.clone()).await?;
         println!("  status={:?} progress={:?}", state.status, state.progress);
-        match state.status.as_deref() {
-            Some("completed") => {
+        match state.status {
+            Some(TaskStatus::ProcessingCompleted) => {
                 // ProcessorResponse shape varies; raw JSON is the safest read.
                 let raw = serde_json::to_value(&state.response)?;
                 break raw
@@ -69,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     })
                     .ok_or("task completed but did not return a costReportId")?;
             }
-            Some("failed") | Some("error") => {
+            Some(TaskStatus::ProcessingError) => {
                 return Err(format!(
                     "task ended with status {:?}: {}",
                     state.status,

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -14,6 +14,7 @@
 //! Pass `--watch` after the task id to poll every 5 seconds until the task
 //! reaches a terminal state.
 
+use redis_cloud::types::TaskStatus;
 use redis_cloud::{CloudClient, CloudError};
 
 #[tokio::main]
@@ -44,8 +45,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("  {desc}");
                 }
                 let terminal = matches!(
-                    task.status.as_deref(),
-                    Some("completed") | Some("failed") | Some("error")
+                    task.status,
+                    Some(TaskStatus::ProcessingCompleted | TaskStatus::ProcessingError)
                 );
                 if !watch || terminal {
                     break;

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -40,7 +40,8 @@
 //! # }
 //! ```
 
-use crate::types::{Link, ProcessorResponse};
+use crate::types::Link;
+pub use crate::types::TaskStateUpdate;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 
@@ -374,39 +375,6 @@ pub struct AclRoleRedisRuleSpec {
 
     /// A list of databases where the specified rule applies for this role.
     pub databases: Vec<AclRoleDatabaseSpec>,
-}
-
-/// Task state update response
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TaskStateUpdate {
-    /// Task ID (UUID)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
-
-    /// Command type (e.g., "subscriptionDeleteRequest")
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-
-    /// Task status (e.g., "processing-completed")
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
-
-    /// Task description
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// Timestamp of the task
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<String>,
-
-    /// Task response with resource info
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response: Option<ProcessorResponse>,
-
-    /// HATEOAS links
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
 }
 
 // ============================================================================

--- a/src/cloud_accounts.rs
+++ b/src/cloud_accounts.rs
@@ -53,7 +53,8 @@
 //! # }
 //! ```
 
-use crate::types::{Link, ProcessorResponse};
+use crate::types::Link;
+pub use crate::types::TaskStateUpdate;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 
@@ -195,39 +196,6 @@ pub struct CloudAccounts {
     pub cloud_accounts: Option<Vec<CloudAccount>>,
 
     /// HATEOAS links for API navigation
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
-}
-
-/// Task state update response
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TaskStateUpdate {
-    /// Task ID (UUID)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
-
-    /// Command type
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-
-    /// Task status
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
-
-    /// Task description
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// Timestamp
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<String>,
-
-    /// Task response with resource info
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response: Option<ProcessorResponse>,
-
-    /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Vec<Link>>,
 }

--- a/src/fixed/databases.rs
+++ b/src/fixed/databases.rs
@@ -45,7 +45,8 @@
 //! # }
 //! ```
 
-use crate::types::{Link, ProcessorResponse};
+use crate::types::Link;
+pub use crate::types::{CloudTag, CloudTags, Tag, TaskStateUpdate};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -165,22 +166,6 @@ pub struct DynamicEndpoints {
     pub private: Option<String>,
 }
 
-/// Database tag
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Tag {
-    /// Database tag key.
-    pub key: String,
-
-    /// Database tag value.
-    pub value: String,
-
-    /// Read-only on the response; populated by the server with the
-    /// operation type (e.g. `"CREATE_DATABASE_TAG"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-}
-
 /// Database tags update request message
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -224,31 +209,6 @@ pub struct DatabaseSyncSourceSpec {
 pub struct DatabaseCertificateSpec {
     /// Client certificate public key in PEM format, with new line characters replaced with '\n'.
     pub public_certificate_pem_string: String,
-}
-
-/// Database tag
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CloudTag {
-    /// Database tag key.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub key: Option<String>,
-
-    /// Database tag value.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>,
-
-    /// Timestamp when the tag was created.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub created_at: Option<String>,
-
-    /// Timestamp when the tag was last updated.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<String>,
-
-    /// HATEOAS links
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
 }
 
 /// Database slowlog entry
@@ -371,19 +331,6 @@ pub struct DatabaseAlertSpec {
 
     /// Value over which an alert will be sent. Default values and range depend on the alert type. See [Configure alerts](https://redis.io/docs/latest/operate/rc/databases/monitor-performance/#configure-metric-alerts) for more information.
     pub value: i32,
-}
-
-/// Redis list of database tags
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CloudTags {
-    /// Account ID owning the tags.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_id: Option<i32>,
-
-    /// HATEOAS links
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
 }
 
 /// `FixedDatabase`
@@ -565,40 +512,6 @@ pub struct DatabaseSlowLogEntries {
     /// Slowlog entries returned for the database.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entries: Option<Vec<DatabaseSlowLogEntry>>,
-
-    /// HATEOAS links
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
-}
-
-/// `TaskStateUpdate`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TaskStateUpdate {
-    /// Task identifier.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
-
-    /// Read-only on the response; populated by the server with the
-    /// operation type (e.g. `"CREATE_DATABASE"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-
-    /// Current task status (e.g. `"processing-in-progress"`, `"processing-completed"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
-
-    /// Human-readable description of the current task state.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// Timestamp of the latest task state update.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<String>,
-
-    /// Task response payload from the processor.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response: Option<ProcessorResponse>,
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/fixed/subscriptions.rs
+++ b/src/fixed/subscriptions.rs
@@ -49,7 +49,8 @@
 //! # }
 //! ```
 
-use crate::types::{Link, ProcessorResponse};
+use crate::types::Link;
+pub use crate::types::TaskStateUpdate;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
@@ -414,40 +415,6 @@ pub struct FixedSubscription {
     /// Aggregate status of databases in this subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_status: Option<String>,
-
-    /// HATEOAS links
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
-}
-
-/// `TaskStateUpdate`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TaskStateUpdate {
-    /// Task identifier.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
-
-    /// Read-only on the response; populated by the server with the
-    /// operation type (e.g. `"CREATE_FIXED_SUBSCRIPTION"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-
-    /// Current task status (e.g. `"processing-in-progress"`, `"processing-completed"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
-
-    /// Human-readable description of the current task state.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// Timestamp of the latest task state update.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<String>,
-
-    /// Task response payload from the processor.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response: Option<ProcessorResponse>,
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -51,7 +51,8 @@
 //! # }
 //! ```
 
-use crate::types::{Link, ProcessorResponse};
+use crate::types::Link;
+pub use crate::types::{CloudTag, CloudTags, Tag, TaskStateUpdate};
 use crate::{CloudClient, Result};
 use async_stream::try_stream;
 use futures_core::Stream;
@@ -173,22 +174,6 @@ pub struct DatabaseTagUpdateRequest {
     pub command_type: Option<String>,
 }
 
-/// Database tag
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Tag {
-    /// Database tag key.
-    pub key: String,
-
-    /// Database tag value.
-    pub value: String,
-
-    /// Read-only on the response; populated by the server with the
-    /// operation type (e.g. `"CREATE_DATABASE_TAG"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-}
-
 /// Active-Active database flush request message
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -259,31 +244,6 @@ pub struct DatabaseSyncSourceSpec {
 pub struct DatabaseCertificateSpec {
     /// Client certificate public key in PEM format, with new line characters replaced with '\n'.
     pub public_certificate_pem_string: String,
-}
-
-/// Database tag
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CloudTag {
-    /// Database tag key.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub key: Option<String>,
-
-    /// Database tag value.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>,
-
-    /// Timestamp when the tag was created.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub created_at: Option<String>,
-
-    /// Timestamp when the tag was last updated.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<String>,
-
-    /// HATEOAS links
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
 }
 
 /// `BdbVersionUpgradeStatus`
@@ -1216,19 +1176,6 @@ pub struct DatabaseImportRequest {
     pub command_type: Option<String>,
 }
 
-/// Redis list of database tags
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CloudTags {
-    /// Account ID owning the tags.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_id: Option<i32>,
-
-    /// HATEOAS links
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
-}
-
 /// Upgrades the specified Pro database to a later Redis version.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -1297,40 +1244,6 @@ pub struct LocalRegionProperties {
     /// Optional. Redis Serialization Protocol version for this region. Must be compatible with Redis version.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resp_version: Option<String>,
-}
-
-/// `TaskStateUpdate`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TaskStateUpdate {
-    /// Task identifier.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
-
-    /// Read-only on the response; populated by the server with the
-    /// operation type (e.g. `"CREATE_DATABASE"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-
-    /// Current task status (e.g. `"processing-in-progress"`, `"processing-completed"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
-
-    /// Human-readable description of the current task state.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// Timestamp of the latest task state update.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<String>,
-
-    /// Task response payload from the processor.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response: Option<ProcessorResponse>,
-
-    /// HATEOAS links
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
 }
 
 /// Database update request

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -51,7 +51,8 @@
 //! # }
 //! ```
 
-use crate::types::{Link, ProcessorResponse};
+use crate::types::Link;
+pub use crate::types::TaskStateUpdate;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -841,40 +842,6 @@ pub struct ActiveActiveRegionToDelete {
     /// Name of the cloud provider region to delete.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
-}
-
-/// `TaskStateUpdate`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TaskStateUpdate {
-    /// Task identifier.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
-
-    /// Read-only on the response; populated by the server with the
-    /// operation type (e.g. `"CREATE_SUBSCRIPTION"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-
-    /// Current task status (e.g. `"processing-in-progress"`, `"processing-completed"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
-
-    /// Human-readable description of the current task state.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// Timestamp of the latest task state update.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<String>,
-
-    /// Task response payload from the processor.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response: Option<ProcessorResponse>,
-
-    /// HATEOAS links
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
 }
 
 /// The cloud provider region or list of regions (Active-Active only) and networking details.

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -32,6 +32,7 @@
 //!
 //! ```no_run
 //! use redis_cloud::{CloudClient, TaskHandler};
+//! use redis_cloud::types::TaskStatus;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = CloudClient::builder()
@@ -45,7 +46,7 @@
 //! let task = handler.get_task_by_id("task-123".to_string()).await?;
 //!
 //! // Check if task is complete
-//! if task.status == Some("completed".to_string()) {
+//! if matches!(task.status, Some(TaskStatus::ProcessingCompleted)) {
 //!     println!("Task completed successfully");
 //!     if let Some(response) = task.response {
 //!         println!("Result: {:?}", response);
@@ -56,62 +57,12 @@
 //! ```
 
 use crate::error::CloudError;
-use crate::types::{Link, ProcessorResponse};
 use crate::{CloudClient, Result};
-use serde::{Deserialize, Serialize};
 
-// ============================================================================
-// Models
-// ============================================================================
-
-/// Wrapper response for `GET /tasks` per the OpenAPI spec (`TasksStateUpdate`).
-///
-/// Kept private because [`TasksHandler::get_all_tasks`] unwraps to the inner
-/// `Vec<TaskStateUpdate>` for caller ergonomics.
-#[derive(Debug, Clone, Deserialize)]
-struct TasksStateUpdate {
-    #[serde(default)]
-    tasks: Vec<TaskStateUpdate>,
-}
-
-/// Task state update
-///
-/// Represents the state and result of an asynchronous task
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TaskStateUpdate {
-    /// Unique task identifier
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
-
-    /// Type of command being executed (e.g., "`CREATE_DATABASE`", "`DELETE_SUBSCRIPTION`")
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-
-    /// Current task status (e.g., "processing", "completed", "failed")
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
-
-    /// Human-readable description of the task
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// Timestamp of last task update
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<String>,
-
-    /// Task completion percentage (0-100)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub progress: Option<f64>,
-
-    /// Result data once task is completed
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response: Option<ProcessorResponse>,
-
-    /// HATEOAS links for API navigation
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
-}
+// Canonical task models live in `crate::types` (#64). Re-exported here so the
+// historical `tasks::TaskStateUpdate` path keeps resolving.
+pub use crate::types::TaskStateUpdate;
+use crate::types::TasksStateUpdate;
 
 // ============================================================================
 // Handler

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,17 +10,18 @@
 //!   completion.
 //! - **HATEOAS navigation** — [`Link`] and [`Links`] capture the `links`
 //!   arrays the API returns alongside most resources.
-//! - **Tagging** — [`CloudTag`] and [`CloudTags`] model the key/value tag
-//!   pairs used for billing and resource filtering.
+//! - **Tagging** — [`Tag`] is the key/value pair used in request bodies;
+//!   [`CloudTag`] and [`CloudTags`] model the richer shapes the database tag
+//!   endpoints return.
 //! - **Common enums** — [`CloudProvider`], [`Protocol`],
 //!   [`DataPersistence`], [`SubscriptionStatus`], [`DatabaseStatus`] are
 //!   shared across the database, subscription, and connectivity modules.
 //! - **Generic wrappers** — [`PaginatedResponse`], [`EmptyResponse`],
 //!   [`ErrorResponse`] for cross-cutting response shapes.
 //!
-//! Consolidating these shared models into a single canonical location
-//! is the goal of #64 (currently several endpoint modules redefine their
-//! own copies of `TaskStateUpdate` and tag types).
+//! These models are the single canonical location for shared shapes (#64):
+//! endpoint modules import them rather than redefining their own copies of
+//! `TaskStateUpdate` and the tag types.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -59,6 +60,10 @@ pub struct TaskStateUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
 
+    /// Task completion percentage (0-100), when the processor reports it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress: Option<f64>,
+
     /// Result of the task once it has completed. See [`ProcessorResponse`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response: Option<ProcessorResponse>,
@@ -86,6 +91,14 @@ pub enum TaskStatus {
     ProcessingCompleted,
     /// Task failed during processing. See `response.error` for details.
     ProcessingError,
+    /// A status value not recognized by this client.
+    ///
+    /// The wire format is a free-form string and the server may introduce
+    /// new states; unknown values deserialize here rather than failing the
+    /// whole response. Note this variant does not round-trip — serializing it
+    /// emits `"unknown"`, not the original wire value.
+    #[serde(other)]
+    Unknown,
 }
 
 /// Result payload included on a completed [`TaskStateUpdate`].
@@ -178,6 +191,7 @@ pub enum ProcessorError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TasksStateUpdate {
     /// Tasks returned by the server.
+    #[serde(default)]
     pub tasks: Vec<TaskStateUpdate>,
 }
 
@@ -185,20 +199,68 @@ pub struct TasksStateUpdate {
 // Tag Types (Used in database and subscription endpoints)
 // ============================================================================
 
-/// Key-value tag attached to a database or subscription.
+/// Key-value tag used in create/update request bodies and embedded tag lists.
+///
+/// Matches the `Tag` schema (`key`/`value` required). `command_type` is a
+/// server-populated read-only field that appears on some responses; it is
+/// skipped on serialization when absent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CloudTag {
-    /// Tag name.
+#[serde(rename_all = "camelCase")]
+pub struct Tag {
+    /// Tag key.
     pub key: String,
+
     /// Tag value.
     pub value: String,
+
+    /// Read-only on the response; populated by the server with the
+    /// operation type (e.g. `"CREATE_DATABASE_TAG"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_type: Option<String>,
 }
 
-/// Collection wrapper for a list of [`CloudTag`].
+/// A single tag as returned by the database tag endpoints.
+///
+/// Matches the `CloudTag` schema: all fields optional, with creation/update
+/// timestamps and HATEOAS links alongside the key/value pair.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudTag {
+    /// Tag key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+
+    /// Tag value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+
+    /// Timestamp when the tag was created.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+
+    /// Timestamp when the tag was last updated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+
+    /// HATEOAS links.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
+}
+
+/// Collection wrapper returned by the database tags listing endpoints.
+///
+/// Matches the `CloudTags` schema, which is a HATEOAS envelope carrying the
+/// owning account ID and links rather than an inline tag array.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudTags {
-    /// Tags in the collection.
-    pub tags: Vec<CloudTag>,
+    /// Account ID owning the tags.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<i32>,
+
+    /// HATEOAS links.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
 }
 
 // ============================================================================

--- a/src/users.rs
+++ b/src/users.rs
@@ -49,7 +49,8 @@
 //! # }
 //! ```
 
-use crate::types::{Link, ProcessorResponse};
+use crate::types::Link;
+pub use crate::types::TaskStateUpdate;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 
@@ -113,42 +114,6 @@ pub struct AccountUserOptions {
     /// Whether multi-factor authentication is enabled for this user.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mfa_enabled: Option<bool>,
-}
-
-/// Task state update response for user operations.
-///
-/// Local copy duplicating [`crate::types::TaskStateUpdate`]. Consolidation
-/// onto the canonical type is tracked in #64.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TaskStateUpdate {
-    /// UUID of the task. Use with `TasksHandler::get_task_by_id` to poll.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
-
-    /// Type of command being executed (e.g. `"DELETE_ACCOUNT_USER"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-
-    /// Current task status (kebab-case, e.g. `"processing-completed"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
-
-    /// Human-readable description of the task.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// Timestamp of the last task update (ISO-8601).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<String>,
-
-    /// Result of the task once it has completed. See [`ProcessorResponse`].
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response: Option<ProcessorResponse>,
-
-    /// HATEOAS links
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<Vec<Link>>,
 }
 
 /// User information

--- a/tests/acl_tests.rs
+++ b/tests/acl_tests.rs
@@ -1,3 +1,4 @@
+use redis_cloud::types::TaskStatus;
 use redis_cloud::{AclHandler, CloudClient};
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
@@ -49,7 +50,7 @@ async fn test_create_redis_rule() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-123",
             "commandType": "CREATE_REDIS_RULE",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Creating Redis ACL rule",
             "timestamp": "2024-01-01T00:00:00Z",
             "response": {
@@ -75,7 +76,7 @@ async fn test_create_redis_rule() {
 
     let result = handler.create_redis_rule(&request).await.unwrap();
     assert_eq!(result.task_id, Some("task-123".to_string()));
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
 
 #[tokio::test]
@@ -222,7 +223,7 @@ async fn test_update_redis_rule() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-update-123",
             "commandType": "UPDATE_REDIS_RULE",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Updating Redis ACL rule",
             "timestamp": "2024-01-01T12:00:00Z"
         })))
@@ -247,7 +248,7 @@ async fn test_update_redis_rule() {
     let result = handler.update_redis_rule(123, &request).await.unwrap();
     assert_eq!(result.task_id, Some("task-update-123".to_string()));
     assert_eq!(result.command_type, Some("UPDATE_REDIS_RULE".to_string()));
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
 
 #[tokio::test]
@@ -261,7 +262,7 @@ async fn test_create_role() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-create-role-789",
             "commandType": "CREATE_ROLE",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Creating ACL role",
             "timestamp": "2024-01-01T13:00:00Z",
             "response": {
@@ -295,7 +296,7 @@ async fn test_create_role() {
     let result = handler.create_role(&request).await.unwrap();
     assert_eq!(result.task_id, Some("task-create-role-789".to_string()));
     assert_eq!(result.command_type, Some("CREATE_ROLE".to_string()));
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
 
 #[tokio::test]
@@ -309,7 +310,7 @@ async fn test_delete_acl_role() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-delete-role-456",
             "commandType": "DELETE_ROLE",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Deleting ACL role"
         })))
         .mount(&mock_server)
@@ -327,7 +328,7 @@ async fn test_delete_acl_role() {
 
     assert_eq!(result.task_id, Some("task-delete-role-456".to_string()));
     assert_eq!(result.command_type, Some("DELETE_ROLE".to_string()));
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
 
 #[tokio::test]
@@ -427,7 +428,7 @@ async fn test_delete_user() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-delete-user-789",
             "commandType": "DELETE_USER",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Deleting ACL user"
         })))
         .mount(&mock_server)
@@ -445,7 +446,7 @@ async fn test_delete_user() {
 
     assert_eq!(result.task_id, Some("task-delete-user-789".to_string()));
     assert_eq!(result.command_type, Some("DELETE_USER".to_string()));
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
 
 #[tokio::test]
@@ -459,7 +460,7 @@ async fn test_update_user() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-update-user-456",
             "commandType": "UPDATE_USER",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Updating ACL user",
             "timestamp": "2024-01-01T14:00:00Z"
         })))
@@ -484,7 +485,7 @@ async fn test_update_user() {
     let result = handler.update_acl_user(456, &request).await.unwrap();
     assert_eq!(result.task_id, Some("task-update-user-456".to_string()));
     assert_eq!(result.command_type, Some("UPDATE_USER".to_string()));
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
 
 #[tokio::test]
@@ -655,7 +656,7 @@ async fn test_task_state_update_with_error() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-error-123",
             "commandType": "CREATE_REDIS_RULE",
-            "status": "failed",
+            "status": "processing-error",
             "description": "Failed to create Redis ACL rule",
             "timestamp": "2024-01-01T15:00:00Z",
             "response": {
@@ -682,7 +683,7 @@ async fn test_task_state_update_with_error() {
 
     let result = handler.create_redis_rule(&request).await.unwrap();
     assert_eq!(result.task_id, Some("task-error-123".to_string()));
-    assert_eq!(result.status, Some("failed".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingError));
     assert_eq!(
         result.description,
         Some("Failed to create Redis ACL rule".to_string())
@@ -809,7 +810,7 @@ async fn test_create_user_with_full_response() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-789",
             "commandType": "CREATE_USER",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Creating ACL user",
             "timestamp": "2024-01-01T16:00:00Z",
             "response": {
@@ -845,7 +846,7 @@ async fn test_create_user_with_full_response() {
     let result = handler.create_user(&request).await.unwrap();
     assert_eq!(result.task_id, Some("task-789".to_string()));
     assert_eq!(result.command_type, Some("CREATE_USER".to_string()));
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
     assert_eq!(result.timestamp, Some("2024-01-01T16:00:00Z".to_string()));
     assert!(result.links.is_some());
 

--- a/tests/cloud_accounts_tests.rs
+++ b/tests/cloud_accounts_tests.rs
@@ -1,3 +1,4 @@
+use redis_cloud::types::TaskStatus;
 use redis_cloud::{CloudAccountHandler, CloudClient};
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
@@ -91,7 +92,7 @@ async fn test_create_cloud_account() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-create-123",
             "commandType": "CREATE_CLOUD_ACCOUNT",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Creating cloud account",
             "timestamp": "2024-01-01T00:00:00Z",
             "response": {
@@ -126,7 +127,7 @@ async fn test_create_cloud_account() {
         result.command_type,
         Some("CREATE_CLOUD_ACCOUNT".to_string())
     );
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
 
 #[tokio::test]
@@ -262,7 +263,7 @@ async fn test_create_gcp_cloud_account() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-gcp-123",
             "commandType": "CREATE_CLOUD_ACCOUNT",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Creating GCP cloud account",
             "timestamp": "2024-01-02T10:00:00Z",
             "response": {
@@ -298,7 +299,7 @@ async fn test_create_gcp_cloud_account() {
         result.command_type,
         Some("CREATE_CLOUD_ACCOUNT".to_string())
     );
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
     assert!(result.response.is_some());
 
     let response = result.response.unwrap();
@@ -610,7 +611,7 @@ async fn test_task_state_update_with_failed_status() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-failed-123",
             "commandType": "CREATE_CLOUD_ACCOUNT",
-            "status": "failed",
+            "status": "processing-error",
             "description": "Failed to create cloud account",
             "timestamp": "2024-01-01T15:00:00Z",
             "response": {
@@ -642,7 +643,7 @@ async fn test_task_state_update_with_failed_status() {
 
     let result = handler.create_cloud_account(&request).await.unwrap();
     assert_eq!(result.task_id, Some("task-failed-123".to_string()));
-    assert_eq!(result.status, Some("failed".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingError));
     assert_eq!(
         result.description,
         Some("Failed to create cloud account".to_string())

--- a/tests/cost_report_tests.rs
+++ b/tests/cost_report_tests.rs
@@ -6,6 +6,7 @@
 //! (POST /cost-report) and `download_cost_report` (GET /cost-report/{id}).
 
 use redis_cloud::cost_report::CostReportCreateRequest;
+use redis_cloud::types::TaskStatus;
 use redis_cloud::{CloudClient, CostReportFormat, CostReportHandler, SubscriptionType};
 use serde_json::json;
 use wiremock::matchers::{body_json, header, method, path};
@@ -42,7 +43,7 @@ async fn test_generate_cost_report_happy_path() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "cost-report-task-1",
             "commandType": "GENERATE_COST_REPORT",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Generating cost report",
             "timestamp": "2025-02-01T00:00:00Z"
         })))
@@ -53,7 +54,7 @@ async fn test_generate_cost_report_happy_path() {
     let task = handler.generate_cost_report(request).await.unwrap();
 
     assert_eq!(task.task_id, Some("cost-report-task-1".to_string()));
-    assert_eq!(task.status, Some("processing".to_string()));
+    assert_eq!(task.status, Some(TaskStatus::ProcessingInProgress));
     assert_eq!(task.command_type, Some("GENERATE_COST_REPORT".to_string()));
 }
 

--- a/tests/databases_tests.rs
+++ b/tests/databases_tests.rs
@@ -1,3 +1,4 @@
+use redis_cloud::types::TaskStatus;
 use redis_cloud::{CloudClient, DatabaseHandler};
 use serde_json::json;
 use wiremock::matchers::{body_json, header, method, path, query_param};
@@ -62,7 +63,7 @@ async fn test_create_database() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-create-db-123",
             "commandType": "CREATE_DATABASE",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Creating database",
             "timestamp": "2024-01-01T00:00:00Z",
             "response": {
@@ -119,7 +120,7 @@ async fn test_create_database() {
     let result = handler.create_database(123, &request).await.unwrap();
     assert_eq!(result.task_id, Some("task-create-db-123".to_string()));
     assert_eq!(result.command_type, Some("CREATE_DATABASE".to_string()));
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
 
 #[tokio::test]
@@ -692,7 +693,7 @@ async fn test_task_response_with_error() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-failed-create",
             "commandType": "CREATE_DATABASE",
-            "status": "failed",
+            "status": "processing-error",
             "description": "Failed to create database",
             "response": {
                 "error": "Insufficient memory quota",
@@ -748,7 +749,7 @@ async fn test_task_response_with_error() {
 
     let result = handler.create_database(123, &request).await.unwrap();
     assert_eq!(result.task_id, Some("task-failed-create".to_string()));
-    assert_eq!(result.status, Some("failed".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingError));
     assert!(result.response.is_some());
 }
 

--- a/tests/subscriptions_tests.rs
+++ b/tests/subscriptions_tests.rs
@@ -1,3 +1,4 @@
+use redis_cloud::types::TaskStatus;
 use redis_cloud::{CloudClient, SubscriptionsHandler};
 use serde_json::json;
 use wiremock::matchers::{body_json, header, method, path, query_param};
@@ -442,7 +443,7 @@ async fn test_delete_regions_from_active_active_subscription() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-delete-region",
             "commandType": "DELETE_REGION",
-            "status": "processing"
+            "status": "processing-in-progress"
         })))
         .mount(&mock_server)
         .await;
@@ -473,7 +474,7 @@ async fn test_delete_regions_from_active_active_subscription() {
 
     assert_eq!(result.task_id.as_deref(), Some("task-delete-region"));
     assert_eq!(result.command_type.as_deref(), Some("DELETE_REGION"));
-    assert_eq!(result.status.as_deref(), Some("processing"));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
 
 #[tokio::test]

--- a/tests/tasks_tests.rs
+++ b/tests/tasks_tests.rs
@@ -1,3 +1,4 @@
+use redis_cloud::types::TaskStatus;
 use redis_cloud::{CloudClient, tasks::TasksHandler};
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
@@ -62,7 +63,7 @@ async fn test_get_all_tasks_canonical_wrapper() {
     assert_eq!(tasks.len(), 3);
     assert_eq!(tasks[0].task_id, Some("task-1".to_string()));
     assert_eq!(tasks[0].command_type, Some("CREATE_DATABASE".to_string()));
-    assert_eq!(tasks[1].status, Some("processing-in-progress".to_string()));
+    assert_eq!(tasks[1].status, Some(TaskStatus::ProcessingInProgress));
     assert_eq!(tasks[2].task_id, Some("task-3".to_string()));
 }
 
@@ -140,7 +141,7 @@ async fn test_get_task_by_id() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "taskId": "task-123",
             "commandType": "CREATE_DATABASE",
-            "status": "completed",
+            "status": "processing-completed",
             "description": "Database created successfully",
             "timestamp": "2024-01-01T00:00:00Z",
             "response": {
@@ -174,7 +175,7 @@ async fn test_get_task_by_id() {
 
     assert_eq!(result.task_id, Some("task-123".to_string()));
     assert_eq!(result.command_type, Some("CREATE_DATABASE".to_string()));
-    assert_eq!(result.status, Some("completed".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingCompleted));
     assert!(result.response.is_some());
 }
 
@@ -189,7 +190,7 @@ async fn test_get_task_by_id_processing() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "taskId": "task-456",
             "commandType": "UPDATE_SUBSCRIPTION",
-            "status": "processing",
+            "status": "processing-in-progress",
             "description": "Updating subscription configuration",
             "timestamp": "2024-01-01T00:00:00Z",
             "progress": 65
@@ -211,7 +212,7 @@ async fn test_get_task_by_id_processing() {
         .unwrap();
 
     assert_eq!(result.task_id, Some("task-456".to_string()));
-    assert_eq!(result.status, Some("processing".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
 
 #[tokio::test]
@@ -225,7 +226,7 @@ async fn test_get_task_by_id_failed() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "taskId": "task-789",
             "commandType": "DELETE_DATABASE",
-            "status": "failed",
+            "status": "processing-error",
             "description": "Failed to delete database",
             "timestamp": "2024-01-01T00:00:00Z",
             "response": {
@@ -250,7 +251,7 @@ async fn test_get_task_by_id_failed() {
         .unwrap();
 
     assert_eq!(result.task_id, Some("task-789".to_string()));
-    assert_eq!(result.status, Some("failed".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingError));
     assert!(result.response.is_some());
 }
 
@@ -291,7 +292,7 @@ async fn test_get_task_by_id_failed_with_error_object() {
         .await
         .unwrap();
 
-    assert_eq!(result.status, Some("processing-error".to_string()));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingError));
     let response = result.response.expect("response present");
     // The structured object is preserved and a readable message is extracted.
     assert!(response.error.as_ref().unwrap().is_object());

--- a/tests/types_tests.rs
+++ b/tests/types_tests.rs
@@ -12,6 +12,7 @@ fn test_task_state_update_serialization() {
         status: Some(TaskStatus::ProcessingInProgress),
         description: Some("Creating database".to_string()),
         timestamp: Some("2023-12-01T10:00:00Z".to_string()),
+        progress: None,
         response: None,
         links: None,
     };
@@ -104,26 +105,46 @@ fn test_processor_response_with_resource() {
 }
 
 #[test]
-fn test_cloud_tags() {
-    let tags = CloudTags {
-        tags: vec![
-            CloudTag {
-                key: "environment".to_string(),
-                value: "production".to_string(),
-            },
-            CloudTag {
-                key: "team".to_string(),
-                value: "platform".to_string(),
-            },
-        ],
+fn test_tag_round_trip() {
+    // `Tag` is the key/value pair used in request bodies.
+    let tag = Tag {
+        key: "environment".to_string(),
+        value: "production".to_string(),
+        command_type: None,
     };
 
-    let json_str = serde_json::to_string(&tags).unwrap();
-    let parsed: CloudTags = serde_json::from_str(&json_str).unwrap();
+    let json_str = serde_json::to_string(&tag).unwrap();
+    // command_type is skipped when absent.
+    assert_eq!(json_str, r#"{"key":"environment","value":"production"}"#);
 
-    assert_eq!(parsed.tags.len(), 2);
-    assert_eq!(parsed.tags[0].key, "environment");
-    assert_eq!(parsed.tags[0].value, "production");
+    let parsed: Tag = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(parsed.key, "environment");
+    assert_eq!(parsed.value, "production");
+}
+
+#[test]
+fn test_cloud_tag_response_shape() {
+    // `CloudTag` is the richer shape the database tag endpoints return.
+    let json = json!({
+        "key": "team",
+        "value": "platform",
+        "createdAt": "2023-12-01T10:00:00Z",
+        "updatedAt": "2023-12-02T10:00:00Z",
+        "links": []
+    });
+    let tag: CloudTag = serde_json::from_value(json).unwrap();
+    assert_eq!(tag.key.as_deref(), Some("team"));
+    assert_eq!(tag.value.as_deref(), Some("platform"));
+    assert_eq!(tag.created_at.as_deref(), Some("2023-12-01T10:00:00Z"));
+    assert_eq!(tag.updated_at.as_deref(), Some("2023-12-02T10:00:00Z"));
+
+    // `CloudTags` is the HATEOAS envelope returned by the listing endpoint.
+    let tags: CloudTags = serde_json::from_value(json!({
+        "accountId": 42,
+        "links": []
+    }))
+    .unwrap();
+    assert_eq!(tags.account_id, Some(42));
 }
 
 #[test]
@@ -266,16 +287,13 @@ fn test_deserialize_real_task_response() {
 #[test]
 fn test_extra_fields_ignored() {
     let json = json!({
-        "tags": [
-            {"key": "env", "value": "prod"}
-        ],
+        "accountId": 7,
+        "links": [],
         "unknownField": "someValue",
         "anotherField": 123
     });
 
     // Unknown fields should be ignored without causing errors
     let tags: CloudTags = serde_json::from_value(json).unwrap();
-    assert_eq!(tags.tags.len(), 1);
-    assert_eq!(tags.tags[0].key, "env");
-    assert_eq!(tags.tags[0].value, "prod");
+    assert_eq!(tags.account_id, Some(7));
 }


### PR DESCRIPTION
Closes #64.

## Summary

Consolidates the duplicated shared models the crate had drifted into, with `crate::types` as the single canonical source.

- **`TaskStateUpdate`**: collapses **9** near-identical definitions (`types`, `tasks`, `users`, `cloud_accounts`, `acl`, `flexible::{subscriptions,databases}`, `fixed::{subscriptions,databases}`) onto `types::TaskStateUpdate`. Each module re-exports it, so existing public paths (`acl::TaskStateUpdate`, etc.) keep resolving.
- **Task status typing**: `status` is now the typed `Option<TaskStatus>` enum instead of `Option<String>`. A `#[serde(other)] Unknown` catch-all means unrecognized wire values deserialize cleanly rather than failing the whole response (avoids the #76-class silent/hard failure). `TaskStateUpdate` also gains `progress: Option<f64>`.
- **Tag models**: the old `types::CloudTag`/`CloudTags` were unused *and* mismodeled vs the OpenAPI spec. Redefined to the real wire shapes:
  - `Tag` = `{key, value, command_type?}` — the request key/value pair
  - `CloudTag` = `{key?, value?, created_at?, updated_at?, links?}`
  - `CloudTags` = `{account_id?, links?}` (HATEOAS envelope; confirmed against the bundled spec — it genuinely has no inline `tags` array)
  - `flexible::databases` and `fixed::databases` re-export these.

Net **−283 lines**.

## Acceptance criteria (#64)

- [x] One canonical representation for task state, tags, and links
- [x] Task status typing consistent across handlers (typed `TaskStatus`)
- [x] Endpoint modules stop redefining structurally identical shared models
- [x] Tests and examples updated to canonical types

## Validation

- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ (0 warnings)
- `cargo test --workspace` ✓ (285 tests + doctests)
- Strict rustdoc (`-D warnings -D rustdoc::broken_intra_doc_links`) ✓

## Breaking changes

`TaskStateUpdate::status` is now `Option<TaskStatus>` (was `Option<String>`); the tag type shapes changed. Documented in CHANGELOG under `[Unreleased]`.

## Follow-ups this unblocks

- #78 (private_link `Value` → `TaskStateUpdate`) — direct dependent
- #65 (handler surface harmonization)