### PR TITLE
refactor(connectivity): reconcile TGW + PSC handler paths with spec (#72, PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** reconciled the connectivity (Transit Gateway + Private Service
+  Connect) handler paths with the refreshed OpenAPI spec
+  ([#72](https://github.com/redis-developer/redis-cloud-rs/issues/72)). This
+  clears the entire non-spec route allowlist (22 → 0) and raises spec coverage
+  to 141/155. Signature/behavior changes:
+  - TGW invitation accept/reject now issue `PUT .../transitGateways/invitations/{id}/{accept,reject}`
+    (previously `POST .../tgw/shared-invitations/...`); `get_shared_invitations`
+    now hits `.../transitGateways/invitations`.
+  - Active-Active TGW methods (`get_attachments_active_active`,
+    `get_shared_invitations_active_active`) gained a `region_id` parameter, and
+    `create_attachment_active_active` / `update_attachment_cidrs_active_active` /
+    `delete_attachment_active_active` now use the spec
+    `.../regions/{regionId}/transitGateways/{tgwId}/attachment` shape (with a
+    `tgw_id` parameter where required).
+  - Removed `TransitGatewayHandler::create_attachment` (the no-id variant that
+    posted to the non-spec `.../transitGateways/attachments`); use
+    `create_attachment_with_id`.
+  - PSC endpoint operations (`create_endpoint`, `delete_endpoint`,
+    `update_endpoint`, creation/deletion scripts, and their Active-Active
+    variants) now take an explicit `psc_service_id` and target the spec
+    `.../private-service-connect/{pscServiceId}/endpoints/{endpointId}` shape;
+    the Active-Active service methods gained a `region_id` parameter. Removed
+    the non-spec `get_endpoints` / `get_endpoints_active_active` list methods.
+  - `ConnectivityHandler::create_psc_endpoint` and `update_psc_service_endpoint`
+    gained the corresponding `psc_service_id` parameter.
+
 ### Added
 
 - Executable route-coverage checks between the typed client handlers and the

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -257,9 +257,12 @@ impl ConnectivityHandler {
     pub async fn create_psc_endpoint(
         &self,
         subscription_id: i32,
+        psc_service_id: i32,
         request: &PscEndpointUpdateRequest,
     ) -> crate::Result<crate::types::TaskStateUpdate> {
-        self.psc.create_endpoint(subscription_id, request).await
+        self.psc
+            .create_endpoint(subscription_id, psc_service_id, request)
+            .await
     }
 
     // ========================================================================
@@ -377,11 +380,12 @@ impl ConnectivityHandler {
     pub async fn update_psc_service_endpoint(
         &self,
         subscription_id: i32,
+        psc_service_id: i32,
         endpoint_id: i32,
         request: &PscEndpointUpdateRequest,
     ) -> crate::Result<crate::types::TaskStateUpdate> {
         self.psc
-            .update_endpoint(subscription_id, endpoint_id, request)
+            .update_endpoint(subscription_id, psc_service_id, endpoint_id, request)
             .await
     }
 

--- a/src/connectivity/psc.rs
+++ b/src/connectivity/psc.rs
@@ -239,24 +239,18 @@ impl PscHandler {
             .await
     }
 
-    /// Get Private Service Connect endpoints
-    pub async fn get_endpoints(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
-        self.client
-            .get(&format!(
-                "/subscriptions/{subscription_id}/private-service-connect/endpoints"
-            ))
-            .await
-    }
-
-    /// Create Private Service Connect endpoint
+    /// Create a Private Service Connect endpoint under the given service.
     pub async fn create_endpoint(
         &self,
         subscription_id: i32,
+        psc_service_id: i32,
         request: &PscEndpointUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!("/subscriptions/{subscription_id}/private-service-connect/endpoints"),
+                &format!(
+                    "/subscriptions/{subscription_id}/private-service-connect/{psc_service_id}"
+                ),
                 request,
             )
             .await
@@ -266,11 +260,12 @@ impl PscHandler {
     pub async fn delete_endpoint(
         &self,
         subscription_id: i32,
+        psc_service_id: i32,
         endpoint_id: i32,
     ) -> Result<TaskStateUpdate> {
         self.client
             .delete_typed(&format!(
-                "/subscriptions/{subscription_id}/private-service-connect/endpoints/{endpoint_id}"
+                "/subscriptions/{subscription_id}/private-service-connect/{psc_service_id}/endpoints/{endpoint_id}"
             ))
             .await
     }
@@ -279,11 +274,10 @@ impl PscHandler {
     pub async fn update_endpoint(
         &self,
         subscription_id: i32,
+        psc_service_id: i32,
         endpoint_id: i32,
         request: &PscEndpointUpdateRequest,
     ) -> Result<TaskStateUpdate> {
-        // Use psc_service_id from request
-        let psc_service_id = request.psc_service_id;
         self.client
             .put(
                 &format!(
@@ -298,11 +292,12 @@ impl PscHandler {
     pub async fn get_endpoint_creation_script(
         &self,
         subscription_id: i32,
+        psc_service_id: i32,
         endpoint_id: i32,
     ) -> Result<String> {
         self.client
             .get(&format!(
-                "/subscriptions/{subscription_id}/private-service-connect/endpoints/{endpoint_id}/creationScripts"
+                "/subscriptions/{subscription_id}/private-service-connect/{psc_service_id}/endpoints/{endpoint_id}/creationScripts"
             ))
             .await
     }
@@ -311,11 +306,12 @@ impl PscHandler {
     pub async fn get_endpoint_deletion_script(
         &self,
         subscription_id: i32,
+        psc_service_id: i32,
         endpoint_id: i32,
     ) -> Result<String> {
         self.client
             .get(&format!(
-                "/subscriptions/{subscription_id}/private-service-connect/endpoints/{endpoint_id}/deletionScripts"
+                "/subscriptions/{subscription_id}/private-service-connect/{psc_service_id}/endpoints/{endpoint_id}/deletionScripts"
             ))
             .await
     }
@@ -324,62 +320,61 @@ impl PscHandler {
     // Active-Active PSC Operations
     // ========================================================================
 
-    /// Delete Active-Active PSC service
+    /// Delete Active-Active PSC service for a region
     pub async fn delete_service_active_active(
         &self,
         subscription_id: i32,
+        region_id: i32,
     ) -> Result<TaskStateUpdate> {
         self.client
             .delete_typed(&format!(
-                "/subscriptions/{subscription_id}/regions/private-service-connect"
+                "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect"
             ))
             .await
     }
 
-    /// Get Active-Active PSC service
-    pub async fn get_service_active_active(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
+    /// Get Active-Active PSC service for a region
+    pub async fn get_service_active_active(
+        &self,
+        subscription_id: i32,
+        region_id: i32,
+    ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{subscription_id}/regions/private-service-connect"
+                "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect"
             ))
             .await
     }
 
-    /// Create Active-Active PSC service
+    /// Create Active-Active PSC service for a region
     pub async fn create_service_active_active(
         &self,
         subscription_id: i32,
+        region_id: i32,
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!("/subscriptions/{subscription_id}/regions/private-service-connect"),
+                &format!(
+                    "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect"
+                ),
                 &serde_json::json!({}),
             )
             .await
     }
 
-    /// Get Active-Active PSC endpoints
-    pub async fn get_endpoints_active_active(
-        &self,
-        subscription_id: i32,
-    ) -> Result<TaskStateUpdate> {
-        self.client
-            .get(&format!(
-                "/subscriptions/{subscription_id}/regions/private-service-connect/endpoints"
-            ))
-            .await
-    }
-
-    /// Create Active-Active PSC endpoint
+    /// Create an Active-Active Private Service Connect endpoint under the
+    /// given service for a region.
     pub async fn create_endpoint_active_active(
         &self,
         subscription_id: i32,
+        region_id: i32,
+        psc_service_id: i32,
         request: &PscEndpointUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
                 &format!(
-                    "/subscriptions/{subscription_id}/regions/private-service-connect/endpoints"
+                    "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/{psc_service_id}"
                 ),
                 request,
             )
@@ -391,10 +386,11 @@ impl PscHandler {
         &self,
         subscription_id: i32,
         region_id: i32,
+        psc_service_id: i32,
         endpoint_id: i32,
     ) -> Result<TaskStateUpdate> {
         self.client.delete_typed(&format!(
-                "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/endpoints/{endpoint_id}"
+                "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/{psc_service_id}/endpoints/{endpoint_id}"
             )).await
     }
 
@@ -403,13 +399,14 @@ impl PscHandler {
         &self,
         subscription_id: i32,
         region_id: i32,
+        psc_service_id: i32,
         endpoint_id: i32,
         request: &PscEndpointUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
             .put(
                 &format!(
-                    "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/{subscription_id}/endpoints/{endpoint_id}"
+                    "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/{psc_service_id}/endpoints/{endpoint_id}"
                 ),
                 request,
             )

--- a/src/connectivity/transit_gateway.rs
+++ b/src/connectivity/transit_gateway.rs
@@ -180,7 +180,7 @@ impl TransitGatewayHandler {
     pub async fn get_shared_invitations(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{subscription_id}/tgw/shared-invitations"
+                "/subscriptions/{subscription_id}/transitGateways/invitations"
             ))
             .await
     }
@@ -192,9 +192,9 @@ impl TransitGatewayHandler {
         invitation_id: String,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .post(
+            .put(
                 &format!(
-                    "/subscriptions/{subscription_id}/tgw/shared-invitations/{invitation_id}/accept"
+                    "/subscriptions/{subscription_id}/transitGateways/invitations/{invitation_id}/accept"
                 ),
                 &serde_json::json!({}),
             )
@@ -208,9 +208,9 @@ impl TransitGatewayHandler {
         invitation_id: String,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .post(
+            .put(
                 &format!(
-                    "/subscriptions/{subscription_id}/tgw/shared-invitations/{invitation_id}/reject"
+                    "/subscriptions/{subscription_id}/transitGateways/invitations/{invitation_id}/reject"
                 ),
                 &serde_json::json!({}),
             )
@@ -250,20 +250,6 @@ impl TransitGatewayHandler {
             .await
     }
 
-    /// Create Transit Gateway attachment
-    pub async fn create_attachment(
-        &self,
-        subscription_id: i32,
-        request: &TgwAttachmentRequest,
-    ) -> Result<TaskStateUpdate> {
-        self.client
-            .post(
-                &format!("/subscriptions/{subscription_id}/transitGateways/attachments"),
-                request,
-            )
-            .await
-    }
-
     /// Update Transit Gateway attachment CIDRs
     pub async fn update_attachment_cidrs(
         &self,
@@ -285,26 +271,28 @@ impl TransitGatewayHandler {
     // Active-Active Transit Gateway Operations
     // ========================================================================
 
-    /// Get Active-Active Transit Gateway attachments
+    /// Get Active-Active Transit Gateway attachments for a region
     pub async fn get_attachments_active_active(
         &self,
         subscription_id: i32,
+        region_id: i32,
     ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{subscription_id}/regions/transitGateways"
+                "/subscriptions/{subscription_id}/regions/{region_id}/transitGateways"
             ))
             .await
     }
 
-    /// Get Active-Active Transit Gateway shared invitations
+    /// Get Active-Active Transit Gateway shared invitations for a region
     pub async fn get_shared_invitations_active_active(
         &self,
         subscription_id: i32,
+        region_id: i32,
     ) -> Result<TaskStateUpdate> {
         self.client
             .get(&format!(
-                "/subscriptions/{subscription_id}/regions/tgw/shared-invitations"
+                "/subscriptions/{subscription_id}/regions/{region_id}/transitGateways/invitations"
             ))
             .await
     }
@@ -317,9 +305,9 @@ impl TransitGatewayHandler {
         invitation_id: String,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .post(
+            .put(
                 &format!(
-                    "/subscriptions/{subscription_id}/regions/{region_id}/tgw/shared-invitations/{invitation_id}/accept"
+                    "/subscriptions/{subscription_id}/regions/{region_id}/transitGateways/invitations/{invitation_id}/accept"
                 ),
                 &serde_json::json!({}),
             )
@@ -334,9 +322,9 @@ impl TransitGatewayHandler {
         invitation_id: String,
     ) -> Result<TaskStateUpdate> {
         self.client
-            .post(
+            .put(
                 &format!(
-                    "/subscriptions/{subscription_id}/regions/{region_id}/tgw/shared-invitations/{invitation_id}/reject"
+                    "/subscriptions/{subscription_id}/regions/{region_id}/transitGateways/invitations/{invitation_id}/reject"
                 ),
                 &serde_json::json!({}),
             )
@@ -348,10 +336,10 @@ impl TransitGatewayHandler {
         &self,
         subscription_id: i32,
         region_id: i32,
-        attachment_id: String,
+        tgw_id: String,
     ) -> Result<TaskStateUpdate> {
         self.client.delete_typed(&format!(
-                "/subscriptions/{subscription_id}/regions/{region_id}/tgw/attachments/{attachment_id}"
+                "/subscriptions/{subscription_id}/regions/{region_id}/transitGateways/{tgw_id}/attachment"
             )).await
     }
 
@@ -360,11 +348,14 @@ impl TransitGatewayHandler {
         &self,
         subscription_id: i32,
         region_id: i32,
+        tgw_id: &str,
         request: &TgwAttachmentRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
             .post(
-                &format!("/subscriptions/{subscription_id}/regions/{region_id}/tgw/attachments"),
+                &format!(
+                    "/subscriptions/{subscription_id}/regions/{region_id}/transitGateways/{tgw_id}/attachment"
+                ),
                 request,
             )
             .await
@@ -375,13 +366,13 @@ impl TransitGatewayHandler {
         &self,
         subscription_id: i32,
         region_id: i32,
-        attachment_id: String,
+        tgw_id: String,
         request: &TgwAttachmentRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
             .put(
                 &format!(
-                    "/subscriptions/{subscription_id}/regions/{region_id}/tgw/attachments/{attachment_id}/cidrs"
+                    "/subscriptions/{subscription_id}/regions/{region_id}/transitGateways/{tgw_id}/attachment"
                 ),
                 request,
             )

--- a/tests/connectivity_tests.rs
+++ b/tests/connectivity_tests.rs
@@ -365,7 +365,7 @@ async fn test_update_psc_service() {
     };
 
     let result = handler
-        .update_psc_service_endpoint(123, 1, &request)
+        .update_psc_service_endpoint(123, 789, 1, &request)
         .await
         .unwrap();
     assert_eq!(result.task_id, Some("task-update-psc".to_string()));

--- a/tests/fixtures/openapi_non_spec_routes.txt
+++ b/tests/fixtures/openapi_non_spec_routes.txt
@@ -4,29 +4,8 @@
 # Each line is `METHOD /normalized/path` where `{}` is a path parameter.
 # The route-coverage test (tests/openapi_route_coverage.rs) treats these as
 # KNOWN drift: a client route is allowed to be off-spec only if it is listed
-# here. Most are legacy path shapes pending reconciliation under #72.
+# here.
 #
-# To remove an entry: fix the handler path to match the spec, then delete the
-# line — the test will fail if a listed route actually matches the spec.
-DELETE /subscriptions/{}/private-service-connect/endpoints/{}
-DELETE /subscriptions/{}/regions/private-service-connect
-DELETE /subscriptions/{}/regions/{}/private-service-connect/endpoints/{}
-DELETE /subscriptions/{}/regions/{}/tgw/attachments/{}
-GET /subscriptions/{}/private-service-connect/endpoints
-GET /subscriptions/{}/private-service-connect/endpoints/{}/creationScripts
-GET /subscriptions/{}/private-service-connect/endpoints/{}/deletionScripts
-GET /subscriptions/{}/regions/private-service-connect
-GET /subscriptions/{}/regions/private-service-connect/endpoints
-GET /subscriptions/{}/regions/tgw/shared-invitations
-GET /subscriptions/{}/regions/transitGateways
-GET /subscriptions/{}/tgw/shared-invitations
-POST /subscriptions/{}/private-service-connect/endpoints
-POST /subscriptions/{}/regions/private-service-connect
-POST /subscriptions/{}/regions/private-service-connect/endpoints
-POST /subscriptions/{}/regions/{}/tgw/attachments
-POST /subscriptions/{}/regions/{}/tgw/shared-invitations/{}/accept
-POST /subscriptions/{}/regions/{}/tgw/shared-invitations/{}/reject
-POST /subscriptions/{}/tgw/shared-invitations/{}/accept
-POST /subscriptions/{}/tgw/shared-invitations/{}/reject
-POST /subscriptions/{}/transitGateways/attachments
-PUT /subscriptions/{}/regions/{}/tgw/attachments/{}/cidrs
+# Currently empty — the connectivity path reconciliation (#72) brought every
+# client route in line with the spec. Add an entry only for a deliberate,
+# documented exception.

--- a/tests/fixtures/openapi_unsupported_routes.txt
+++ b/tests/fixtures/openapi_unsupported_routes.txt
@@ -7,36 +7,17 @@
 #
 # To remove an entry: implement the handler, then delete the line — the test
 # will fail if a listed route is actually covered (no stale entries allowed).
-DELETE /subscriptions/{}/private-service-connect/{}/endpoints/{}
 DELETE /subscriptions/{}/regions/peerings/{}
 DELETE /subscriptions/{}/regions/{}/private-link
-DELETE /subscriptions/{}/regions/{}/private-service-connect
-DELETE /subscriptions/{}/regions/{}/private-service-connect/{}/endpoints/{}
-DELETE /subscriptions/{}/regions/{}/transitGateways/{}/attachment
 GET /fixed/subscriptions/{}/databases/{}/traffic
 GET /subscriptions/{}/databases/{}/traffic
 GET /subscriptions/{}/private-service-connect/{}
-GET /subscriptions/{}/private-service-connect/{}/endpoints/{}/creationScripts
-GET /subscriptions/{}/private-service-connect/{}/endpoints/{}/deletionScripts
 GET /subscriptions/{}/regions/peerings
-GET /subscriptions/{}/regions/{}/private-service-connect
 GET /subscriptions/{}/regions/{}/private-service-connect/{}
-GET /subscriptions/{}/regions/{}/transitGateways
-GET /subscriptions/{}/regions/{}/transitGateways/invitations
-GET /subscriptions/{}/transitGateways/invitations
 POST /fixed/subscriptions/{}/databases/{}/traffic/resume
 POST /subscriptions/{}/databases/{}/traffic/resume
 POST /subscriptions/{}/private-link/connections/disassociate
-POST /subscriptions/{}/private-service-connect/{}
 POST /subscriptions/{}/regions/peerings
 POST /subscriptions/{}/regions/{}/private-link/connections/disassociate
-POST /subscriptions/{}/regions/{}/private-service-connect
-POST /subscriptions/{}/regions/{}/private-service-connect/{}
-POST /subscriptions/{}/regions/{}/transitGateways/{}/attachment
 PUT /subscriptions/{}/regions/peerings/{}
-PUT /subscriptions/{}/regions/{}/transitGateways/invitations/{}/accept
-PUT /subscriptions/{}/regions/{}/transitGateways/invitations/{}/reject
-PUT /subscriptions/{}/regions/{}/transitGateways/{}/attachment
 PUT /subscriptions/{}/resource-tags
-PUT /subscriptions/{}/transitGateways/invitations/{}/accept
-PUT /subscriptions/{}/transitGateways/invitations/{}/reject


### PR DESCRIPTION
Part of #72 — **PR 1 of 2** (path reconciliation; the follow-up implements the remaining endpoints).

## Summary

Reshapes the Transit Gateway and Private Service Connect handler routes to match the refreshed OpenAPI spec. The previous paths were genuinely wrong against the live API (legacy `tgw/…` shapes, missing `{pscServiceId}`/`{regionId}` segments, `POST` where the spec uses `PUT`).

**Result: the non-spec route allowlist drops 22 → 0, and spec coverage rises 122 → 141 / 155.** Verified by the #67 route-coverage test, whose stale-entry checks also confirm the allowlists now exactly reflect reality.

## Transit Gateway
- Invitation accept/reject → `PUT .../transitGateways/invitations/{id}/{accept,reject}` (were `POST .../tgw/shared-invitations/...`); `get_shared_invitations` → `.../transitGateways/invitations`.
- AA `get_attachments_active_active` / `get_shared_invitations_active_active` gained a `region_id`; AA create/update/delete attachment now use `.../regions/{regionId}/transitGateways/{tgwId}/attachment`.
- Removed the no-id `create_attachment` (non-spec `.../transitGateways/attachments`) — use `create_attachment_with_id`.

## Private Service Connect
- Endpoint create/delete/update + creation/deletion scripts (and AA variants) now take an explicit `psc_service_id` and target `.../private-service-connect/{pscServiceId}/endpoints/{endpointId}`.
- AA service methods gained a `region_id`; **fixed a real bug** where `update_endpoint_active_active` put `subscription_id` in the `pscServiceId` slot.
- Removed the non-spec `get_endpoints` / `get_endpoints_active_active` list methods.
- `ConnectivityHandler::{create_psc_endpoint, update_psc_service_endpoint}` gained `psc_service_id`.

## Still deferred (PR 2)
The 14 genuinely-unimplemented spec routes remain in `openapi_unsupported_routes.txt`: AA `regions/peerings` CRUD, database `traffic` get/resume (pro + fixed), `resource-tags` PUT, private-link `disassociate` (×2), PSC service-by-id GET (×2), AA region private-link delete.

## Validation
- `clippy --all-targets -D warnings` ✓ (0) · `cargo test --workspace` ✓ (290) · `fmt` ✓ · strict rustdoc ✓

## Breaking changes
Connectivity method signatures and paths changed; two legacy methods removed. Documented in CHANGELOG.