### PR TITLE
fix(flexible/databases): correct timeUTC serde casing in DatabaseBackupConfig (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     HATEOAS envelope). The key/value request pair is now `types::Tag`.
     `flexible::databases` and `fixed::databases` re-export these.
 
+### Fixed
+
+- `DatabaseBackupConfig::time_utc` and `database_backup_time_utc` now serialize
+  as `timeUTC` / `databaseBackupTimeUTC` (uppercase `UTC`) to match the OpenAPI
+  spec ([#108](https://github.com/redis-developer/redis-cloud-rs/issues/108)).
+  The previous camelCase (`timeUtc`) did not match the API, so a backup start
+  hour set on a create/update request was silently dropped. Also corrected the
+  docs on the paired `backup_interval`/`database_backup_time_utc`/
+  `backup_storage_type` fields: they are alternate **request** field names the
+  API accepts, not server-returned aliases (investigation from #97).
+
 ## [0.9.5](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.4...v0.9.5) - 2026-02-06
 
 ### Fixed

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -412,23 +412,32 @@ pub struct DatabaseBackupConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval: Option<String>,
 
-    /// Server-returned alias for `interval` (e.g. `"every-4-hours"`).
+    /// Alternate request field name for [`Self::interval`] that the API also
+    /// accepts (`backupInterval`). Prefer `interval`, which is the documented
+    /// form in the OpenAPI spec.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup_interval: Option<String>,
 
     /// Optional. Hour when the backup starts. Available only for "every-12-hours" and "every-24-hours" backup intervals. Specified as an hour in 24-hour UTC time. Example: "14:00" is 2 PM UTC.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "timeUTC", skip_serializing_if = "Option::is_none")]
     pub time_utc: Option<String>,
 
-    /// Server-returned alias for `time_utc` (24-hour UTC time, e.g. `"14:00"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Alternate request field name for [`Self::time_utc`] that the API also
+    /// accepts (`databaseBackupTimeUTC`). Prefer `time_utc`, which is the
+    /// documented form in the OpenAPI spec.
+    #[serde(
+        rename = "databaseBackupTimeUTC",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub database_backup_time_utc: Option<String>,
 
     /// Required when active is 'true'. Type of storage to host backup files. Can be "aws-s3", "google-blob-storage", "azure-blob-storage", or "ftp". See [Set up backup storage locations](https://redis.io/docs/latest/operate/rc/databases/back-up-data/#set-up-backup-storage-locations) to learn how to set up backup storage locations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_type: Option<String>,
 
-    /// Server-returned alias for `storage_type`.
+    /// Alternate request field name for [`Self::storage_type`] that the API
+    /// also accepts (`backupStorageType`). Prefer `storage_type`, which is the
+    /// documented form in the OpenAPI spec.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup_storage_type: Option<String>,
 

--- a/tests/databases_tests.rs
+++ b/tests/databases_tests.rs
@@ -1113,3 +1113,62 @@ async fn test_stream_databases() {
     }
     assert_eq!(count, 2);
 }
+
+/// Lock the `DatabaseBackupConfig` wire field names to the OpenAPI spec.
+///
+/// Regression guard for #108: `time_utc`/`database_backup_time_utc` must
+/// serialize as `timeUTC`/`databaseBackupTimeUTC` (uppercase `UTC`), not the
+/// camelCase `timeUtc` that `rename_all` would otherwise produce — otherwise
+/// the backup start hour is silently dropped from create/update requests.
+#[test]
+fn test_backup_config_wire_field_names_match_spec() {
+    use redis_cloud::databases::DatabaseBackupConfig;
+
+    let config = DatabaseBackupConfig {
+        active: Some(true),
+        interval: Some("every-12-hours".to_string()),
+        backup_interval: Some("every-12-hours".to_string()),
+        time_utc: Some("14:00".to_string()),
+        database_backup_time_utc: Some("14:00".to_string()),
+        storage_type: Some("aws-s3".to_string()),
+        backup_storage_type: Some("aws-s3".to_string()),
+        storage_path: Some("s3://bucket/path".to_string()),
+    };
+
+    let value = serde_json::to_value(&config).unwrap();
+    let obj = value.as_object().unwrap();
+
+    // The two fields the bug was about: uppercase UTC, matching the spec.
+    assert!(
+        obj.contains_key("timeUTC"),
+        "expected key `timeUTC`, got {obj:?}"
+    );
+    assert!(
+        obj.contains_key("databaseBackupTimeUTC"),
+        "expected key `databaseBackupTimeUTC`, got {obj:?}"
+    );
+    // The camelCase forms must NOT appear (they would be silently ignored by the API).
+    assert!(!obj.contains_key("timeUtc"));
+    assert!(!obj.contains_key("databaseBackupTimeUtc"));
+
+    // The rest follow plain camelCase, matching the spec.
+    for key in [
+        "active",
+        "interval",
+        "backupInterval",
+        "storageType",
+        "backupStorageType",
+        "storagePath",
+    ] {
+        assert!(obj.contains_key(key), "expected key `{key}`, got {obj:?}");
+    }
+
+    // Round-trips from the spec's wire names back into the typed fields.
+    let parsed: DatabaseBackupConfig = serde_json::from_value(json!({
+        "timeUTC": "09:00",
+        "databaseBackupTimeUTC": "09:00"
+    }))
+    .unwrap();
+    assert_eq!(parsed.time_utc.as_deref(), Some("09:00"));
+    assert_eq!(parsed.database_backup_time_utc.as_deref(), Some("09:00"));
+}


### PR DESCRIPTION
Closes #108. Resolves the investigation in #97.

## The bug

`DatabaseBackupConfig` derives `#[serde(rename_all = "camelCase")]`, producing `timeUtc` / `databaseBackupTimeUtc` — but the OpenAPI spec uses **`timeUTC` / `databaseBackupTimeUTC`** (uppercase `UTC`). serde is case-sensitive, and this is a **request** type (the `remoteBackup` field of `DatabaseCreateRequest` / `DatabaseUpdateRequest` / `LocalRegionProperties`). So a caller who set `time_utc` sent `{"timeUtc": ...}`, the API ignored the unknown key, and the backup start hour was **silently dropped** from the request.

## Fix

- Explicit `#[serde(rename = "timeUTC")]` / `#[serde(rename = "databaseBackupTimeUTC")]`.
- New regression test (`test_backup_config_wire_field_names_match_spec`) asserting the emitted JSON keys match the spec and that the spec's wire names round-trip back into the typed fields.

## Doc correction (from the #97 investigation)

The paired fields `backup_interval` / `database_backup_time_utc` / `backup_storage_type` were documented as "server-returned alias for …". That's wrong — `DatabaseBackupConfig` is request-only. The spec declares both the short forms (`interval`/`timeUTC`/`storageType`, which carry the documentation) and these prefixed forms (undocumented alternates the API also accepts) as request properties. Docs now describe them as alternate request field names, preferring the short forms.

## Validation
- `clippy --all-targets -D warnings` ✓ (0) · `cargo test --workspace` ✓ (286) · `fmt` ✓ · strict rustdoc ✓