### PR TITLE
refactor(connectivity): return TaskStateUpdate for task-returning endpoints (#78) [re-land]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** connectivity handlers now return `TaskStateUpdate` instead of
+  `serde_json::Value` for every endpoint the spec marks task-returning
+  ([#78](https://github.com/redis-developer/redis-cloud-rs/issues/78)). This
+  covers all 11 `private_link` methods, the PSC/Transit Gateway/VPC peering
+  deletes (which previously discarded the body and returned `Value::Null`), and
+  the corresponding `ConnectivityHandler` façade deletes. Callers can now poll
+  the returned `task_id` to completion instead of dropping to raw HTTP. Added
+  `CloudClient::delete_typed` for bodyless DELETEs that return a parsed body.
+
 - **Breaking:** consolidated shared task and tag models onto canonical types in
   `crate::types` ([#64](https://github.com/redis-developer/redis-cloud-rs/issues/64)).
   The per-module `TaskStateUpdate` copies (in `tasks`, `users`, `cloud_accounts`,

--- a/src/client.rs
+++ b/src/client.rs
@@ -589,6 +589,29 @@ impl CloudClient {
         }
     }
 
+    /// Execute a bodyless DELETE request, deserializing the response body.
+    ///
+    /// Unlike [`Self::delete`] (which discards the body) this parses the
+    /// response into `T`. Connectivity deletes are asynchronous and the spec
+    /// returns a [`TaskStateUpdate`](crate::types::TaskStateUpdate) so callers
+    /// can poll the resulting task to completion.
+    #[instrument(skip(self), fields(method = "DELETE"))]
+    pub async fn delete_typed<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let url = self.normalize_url(path);
+        debug!("DELETE {}", url);
+
+        let response = self
+            .client
+            .delete(&url)
+            .header("x-api-key", &self.api_key)
+            .header("x-api-secret-key", &self.api_secret)
+            .send()
+            .await?;
+
+        trace!("Response status: {}", response.status());
+        self.handle_response(response).await
+    }
+
     /// Execute raw GET request returning JSON Value
     #[instrument(skip(self), fields(method = "GET"))]
     pub async fn get_raw(&self, path: &str) -> Result<serde_json::Value> {

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -146,9 +146,9 @@ impl ConnectivityHandler {
     /// Delete a VPC peering by its peering ID.
     ///
     /// `DELETE /subscriptions/{subscriptionId}/peerings/{peeringId}`.
-    /// Delegates to [`VpcPeeringHandler::delete`], which currently returns
-    /// `serde_json::Value::Null`. Typing the deletion response is tracked as
-    /// a follow-on under #78.
+    /// Delegates to [`VpcPeeringHandler::delete`]. The deletion is asynchronous;
+    /// the returned [`TaskStateUpdate`](crate::types::TaskStateUpdate) carries a
+    /// `task_id` that can be polled to completion.
     ///
     /// # Errors
     ///
@@ -158,7 +158,7 @@ impl ConnectivityHandler {
         &self,
         subscription_id: i32,
         peering_id: i32,
-    ) -> crate::Result<serde_json::Value> {
+    ) -> crate::Result<crate::types::TaskStateUpdate> {
         self.vpc_peering.delete(subscription_id, peering_id).await
     }
 
@@ -230,9 +230,10 @@ impl ConnectivityHandler {
     /// Delete the Private Service Connect service for a Pro subscription.
     ///
     /// `DELETE /subscriptions/{subscriptionId}/private-service-connect`.
-    /// Delegates to [`PscHandler::delete_service`]. Currently returns
-    /// `serde_json::Value::Null`; typing the deletion response is tracked
-    /// under #78.
+    /// Delegates to [`PscHandler::delete_service`]. The deletion is
+    /// asynchronous; the returned
+    /// [`TaskStateUpdate`](crate::types::TaskStateUpdate) carries a `task_id`
+    /// that can be polled to completion.
     ///
     /// # Errors
     ///
@@ -240,7 +241,7 @@ impl ConnectivityHandler {
     pub async fn delete_psc_service(
         &self,
         subscription_id: i32,
-    ) -> crate::Result<serde_json::Value> {
+    ) -> crate::Result<crate::types::TaskStateUpdate> {
         self.psc.delete_service(subscription_id).await
     }
 
@@ -303,9 +304,10 @@ impl ConnectivityHandler {
     /// Delete a Transit Gateway attachment by attachment ID.
     ///
     /// `DELETE /subscriptions/{subscriptionId}/transitGateways/{tgwId}`.
-    /// Delegates to [`TransitGatewayHandler::delete_attachment`]. Currently
-    /// returns `serde_json::Value::Null`; typing the deletion response is
-    /// tracked under #78.
+    /// Delegates to [`TransitGatewayHandler::delete_attachment`]. The deletion
+    /// is asynchronous; the returned
+    /// [`TaskStateUpdate`](crate::types::TaskStateUpdate) carries a `task_id`
+    /// that can be polled to completion.
     ///
     /// # Errors
     ///
@@ -315,7 +317,7 @@ impl ConnectivityHandler {
         &self,
         subscription_id: i32,
         attachment_id: i32,
-    ) -> crate::Result<serde_json::Value> {
+    ) -> crate::Result<crate::types::TaskStateUpdate> {
         self.transit_gateway
             .delete_attachment(subscription_id, attachment_id.to_string())
             .await

--- a/src/connectivity/private_link.rs
+++ b/src/connectivity/private_link.rs
@@ -44,10 +44,9 @@
 //! # }
 //! ```
 
+use crate::types::TaskStateUpdate;
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-// Note: Value is still needed for return types that use raw JSON responses
 
 // ============================================================================
 // Request/Response Types
@@ -273,8 +272,9 @@ impl PrivateLinkHandler {
     ///
     /// # Returns
     ///
-    /// Returns the `PrivateLink` configuration as JSON
-    pub async fn get(&self, subscription_id: i32) -> Result<Value> {
+    /// Returns a [`TaskStateUpdate`] to poll; the configuration is available
+    /// once the task completes.
+    pub async fn get(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!("/subscriptions/{subscription_id}/private-link"))
             .await
@@ -298,7 +298,7 @@ impl PrivateLinkHandler {
         &self,
         subscription_id: i32,
         request: &PrivateLinkCreateRequest,
-    ) -> Result<Value> {
+    ) -> Result<TaskStateUpdate> {
         self.client
             .post(
                 &format!("/subscriptions/{subscription_id}/private-link"),
@@ -320,12 +320,12 @@ impl PrivateLinkHandler {
     ///
     /// # Returns
     ///
-    /// Returns the updated principal configuration
+    /// Returns a [`TaskStateUpdate`] to poll for completion.
     pub async fn add_principals(
         &self,
         subscription_id: i32,
         request: &PrivateLinkAddPrincipalRequest,
-    ) -> Result<Value> {
+    ) -> Result<TaskStateUpdate> {
         self.client
             .post(
                 &format!("/subscriptions/{subscription_id}/private-link/principals"),
@@ -347,12 +347,12 @@ impl PrivateLinkHandler {
     ///
     /// # Returns
     ///
-    /// Returns confirmation of deletion
+    /// Returns a [`TaskStateUpdate`] to poll the asynchronous deletion.
     pub async fn remove_principals(
         &self,
         subscription_id: i32,
         request: &PrivateLinkRemovePrincipalRequest,
-    ) -> Result<Value> {
+    ) -> Result<TaskStateUpdate> {
         self.client
             .delete_with_body(
                 &format!("/subscriptions/{subscription_id}/private-link/principals"),
@@ -373,8 +373,9 @@ impl PrivateLinkHandler {
     ///
     /// # Returns
     ///
-    /// Returns the endpoint creation script
-    pub async fn get_endpoint_script(&self, subscription_id: i32) -> Result<Value> {
+    /// Returns a [`TaskStateUpdate`]; the generated script is available once
+    /// the task completes.
+    pub async fn get_endpoint_script(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
                 "/subscriptions/{subscription_id}/private-link/endpoint-script"
@@ -395,9 +396,9 @@ impl PrivateLinkHandler {
     /// # Returns
     ///
     /// Returns task information for tracking the deletion
-    pub async fn delete(&self, subscription_id: i32) -> Result<Value> {
+    pub async fn delete(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
-            .delete_raw(&format!("/subscriptions/{subscription_id}/private-link"))
+            .delete_typed(&format!("/subscriptions/{subscription_id}/private-link"))
             .await
     }
 
@@ -414,8 +415,13 @@ impl PrivateLinkHandler {
     ///
     /// # Returns
     ///
-    /// Returns the `PrivateLink` configuration for the region
-    pub async fn get_active_active(&self, subscription_id: i32, region_id: i32) -> Result<Value> {
+    /// Returns a [`TaskStateUpdate`] to poll; the configuration is available
+    /// once the task completes.
+    pub async fn get_active_active(
+        &self,
+        subscription_id: i32,
+        region_id: i32,
+    ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
                 "/subscriptions/{subscription_id}/regions/{region_id}/private-link"
@@ -443,7 +449,7 @@ impl PrivateLinkHandler {
         subscription_id: i32,
         region_id: i32,
         request: &PrivateLinkCreateRequest,
-    ) -> Result<Value> {
+    ) -> Result<TaskStateUpdate> {
         self.client
             .post(
                 &format!("/subscriptions/{subscription_id}/regions/{region_id}/private-link"),
@@ -466,13 +472,13 @@ impl PrivateLinkHandler {
     ///
     /// # Returns
     ///
-    /// Returns the updated configuration
+    /// Returns a [`TaskStateUpdate`] to poll for completion.
     pub async fn add_principals_active_active(
         &self,
         subscription_id: i32,
         region_id: i32,
         request: &PrivateLinkAddPrincipalRequest,
-    ) -> Result<Value> {
+    ) -> Result<TaskStateUpdate> {
         self.client
             .post(
                 &format!(
@@ -497,13 +503,13 @@ impl PrivateLinkHandler {
     ///
     /// # Returns
     ///
-    /// Returns confirmation of deletion
+    /// Returns a [`TaskStateUpdate`] to poll the asynchronous deletion.
     pub async fn remove_principals_active_active(
         &self,
         subscription_id: i32,
         region_id: i32,
         request: &PrivateLinkRemovePrincipalRequest,
-    ) -> Result<Value> {
+    ) -> Result<TaskStateUpdate> {
         self.client
             .delete_with_body(
                 &format!(
@@ -527,12 +533,13 @@ impl PrivateLinkHandler {
     ///
     /// # Returns
     ///
-    /// Returns the endpoint creation script
+    /// Returns a [`TaskStateUpdate`]; the generated script is available once
+    /// the task completes.
     pub async fn get_endpoint_script_active_active(
         &self,
         subscription_id: i32,
         region_id: i32,
-    ) -> Result<Value> {
+    ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
                 "/subscriptions/{subscription_id}/regions/{region_id}/private-link/endpoint-script"

--- a/src/connectivity/psc.rs
+++ b/src/connectivity/psc.rs
@@ -212,13 +212,12 @@ impl PscHandler {
     // ========================================================================
 
     /// Delete Private Service Connect service
-    pub async fn delete_service(&self, subscription_id: i32) -> Result<serde_json::Value> {
+    pub async fn delete_service(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
-            .delete(&format!(
+            .delete_typed(&format!(
                 "/subscriptions/{subscription_id}/private-service-connect"
             ))
-            .await?;
-        Ok(serde_json::Value::Null)
+            .await
     }
 
     /// Get Private Service Connect service
@@ -268,13 +267,12 @@ impl PscHandler {
         &self,
         subscription_id: i32,
         endpoint_id: i32,
-    ) -> Result<serde_json::Value> {
+    ) -> Result<TaskStateUpdate> {
         self.client
-            .delete(&format!(
+            .delete_typed(&format!(
                 "/subscriptions/{subscription_id}/private-service-connect/endpoints/{endpoint_id}"
             ))
-            .await?;
-        Ok(serde_json::Value::Null)
+            .await
     }
 
     /// Update Private Service Connect endpoint
@@ -330,13 +328,12 @@ impl PscHandler {
     pub async fn delete_service_active_active(
         &self,
         subscription_id: i32,
-    ) -> Result<serde_json::Value> {
+    ) -> Result<TaskStateUpdate> {
         self.client
-            .delete(&format!(
+            .delete_typed(&format!(
                 "/subscriptions/{subscription_id}/regions/private-service-connect"
             ))
-            .await?;
-        Ok(serde_json::Value::Null)
+            .await
     }
 
     /// Get Active-Active PSC service
@@ -395,13 +392,10 @@ impl PscHandler {
         subscription_id: i32,
         region_id: i32,
         endpoint_id: i32,
-    ) -> Result<serde_json::Value> {
-        self.client
-            .delete(&format!(
+    ) -> Result<TaskStateUpdate> {
+        self.client.delete_typed(&format!(
                 "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/endpoints/{endpoint_id}"
-            ))
-            .await?;
-        Ok(serde_json::Value::Null)
+            )).await
     }
 
     /// Update Active-Active PSC endpoint

--- a/src/connectivity/transit_gateway.rs
+++ b/src/connectivity/transit_gateway.rs
@@ -222,13 +222,12 @@ impl TransitGatewayHandler {
         &self,
         subscription_id: i32,
         attachment_id: String,
-    ) -> Result<serde_json::Value> {
+    ) -> Result<TaskStateUpdate> {
         self.client
-            .delete(&format!(
+            .delete_typed(&format!(
                 "/subscriptions/{subscription_id}/transitGateways/{attachment_id}/attachment"
             ))
-            .await?;
-        Ok(serde_json::Value::Null)
+            .await
     }
 
     /// Create Transit Gateway attachment with `tgw_id` in path
@@ -350,13 +349,10 @@ impl TransitGatewayHandler {
         subscription_id: i32,
         region_id: i32,
         attachment_id: String,
-    ) -> Result<serde_json::Value> {
-        self.client
-            .delete(&format!(
+    ) -> Result<TaskStateUpdate> {
+        self.client.delete_typed(&format!(
                 "/subscriptions/{subscription_id}/regions/{region_id}/tgw/attachments/{attachment_id}"
-            ))
-            .await?;
-        Ok(serde_json::Value::Null)
+            )).await
     }
 
     /// Create Active-Active Transit Gateway attachment

--- a/src/connectivity/vpc_peering.rs
+++ b/src/connectivity/vpc_peering.rs
@@ -397,13 +397,12 @@ impl VpcPeeringHandler {
     }
 
     /// Delete VPC peering
-    pub async fn delete(&self, subscription_id: i32, peering_id: i32) -> Result<serde_json::Value> {
+    pub async fn delete(&self, subscription_id: i32, peering_id: i32) -> Result<TaskStateUpdate> {
         self.client
-            .delete(&format!(
+            .delete_typed(&format!(
                 "/subscriptions/{subscription_id}/peerings/{peering_id}"
             ))
-            .await?;
-        Ok(serde_json::Value::Null)
+            .await
     }
 
     /// Update VPC peering
@@ -454,7 +453,7 @@ impl VpcPeeringHandler {
         &self,
         subscription_id: i32,
         peering_id: i32,
-    ) -> Result<serde_json::Value> {
+    ) -> Result<TaskStateUpdate> {
         self.delete(subscription_id, peering_id).await
     }
 

--- a/tests/connectivity_tests.rs
+++ b/tests/connectivity_tests.rs
@@ -97,8 +97,9 @@ async fn test_delete_vpc_peering() {
     let handler = ConnectivityHandler::new(client);
     let result = handler.delete_vpc_peering(123, 456).await.unwrap();
 
-    // Delete methods now return serde_json::Value::Null
-    assert_eq!(result, serde_json::Value::Null);
+    // Deletes are asynchronous and return the task to poll.
+    assert_eq!(result.task_id.as_deref(), Some("task-delete-peering"));
+    assert_eq!(result.command_type.as_deref(), Some("DELETE_VPC_PEERING"));
 }
 
 #[tokio::test]
@@ -398,8 +399,9 @@ async fn test_delete_psc_service() {
     let handler = ConnectivityHandler::new(client);
     let result = handler.delete_psc_service(123).await.unwrap();
 
-    // Delete methods now return serde_json::Value::Null
-    assert_eq!(result, serde_json::Value::Null);
+    // Deletes are asynchronous and return the task to poll.
+    assert_eq!(result.task_id.as_deref(), Some("task-delete-psc"));
+    assert_eq!(result.command_type.as_deref(), Some("DELETE_PSC_SERVICE"));
 }
 
 #[tokio::test]
@@ -517,8 +519,12 @@ async fn test_delete_tgw() {
     let handler = ConnectivityHandler::new(client);
     let result = handler.delete_tgw_attachment(123, 456).await.unwrap();
 
-    // Delete methods now return serde_json::Value::Null
-    assert_eq!(result, serde_json::Value::Null);
+    // Deletes are asynchronous and return the task to poll.
+    assert_eq!(result.task_id.as_deref(), Some("task-delete-tgw"));
+    assert_eq!(
+        result.command_type.as_deref(),
+        Some("DELETE_TGW_ATTACHMENT")
+    );
 }
 
 #[tokio::test]

--- a/tests/private_link_tests.rs
+++ b/tests/private_link_tests.rs
@@ -2,77 +2,73 @@ use redis_cloud::connectivity::{
     PrincipalType, PrivateLinkAddPrincipalRequest, PrivateLinkCreateRequest,
     PrivateLinkRemovePrincipalRequest,
 };
+use redis_cloud::types::TaskStatus;
 use redis_cloud::{CloudClient, PrivateLinkHandler};
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+/// A `TaskStateUpdate`-shaped body. Per the OpenAPI spec every private-link
+/// operation is asynchronous and returns a task the caller can poll.
+fn task_body(task_id: &str, command_type: &str, resource_id: i64) -> serde_json::Value {
+    json!({
+        "taskId": task_id,
+        "commandType": command_type,
+        "status": "processing-completed",
+        "response": { "resourceId": resource_id }
+    })
+}
+
+fn test_client(uri: String) -> CloudClient {
+    CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(uri)
+        .build()
+        .unwrap()
+}
+
 #[tokio::test]
 async fn test_get_private_link() {
     let mock_server = MockServer::start().await;
-
-    let response_body = json!({
-        "resourceId": 123456,
-        "status": "active",
-        "shareName": "my-redis-share",
-        "principals": [
-            {
-                "principal": "123456789012",
-                "type": "aws_account",
-                "alias": "Production Account"
-            }
-        ]
-    });
 
     Mock::given(method("GET"))
         .and(path("/subscriptions/123/private-link"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-get",
+            "PRIVATE_LINK_GET",
+            123456,
+        )))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
     let result = handler.get(123).await.unwrap();
 
-    assert_eq!(result["resourceId"], 123456);
-    assert_eq!(result["status"], "active");
-    assert_eq!(result["shareName"], "my-redis-share");
+    assert_eq!(result.task_id.as_deref(), Some("task-get"));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingCompleted));
+    assert_eq!(result.response.and_then(|r| r.resource_id), Some(123456));
 }
 
 #[tokio::test]
 async fn test_create_private_link() {
     let mock_server = MockServer::start().await;
 
-    let response_body = json!({
-        "resourceId": 123456,
-        "status": "pending",
-        "taskId": "task-789"
-    });
-
     Mock::given(method("POST"))
         .and(path("/subscriptions/123/private-link"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-789",
+            "PRIVATE_LINK_CREATE",
+            123456,
+        )))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
 
     let request = PrivateLinkCreateRequest {
         share_name: "my-redis-share".to_string(),
@@ -83,42 +79,27 @@ async fn test_create_private_link() {
 
     let result = handler.create(123, &request).await.unwrap();
 
-    assert_eq!(result["resourceId"], 123456);
-    assert_eq!(result["status"], "pending");
-    assert_eq!(result["taskId"], "task-789");
+    assert_eq!(result.task_id.as_deref(), Some("task-789"));
+    assert_eq!(result.command_type.as_deref(), Some("PRIVATE_LINK_CREATE"));
 }
 
 #[tokio::test]
 async fn test_add_principals() {
     let mock_server = MockServer::start().await;
 
-    let response_body = json!({
-        "resourceId": 123456,
-        "principals": [
-            {
-                "principal": "987654321098",
-                "type": "iam_role",
-                "alias": "Dev Role"
-            }
-        ]
-    });
-
     Mock::given(method("POST"))
         .and(path("/subscriptions/123/private-link/principals"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-add",
+            "PRIVATE_LINK_ADD_PRINCIPAL",
+            123456,
+        )))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
 
     let request = PrivateLinkAddPrincipalRequest {
         principal: "987654321098".to_string(),
@@ -128,34 +109,27 @@ async fn test_add_principals() {
 
     let result = handler.add_principals(123, &request).await.unwrap();
 
-    assert_eq!(result["resourceId"], 123456);
-    assert!(result["principals"].is_array());
+    assert_eq!(result.task_id.as_deref(), Some("task-add"));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingCompleted));
 }
 
 #[tokio::test]
 async fn test_remove_principals() {
     let mock_server = MockServer::start().await;
 
-    let response_body = json!({
-        "status": "deleted"
-    });
-
     Mock::given(method("DELETE"))
         .and(path("/subscriptions/123/private-link/principals"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-remove",
+            "PRIVATE_LINK_REMOVE_PRINCIPAL",
+            123456,
+        )))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
 
     let request = PrivateLinkRemovePrincipalRequest {
         principal: "987654321098".to_string(),
@@ -165,102 +139,72 @@ async fn test_remove_principals() {
 
     let result = handler.remove_principals(123, &request).await.unwrap();
 
-    assert_eq!(result["status"], "deleted");
+    assert_eq!(result.task_id.as_deref(), Some("task-remove"));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingCompleted));
 }
 
 #[tokio::test]
 async fn test_get_endpoint_script() {
     let mock_server = MockServer::start().await;
 
-    let response_body = json!({
-        "script": "aws ec2 create-vpc-endpoint --vpc-id vpc-123 --service-name com.amazonaws.vpce.us-east-1.vpce-svc-abc123"
-    });
-
     Mock::given(method("GET"))
-        .and(method("GET"))
         .and(path("/subscriptions/123/private-link/endpoint-script"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-script",
+            "PRIVATE_LINK_ENDPOINT_SCRIPT",
+            123456,
+        )))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
     let result = handler.get_endpoint_script(123).await.unwrap();
 
-    assert!(result["script"].is_string());
-    assert!(result["script"].as_str().unwrap().contains("aws ec2"));
+    assert_eq!(result.task_id.as_deref(), Some("task-script"));
 }
 
 #[tokio::test]
 async fn test_get_active_active_private_link() {
     let mock_server = MockServer::start().await;
 
-    let response_body = json!({
-        "resourceId": 123456,
-        "regionId": 1,
-        "status": "active",
-        "shareName": "my-crdb-share"
-    });
-
     Mock::given(method("GET"))
-        .and(method("GET"))
         .and(path("/subscriptions/123/regions/1/private-link"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-aa-get",
+            "PRIVATE_LINK_GET",
+            123456,
+        )))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
     let result = handler.get_active_active(123, 1).await.unwrap();
 
-    assert_eq!(result["resourceId"], 123456);
-    assert_eq!(result["regionId"], 1);
-    assert_eq!(result["shareName"], "my-crdb-share");
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-get"));
+    assert_eq!(result.response.and_then(|r| r.resource_id), Some(123456));
 }
 
 #[tokio::test]
 async fn test_create_active_active_private_link() {
     let mock_server = MockServer::start().await;
 
-    let response_body = json!({
-        "resourceId": 123456,
-        "regionId": 1,
-        "status": "pending",
-        "taskId": "task-999"
-    });
-
     Mock::given(method("POST"))
         .and(path("/subscriptions/123/regions/1/private-link"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-999",
+            "PRIVATE_LINK_CREATE",
+            123456,
+        )))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
 
     let request = PrivateLinkCreateRequest {
         share_name: "my-crdb-share".to_string(),
@@ -274,42 +218,27 @@ async fn test_create_active_active_private_link() {
         .await
         .unwrap();
 
-    assert_eq!(result["resourceId"], 123456);
-    assert_eq!(result["regionId"], 1);
-    assert_eq!(result["taskId"], "task-999");
+    assert_eq!(result.task_id.as_deref(), Some("task-999"));
+    assert_eq!(result.command_type.as_deref(), Some("PRIVATE_LINK_CREATE"));
 }
 
 #[tokio::test]
 async fn test_add_principals_active_active() {
     let mock_server = MockServer::start().await;
 
-    let response_body = json!({
-        "resourceId": 123456,
-        "regionId": 1,
-        "principals": [
-            {
-                "principal": "555666777888",
-                "type": "aws_account"
-            }
-        ]
-    });
-
     Mock::given(method("POST"))
         .and(path("/subscriptions/123/regions/1/private-link/principals"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-aa-add",
+            "PRIVATE_LINK_ADD_PRINCIPAL",
+            123456,
+        )))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
 
     let request = PrivateLinkAddPrincipalRequest {
         principal: "555666777888".to_string(),
@@ -322,34 +251,26 @@ async fn test_add_principals_active_active() {
         .await
         .unwrap();
 
-    assert_eq!(result["resourceId"], 123456);
-    assert_eq!(result["regionId"], 1);
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-add"));
 }
 
 #[tokio::test]
 async fn test_remove_principals_active_active() {
     let mock_server = MockServer::start().await;
 
-    let response_body = json!({
-        "status": "deleted"
-    });
-
     Mock::given(method("DELETE"))
         .and(path("/subscriptions/123/regions/1/private-link/principals"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-aa-remove",
+            "PRIVATE_LINK_REMOVE_PRINCIPAL",
+            123456,
+        )))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
 
     let request = PrivateLinkRemovePrincipalRequest {
         principal: "555666777888".to_string(),
@@ -362,43 +283,35 @@ async fn test_remove_principals_active_active() {
         .await
         .unwrap();
 
-    assert_eq!(result["status"], "deleted");
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-remove"));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingCompleted));
 }
 
 #[tokio::test]
 async fn test_get_endpoint_script_active_active() {
     let mock_server = MockServer::start().await;
 
-    let response_body = json!({
-        "script": "aws ec2 create-vpc-endpoint --vpc-id vpc-456 --service-name com.amazonaws.vpce.us-west-2.vpce-svc-xyz789"
-    });
-
     Mock::given(method("GET"))
-        .and(method("GET"))
         .and(path(
             "/subscriptions/123/regions/1/private-link/endpoint-script",
         ))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-aa-script",
+            "PRIVATE_LINK_ENDPOINT_SCRIPT",
+            123456,
+        )))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
     let result = handler
         .get_endpoint_script_active_active(123, 1)
         .await
         .unwrap();
 
-    assert!(result["script"].is_string());
-    assert!(result["script"].as_str().unwrap().contains("aws ec2"));
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-script"));
 }
 
 #[tokio::test]
@@ -406,7 +319,6 @@ async fn test_error_handling_401() {
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(method("GET"))
         .and(path("/subscriptions/123/private-link"))
         .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
         .mount(&mock_server)
@@ -430,20 +342,12 @@ async fn test_error_handling_404() {
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(method("GET"))
         .and(path("/subscriptions/999/private-link"))
         .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
     let result = handler.get(999).await;
 
     assert!(result.is_err());
@@ -459,14 +363,7 @@ async fn test_error_handling_500() {
         .mount(&mock_server)
         .await;
 
-    let client = CloudClient::builder()
-        .api_key("test-key")
-        .api_secret("test-secret")
-        .base_url(mock_server.uri())
-        .build()
-        .unwrap();
-
-    let handler = PrivateLinkHandler::new(client);
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
     let request = PrivateLinkCreateRequest {
         share_name: "test".to_string(),
         principal: "123".to_string(),


### PR DESCRIPTION
Re-lands #78. Closes #78.

## Why a second PR

PR #105 was stacked on the #64 branch and GitHub marked it "merged", but it merged **into the #64 feature branch ~13s after that branch had already been merged into `main` via #104** — so the #78 changes never actually reached `main` (`CloudClient::delete_typed` and the connectivity `TaskStateUpdate` returns were absent). This PR cherry-picks the original #78 commit onto current `main`; it applied cleanly with no conflicts.

(Lesson for next time: merge stacked PRs bottom-up and wait for the base to land + retarget before merging the child — or just rebase the child onto `main` first.)

## Summary (unchanged from #105)

Every connectivity endpoint the OpenAPI spec marks task-returning now returns the canonical `TaskStateUpdate` instead of `serde_json::Value`:
- **`private_link`** — all 11 methods → `Result<TaskStateUpdate>`
- **`psc` / `transit_gateway` / `vpc_peering` deletes** — previously discarded the body (`Ok(Value::Null)`); now parse the task response
- **`ConnectivityHandler` façade deletes** → `TaskStateUpdate`
- Added **`CloudClient::delete_typed<T>`** for bodyless DELETEs that return a parsed body

Each converted route was verified against the bundled spec (all resolve to a `TaskStateUpdate` response; the private_link create/delete/principals ops attach it to their `204`).

## Validation
- `clippy --all-targets -D warnings` ✓ (0) · `cargo test --workspace` ✓ (285) · `fmt` ✓ · strict rustdoc ✓

## Breaking change
Connectivity methods return `TaskStateUpdate`, not `Value`. CHANGELOG updated.