### PR TITLE
feat(api): implement remaining uncovered spec routes — 100% coverage (#72, PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ConnectivityHandler::create_psc_endpoint` and `update_psc_service_endpoint`
     gained the corresponding `psc_service_id` parameter.
 
+- **Breaking:** the Active-Active VPC peering methods on `VpcPeeringHandler`
+  (`get_active_active`, `create_active_active`, `update_active_active`,
+  `delete_active_active`) previously delegated to the standard
+  `/subscriptions/{id}/peerings` endpoints; they now target the correct
+  `/subscriptions/{id}/regions/peerings[/{peeringId}]` spec surface
+  ([#72](https://github.com/redis-developer/redis-cloud-rs/issues/72)).
+  `create_active_active` now takes `&ActiveActiveVpcPeeringCreateRequest`
+  (was `&VpcPeeringCreateRequest`); `update_active_active` now takes
+  `&VpcPeeringUpdateAwsRequest`.
+
 ### Added
+
+- Implemented every remaining uncovered spec route, raising route coverage to
+  **155/155 (100%)** and emptying the unsupported-route allowlist
+  ([#72](https://github.com/redis-developer/redis-cloud-rs/issues/72)). New
+  typed handler methods and request/response types:
+  - Active-Active VPC peering CRUD on `VpcPeeringHandler` (see the Changed note
+    above), with a new `ActiveActiveVpcPeeringCreateRequest`
+    (`for_aws` / `for_gcp` constructors).
+  - `PrivateLinkHandler::disassociate_connections`, `delete_active_active`, and
+    `disassociate_connections_active_active`, with new
+    `PrivateLinkConnectionsDisassociateRequest`,
+    `PrivateLinkActiveActiveConnectionsDisassociateRequest`, and
+    `PrivateLinkConnectionDisassociate` types.
+  - `PscHandler::get_endpoints` and `get_endpoints_active_active`
+    (`GET .../private-service-connect/{pscServiceId}`).
+  - `get_traffic` and `resume_traffic` on both the Pro and Essentials database
+    handlers, with a shared `types::DatabaseTrafficStateResponse`.
+  - `SubscriptionHandler::update_resource_tags`
+    (`PUT /subscriptions/{id}/resource-tags`) with a new
+    `SubscriptionResourceTagsUpdateRequest`.
 
 - Executable route-coverage checks between the typed client handlers and the
   bundled OpenAPI spec

--- a/src/client.rs
+++ b/src/client.rs
@@ -791,8 +791,13 @@ impl CloudClient {
                 .await
                 .map_err(|e| RestError::ConnectionError(format!("Failed to read response: {e}")))?;
 
+            // Treat an empty success body (e.g. HTTP 204 No Content from the
+            // traffic-resume endpoints) as JSON `null` so it deserializes
+            // cleanly into `()`, `Option<T>`, or `serde_json::Value::Null`.
+            let bytes: &[u8] = if bytes.is_empty() { b"null" } else { &bytes };
+
             // Use serde_path_to_error for better deserialization error messages
-            let deserializer = &mut serde_json::Deserializer::from_slice(&bytes);
+            let deserializer = &mut serde_json::Deserializer::from_slice(bytes);
             serde_path_to_error::deserialize(deserializer).map_err(|err| {
                 let path = err.path().to_string();
                 // Use ConnectionError to provide detailed error message with field path

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -29,7 +29,9 @@ pub use private_link::PrivateLinkHandler;
 
 // Re-export PrivateLink types
 pub use private_link::{
-    PrincipalType, PrivateLinkAddPrincipalRequest, PrivateLinkCreateRequest,
+    PrincipalType, PrivateLinkActiveActiveConnectionsDisassociateRequest,
+    PrivateLinkAddPrincipalRequest, PrivateLinkConnectionDisassociate,
+    PrivateLinkConnectionsDisassociateRequest, PrivateLinkCreateRequest,
     PrivateLinkRemovePrincipalRequest,
 };
 pub use psc::PscHandler;
@@ -40,9 +42,9 @@ pub use vpc_peering::VpcPeeringHandler;
 pub use psc::PscEndpointUpdateRequest;
 pub use transit_gateway::{Cidr, TgwAttachmentRequest, TgwUpdateCidrsRequest};
 pub use vpc_peering::{
-    ActiveActiveVpcPeering, ActiveActiveVpcPeeringList, ActiveActiveVpcRegion, VpcCidr, VpcPeering,
-    VpcPeeringCreateBaseRequest, VpcPeeringCreateRequest, VpcPeeringUpdateAwsRequest,
-    VpcPeeringUpdateRequest,
+    ActiveActiveVpcPeering, ActiveActiveVpcPeeringCreateRequest, ActiveActiveVpcPeeringList,
+    ActiveActiveVpcRegion, VpcCidr, VpcPeering, VpcPeeringCreateBaseRequest,
+    VpcPeeringCreateRequest, VpcPeeringUpdateAwsRequest, VpcPeeringUpdateRequest,
 };
 
 // For backward compatibility, provide a unified handler

--- a/src/connectivity/private_link.rs
+++ b/src/connectivity/private_link.rs
@@ -121,6 +121,71 @@ pub struct PrivateLinkRemovePrincipalRequest {
     pub alias: Option<String>,
 }
 
+/// A single `PrivateLink` connection to disassociate.
+///
+/// Matches the `PrivateLinkConnectionDisassociate` schema. `associationId`,
+/// `type`, and `principalId` are required by the spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateLinkConnectionDisassociate {
+    /// Resource share association ID.
+    pub association_id: String,
+
+    /// VPC endpoint connection ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection_id: Option<String>,
+
+    /// Type of the connection.
+    #[serde(rename = "type")]
+    pub connection_type: String,
+
+    /// Principal ID that owns the connection, e.g. AWS account ID.
+    pub principal_id: String,
+}
+
+/// Request to disassociate connections from a `PrivateLink`.
+///
+/// Matches the `PrivateLinkConnectionsDisassociateRequest` schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateLinkConnectionsDisassociateRequest {
+    /// Subscription that owns the `PrivateLink`. Server-populated from the path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription_id: Option<i32>,
+
+    /// Connections to disassociate from the `PrivateLink`.
+    pub connections: Vec<PrivateLinkConnectionDisassociate>,
+
+    /// Read-only on the response; populated by the server with the operation
+    /// type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_type: Option<String>,
+}
+
+/// Request to disassociate connections from an Active-Active `PrivateLink`.
+///
+/// Matches the `PrivateLinkActiveActiveConnectionsDisassociateRequest` schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateLinkActiveActiveConnectionsDisassociateRequest {
+    /// Subscription that owns the `PrivateLink`. Server-populated from the path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription_id: Option<i32>,
+
+    /// Deployment region ID as defined by the cloud provider. Server-populated
+    /// from the path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region_id: Option<i32>,
+
+    /// Connections to disassociate from the `PrivateLink`.
+    pub connections: Vec<PrivateLinkConnectionDisassociate>,
+
+    /// Read-only on the response; populated by the server with the operation
+    /// type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_type: Option<String>,
+}
+
 /// `PrivateLink` configuration response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -544,6 +609,93 @@ impl PrivateLinkHandler {
             .get(&format!(
                 "/subscriptions/{subscription_id}/regions/{region_id}/private-link/endpoint-script"
             ))
+            .await
+    }
+
+    /// Disassociate connections from a `PrivateLink`
+    ///
+    /// Disassociates one or more VPC endpoint connections from the AWS
+    /// `PrivateLink` configuration for a subscription.
+    ///
+    /// POST /subscriptions/{subscriptionId}/private-link/connections/disassociate
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `request` - The connections to disassociate
+    ///
+    /// # Returns
+    ///
+    /// Returns a [`TaskStateUpdate`] to poll for completion.
+    pub async fn disassociate_connections(
+        &self,
+        subscription_id: i32,
+        request: &PrivateLinkConnectionsDisassociateRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.client
+            .post(
+                &format!("/subscriptions/{subscription_id}/private-link/connections/disassociate"),
+                request,
+            )
+            .await
+    }
+
+    /// Delete Active-Active `PrivateLink`
+    ///
+    /// Deletes the AWS `PrivateLink` configuration for an Active-Active (CRDB)
+    /// subscription region.
+    ///
+    /// DELETE /subscriptions/{subscriptionId}/regions/{regionId}/private-link
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `region_id` - The region ID
+    ///
+    /// # Returns
+    ///
+    /// Returns a [`TaskStateUpdate`] to poll the asynchronous deletion.
+    pub async fn delete_active_active(
+        &self,
+        subscription_id: i32,
+        region_id: i32,
+    ) -> Result<TaskStateUpdate> {
+        self.client
+            .delete_typed(&format!(
+                "/subscriptions/{subscription_id}/regions/{region_id}/private-link"
+            ))
+            .await
+    }
+
+    /// Disassociate connections from an Active-Active `PrivateLink`
+    ///
+    /// Disassociates one or more VPC endpoint connections from the AWS
+    /// `PrivateLink` configuration for an Active-Active subscription region.
+    ///
+    /// POST /subscriptions/{subscriptionId}/regions/{regionId}/private-link/connections/disassociate
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `region_id` - The region ID
+    /// * `request` - The connections to disassociate
+    ///
+    /// # Returns
+    ///
+    /// Returns a [`TaskStateUpdate`] to poll for completion.
+    pub async fn disassociate_connections_active_active(
+        &self,
+        subscription_id: i32,
+        region_id: i32,
+        request: &PrivateLinkActiveActiveConnectionsDisassociateRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.client
+            .post(
+                &format!(
+                    "/subscriptions/{subscription_id}/regions/{region_id}/private-link/connections/disassociate"
+                ),
+                request,
+            )
             .await
     }
 }

--- a/src/connectivity/psc.rs
+++ b/src/connectivity/psc.rs
@@ -256,6 +256,21 @@ impl PscHandler {
             .await
     }
 
+    /// Get the endpoints of a Private Service Connect service.
+    ///
+    /// GET /subscriptions/{subscriptionId}/private-service-connect/{pscServiceId}
+    pub async fn get_endpoints(
+        &self,
+        subscription_id: i32,
+        psc_service_id: i32,
+    ) -> Result<TaskStateUpdate> {
+        self.client
+            .get(&format!(
+                "/subscriptions/{subscription_id}/private-service-connect/{psc_service_id}"
+            ))
+            .await
+    }
+
     /// Delete Private Service Connect endpoint
     pub async fn delete_endpoint(
         &self,
@@ -378,6 +393,23 @@ impl PscHandler {
                 ),
                 request,
             )
+            .await
+    }
+
+    /// Get the endpoints of an Active-Active Private Service Connect service
+    /// for a region.
+    ///
+    /// GET /subscriptions/{subscriptionId}/regions/{regionId}/private-service-connect/{pscServiceId}
+    pub async fn get_endpoints_active_active(
+        &self,
+        subscription_id: i32,
+        region_id: i32,
+        psc_service_id: i32,
+    ) -> Result<TaskStateUpdate> {
+        self.client
+            .get(&format!(
+                "/subscriptions/{subscription_id}/regions/{region_id}/private-service-connect/{psc_service_id}"
+            ))
             .await
     }
 

--- a/src/connectivity/vpc_peering.rs
+++ b/src/connectivity/vpc_peering.rs
@@ -26,8 +26,8 @@
 //! - `PUT    /subscriptions/{subscriptionId}/peerings/{peeringId}`
 //! - `DELETE /subscriptions/{subscriptionId}/peerings/{peeringId}`
 //!
-//! Active-Active subscriptions expose the same surface scoped to a
-//! region under `/subscriptions/{subscriptionId}/regions/{regionId}/...`.
+//! Active-Active subscriptions peer each region independently under
+//! `/subscriptions/{subscriptionId}/regions/peerings[/{peeringId}]`.
 //!
 //! # Example
 //!
@@ -153,6 +153,109 @@ impl VpcPeeringCreateRequest {
 
 /// Base VPC peering creation request (for backward compatibility)
 pub type VpcPeeringCreateBaseRequest = VpcPeeringCreateRequest;
+
+/// Active-Active VPC peering creation request.
+///
+/// The Redis Cloud API documents this as a `oneOf` between an AWS-shaped body
+/// (requiring `sourceRegion`, `destinationRegion`, `awsAccountId`, `vpcId`) and
+/// a GCP-shaped body (requiring `sourceRegion`, `vpcProjectUid`,
+/// `vpcNetworkName`). Like [`VpcPeeringCreateRequest`], both providers live in
+/// one struct and use `#[serde(rename = ...)]` so each field serializes to the
+/// **exact wire name the spec requires**. Use [`Self::for_aws`] or
+/// [`Self::for_gcp`] to construct provider-targeted bodies that avoid mixing
+/// fields.
+///
+/// A type-safe enum split that prevents AWS+GCP field mixing at compile time is
+/// tracked as a follow-on under #65.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveActiveVpcPeeringCreateRequest {
+    /// Cloud provider discriminator (e.g. "AWS", "GCP").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+
+    /// Read-only on the response; populated by the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_type: Option<String>,
+
+    /// Name of the region to create the VPC peering from. Required for both
+    /// providers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_region: Option<String>,
+
+    // ------- AWS body -------
+    /// Name of the region to create the VPC peering to. AWS only; required.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destination_region: Option<String>,
+
+    /// AWS account ID (spec required for AWS).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aws_account_id: Option<String>,
+
+    /// AWS VPC ID (spec required for AWS).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vpc_id: Option<String>,
+
+    /// VPC CIDR. AWS only; optional.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vpc_cidr: Option<String>,
+
+    /// List of VPC CIDRs. AWS only; optional.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vpc_cidrs: Option<Vec<String>>,
+
+    // ------- GCP body -------
+    /// GCP project UID. Wire name: `vpcProjectUid` (spec required for GCP).
+    #[serde(rename = "vpcProjectUid", skip_serializing_if = "Option::is_none")]
+    pub gcp_project_id: Option<String>,
+
+    /// GCP network name. Wire name: `vpcNetworkName` (spec required for GCP).
+    #[serde(rename = "vpcNetworkName", skip_serializing_if = "Option::is_none")]
+    pub network_name: Option<String>,
+}
+
+impl ActiveActiveVpcPeeringCreateRequest {
+    /// Construct an AWS-targeted Active-Active VPC peering creation body.
+    ///
+    /// Pre-populates `provider = "AWS"` and the four required AWS fields
+    /// (`sourceRegion`, `destinationRegion`, `awsAccountId`, `vpcId`). Optional
+    /// CIDR fields can be set directly on the returned struct.
+    #[must_use]
+    pub fn for_aws(
+        source_region: impl Into<String>,
+        destination_region: impl Into<String>,
+        aws_account_id: impl Into<String>,
+        vpc_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: Some("AWS".to_string()),
+            source_region: Some(source_region.into()),
+            destination_region: Some(destination_region.into()),
+            aws_account_id: Some(aws_account_id.into()),
+            vpc_id: Some(vpc_id.into()),
+            ..Self::default()
+        }
+    }
+
+    /// Construct a GCP-targeted Active-Active VPC peering creation body.
+    ///
+    /// Pre-populates `provider = "GCP"` and the three required GCP fields
+    /// (`sourceRegion`, `vpcProjectUid`, `vpcNetworkName`).
+    #[must_use]
+    pub fn for_gcp(
+        source_region: impl Into<String>,
+        project_uid: impl Into<String>,
+        network_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: Some("GCP".to_string()),
+            source_region: Some(source_region.into()),
+            gcp_project_id: Some(project_uid.into()),
+            network_name: Some(network_name.into()),
+            ..Self::default()
+        }
+    }
+}
 
 /// VPC peering update request for AWS
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -424,48 +527,70 @@ impl VpcPeeringHandler {
     // Active-Active VPC Peering
     // ========================================================================
     //
-    // Note: Active-Active VPC peering uses the same API endpoints as standard
-    // VPC peering. These methods are provided for API consistency and to match
-    // the naming convention used by other connectivity handlers.
+    // Active-Active subscriptions peer each region independently under
+    // `/subscriptions/{subscriptionId}/regions/peerings`, a distinct surface
+    // from the standard VPC peering endpoints above.
 
-    /// Get Active-Active VPC peerings
+    /// Get Active-Active VPC peerings for a subscription.
     ///
-    /// Note: Uses the same endpoint as standard VPC peering.
+    /// GET /subscriptions/{subscriptionId}/regions/peerings
     pub async fn get_active_active(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
-        self.get(subscription_id).await
+        self.client
+            .get(&format!(
+                "/subscriptions/{subscription_id}/regions/peerings"
+            ))
+            .await
     }
 
-    /// Create Active-Active VPC peering
+    /// Create an Active-Active VPC peering.
     ///
-    /// Note: Uses the same endpoint as standard VPC peering.
+    /// POST /subscriptions/{subscriptionId}/regions/peerings
+    ///
+    /// Use [`ActiveActiveVpcPeeringCreateRequest::for_aws`] or
+    /// [`ActiveActiveVpcPeeringCreateRequest::for_gcp`] to build a
+    /// provider-targeted body with the spec's required fields.
     pub async fn create_active_active(
         &self,
         subscription_id: i32,
-        request: &VpcPeeringCreateRequest,
+        request: &ActiveActiveVpcPeeringCreateRequest,
     ) -> Result<TaskStateUpdate> {
-        self.create(subscription_id, request).await
+        self.client
+            .post(
+                &format!("/subscriptions/{subscription_id}/regions/peerings"),
+                request,
+            )
+            .await
     }
 
-    /// Delete Active-Active VPC peering
+    /// Update an Active-Active VPC peering's CIDR list.
     ///
-    /// Note: Uses the same endpoint as standard VPC peering.
+    /// PUT /subscriptions/{subscriptionId}/regions/peerings/{peeringId}
+    pub async fn update_active_active(
+        &self,
+        subscription_id: i32,
+        peering_id: i32,
+        request: &VpcPeeringUpdateAwsRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.client
+            .put(
+                &format!("/subscriptions/{subscription_id}/regions/peerings/{peering_id}"),
+                request,
+            )
+            .await
+    }
+
+    /// Delete an Active-Active VPC peering by its peering ID.
+    ///
+    /// DELETE /subscriptions/{subscriptionId}/regions/peerings/{peeringId}
     pub async fn delete_active_active(
         &self,
         subscription_id: i32,
         peering_id: i32,
     ) -> Result<TaskStateUpdate> {
-        self.delete(subscription_id, peering_id).await
-    }
-
-    /// Update Active-Active VPC peering
-    ///
-    /// Note: Uses the same endpoint as standard VPC peering.
-    pub async fn update_active_active(
-        &self,
-        subscription_id: i32,
-        peering_id: i32,
-        request: &VpcPeeringCreateRequest,
-    ) -> Result<TaskStateUpdate> {
-        self.update(subscription_id, peering_id, request).await
+        self.client
+            .delete_typed(&format!(
+                "/subscriptions/{subscription_id}/regions/peerings/{peering_id}"
+            ))
+            .await
     }
 }

--- a/src/fixed/databases.rs
+++ b/src/fixed/databases.rs
@@ -46,7 +46,7 @@
 //! ```
 
 use crate::types::Link;
-pub use crate::types::{CloudTag, CloudTags, Tag, TaskStateUpdate};
+pub use crate::types::{CloudTag, CloudTags, DatabaseTrafficStateResponse, Tag, TaskStateUpdate};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -1143,6 +1143,38 @@ impl FixedDatabaseHandler {
             .post_raw(
                 &format!("/fixed/subscriptions/{subscription_id}/databases/{database_id}/upgrade"),
                 request,
+            )
+            .await
+    }
+
+    /// Get Essentials database traffic state
+    /// Gets the current traffic state for this Essentials database, including
+    /// whether traffic is stopped and whether it can be resumed.
+    ///
+    /// GET /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/traffic
+    pub async fn get_traffic(
+        &self,
+        subscription_id: i32,
+        database_id: i32,
+    ) -> Result<DatabaseTrafficStateResponse> {
+        self.client
+            .get(&format!(
+                "/fixed/subscriptions/{subscription_id}/databases/{database_id}/traffic"
+            ))
+            .await
+    }
+
+    /// Resume Essentials database traffic
+    /// Resumes traffic to this Essentials database after it has been stopped.
+    ///
+    /// POST /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/traffic/resume
+    pub async fn resume_traffic(&self, subscription_id: i32, database_id: i32) -> Result<()> {
+        self.client
+            .post(
+                &format!(
+                    "/fixed/subscriptions/{subscription_id}/databases/{database_id}/traffic/resume"
+                ),
+                &serde_json::json!({}),
             )
             .await
     }

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -52,7 +52,7 @@
 //! ```
 
 use crate::types::Link;
-pub use crate::types::{CloudTag, CloudTags, Tag, TaskStateUpdate};
+pub use crate::types::{CloudTag, CloudTags, DatabaseTrafficStateResponse, Tag, TaskStateUpdate};
 use crate::{CloudClient, Result};
 use async_stream::try_stream;
 use futures_core::Stream;
@@ -2214,6 +2214,36 @@ impl DatabaseHandler {
     /// ```
     pub async fn delete(&self, subscription_id: i32, database_id: i32) -> Result<TaskStateUpdate> {
         self.delete_database_by_id(subscription_id, database_id)
+            .await
+    }
+
+    /// Get Pro database traffic state
+    /// Gets the current traffic state for this Pro database, including whether
+    /// traffic is stopped and whether it can be resumed.
+    ///
+    /// GET /subscriptions/{subscriptionId}/databases/{databaseId}/traffic
+    pub async fn get_traffic(
+        &self,
+        subscription_id: i32,
+        database_id: i32,
+    ) -> Result<DatabaseTrafficStateResponse> {
+        self.client
+            .get(&format!(
+                "/subscriptions/{subscription_id}/databases/{database_id}/traffic"
+            ))
+            .await
+    }
+
+    /// Resume Pro database traffic
+    /// Resumes traffic to this Pro database after it has been stopped.
+    ///
+    /// POST /subscriptions/{subscriptionId}/databases/{databaseId}/traffic/resume
+    pub async fn resume_traffic(&self, subscription_id: i32, database_id: i32) -> Result<()> {
+        self.client
+            .post(
+                &format!("/subscriptions/{subscription_id}/databases/{database_id}/traffic/resume"),
+                &serde_json::json!({}),
+            )
             .await
     }
 }

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -51,8 +51,8 @@
 //! # }
 //! ```
 
-use crate::types::Link;
 pub use crate::types::TaskStateUpdate;
+use crate::types::{Link, Tag};
 use crate::{CloudClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -889,6 +889,26 @@ pub struct SubscriptionMaintenanceWindows {
 // Handler
 // ============================================================================
 
+/// Request to replace the resource tags on a Pro subscription.
+///
+/// Matches the `SubscriptionResourceTagsUpdateRequest` schema. The supplied
+/// tags replace all existing tags on the subscription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionResourceTagsUpdateRequest {
+    /// Subscription to update. Server-populated from the path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription_id: Option<i32>,
+
+    /// Tags to apply to the subscription. Replaces all existing tags.
+    pub resource_tags: Vec<Tag>,
+
+    /// Read-only on the response; populated by the server with the operation
+    /// type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_type: Option<String>,
+}
+
 /// Handler for Pro subscription operations
 ///
 /// Manages flexible subscriptions with auto-scaling, multi-region support,
@@ -1132,6 +1152,24 @@ impl SubscriptionHandler {
         self.client
             .post(
                 &format!("/subscriptions/{subscription_id}/regions"),
+                request,
+            )
+            .await
+    }
+
+    /// Update Pro subscription resource tags
+    /// Replaces all resource tags on the specified Pro subscription with the
+    /// supplied set.
+    ///
+    /// PUT /subscriptions/{subscriptionId}/resource-tags
+    pub async fn update_resource_tags(
+        &self,
+        subscription_id: i32,
+        request: &SubscriptionResourceTagsUpdateRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.client
+            .put(
+                &format!("/subscriptions/{subscription_id}/resource-tags"),
                 request,
             )
             .await

--- a/src/types.rs
+++ b/src/types.rs
@@ -263,6 +263,39 @@ pub struct CloudTags {
     pub links: Option<Vec<Link>>,
 }
 
+/// Traffic state for a database, returned by the `.../traffic` endpoints.
+///
+/// Matches the `DatabaseTrafficStateResponse` schema. Reports whether traffic
+/// to the database is currently stopped and, if so, whether it can be resumed.
+/// Shared by the Pro and Essentials (fixed) database traffic endpoints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DatabaseTrafficStateResponse {
+    /// Database (BDB) ID the traffic state applies to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bdb_id: Option<i32>,
+
+    /// Current traffic status (e.g. `"active"`, `"stopped"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traffic_status: Option<String>,
+
+    /// Whether traffic can currently be resumed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub can_resume: Option<bool>,
+
+    /// Whether a resume operation is already in progress.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resume_in_progress: Option<bool>,
+
+    /// Reason traffic was stopped, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+
+    /// Timestamp from which traffic becomes eligible to resume.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resume_eligible_at: Option<String>,
+}
+
 // ============================================================================
 // Common Response Types
 // ============================================================================

--- a/tests/connectivity_tests.rs
+++ b/tests/connectivity_tests.rs
@@ -1,4 +1,5 @@
-use redis_cloud::{CloudClient, ConnectivityHandler};
+use redis_cloud::connectivity::{ActiveActiveVpcPeeringCreateRequest, VpcPeeringUpdateAwsRequest};
+use redis_cloud::{CloudClient, ConnectivityHandler, PscHandler, VpcPeeringHandler};
 use serde_json::json;
 use wiremock::matchers::{body_json, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -784,4 +785,185 @@ async fn test_vpc_peering_create_gcp_wire_keys() {
 
     let result = handler.create_vpc_peering(123, &request).await.unwrap();
     assert_eq!(result.task_id, Some("task-gcp-keys".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// Active-Active VPC peering (#72): distinct `/regions/peerings` surface, plus
+// PSC get-endpoints by service id. These exercise the specialized sub-handlers
+// directly (the facade does not expose the AA surface).
+// ---------------------------------------------------------------------------
+
+/// Build a `CloudClient` pointed at the mock server.
+fn test_client(uri: String) -> CloudClient {
+    CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(uri)
+        .build()
+        .unwrap()
+}
+
+/// A `TaskStateUpdate`-shaped body for the async connectivity operations.
+fn task_body(task_id: &str, command_type: &str) -> serde_json::Value {
+    json!({
+        "taskId": task_id,
+        "commandType": command_type,
+        "status": "processing-completed",
+        "description": "ok"
+    })
+}
+
+#[tokio::test]
+async fn test_get_active_active_vpc_peerings() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/subscriptions/123/regions/peerings"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(task_body("task-aa-get-peerings", "GET_VPC_PEERING")),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let handler = VpcPeeringHandler::new(test_client(mock_server.uri()));
+    let result = handler.get_active_active(123).await.unwrap();
+
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-get-peerings"));
+}
+
+#[tokio::test]
+async fn test_create_active_active_vpc_peering_aws_wire_keys() {
+    let mock_server = MockServer::start().await;
+
+    // The AA AWS create body must serialize the spec's exact wire keys.
+    let expected_body = json!({
+        "provider": "AWS",
+        "sourceRegion": "us-east-1",
+        "destinationRegion": "us-west-2",
+        "awsAccountId": "123456789012",
+        "vpcId": "vpc-abcdef01",
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/subscriptions/123/regions/peerings"))
+        .and(body_json(&expected_body))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(task_body("task-aa-create-peering", "CREATE_VPC_PEERING")),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let handler = VpcPeeringHandler::new(test_client(mock_server.uri()));
+    let request = ActiveActiveVpcPeeringCreateRequest::for_aws(
+        "us-east-1",
+        "us-west-2",
+        "123456789012",
+        "vpc-abcdef01",
+    );
+
+    let result = handler.create_active_active(123, &request).await.unwrap();
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-create-peering"));
+}
+
+#[tokio::test]
+async fn test_update_active_active_vpc_peering() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/subscriptions/123/regions/peerings/456"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(task_body("task-aa-update-peering", "UPDATE_VPC_PEERING")),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let handler = VpcPeeringHandler::new(test_client(mock_server.uri()));
+    let request = VpcPeeringUpdateAwsRequest {
+        subscription_id: None,
+        vpc_peering_id: None,
+        vpc_cidr: Some("10.0.0.0/16".to_string()),
+        vpc_cidrs: None,
+        command_type: None,
+    };
+
+    let result = handler
+        .update_active_active(123, 456, &request)
+        .await
+        .unwrap();
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-update-peering"));
+}
+
+#[tokio::test]
+async fn test_delete_active_active_vpc_peering() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/subscriptions/123/regions/peerings/456"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(task_body("task-aa-delete-peering", "DELETE_VPC_PEERING")),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let handler = VpcPeeringHandler::new(test_client(mock_server.uri()));
+    let result = handler.delete_active_active(123, 456).await.unwrap();
+
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-delete-peering"));
+}
+
+#[tokio::test]
+async fn test_get_psc_service_endpoints() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/subscriptions/123/private-service-connect/789"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .set_body_json(task_body("task-get-psc-endpoints", "GET_PSC_ENDPOINTS")),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let handler = PscHandler::new(test_client(mock_server.uri()));
+    let result = handler.get_endpoints(123, 789).await.unwrap();
+
+    assert_eq!(result.task_id.as_deref(), Some("task-get-psc-endpoints"));
+}
+
+#[tokio::test]
+async fn test_get_psc_service_endpoints_active_active() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/subscriptions/123/regions/5/private-service-connect/789",
+        ))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .set_body_json(task_body("task-aa-get-psc-endpoints", "GET_PSC_ENDPOINTS")),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let handler = PscHandler::new(test_client(mock_server.uri()));
+    let result = handler
+        .get_endpoints_active_active(123, 5, 789)
+        .await
+        .unwrap();
+
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-get-psc-endpoints"));
 }

--- a/tests/databases_tests.rs
+++ b/tests/databases_tests.rs
@@ -1172,3 +1172,63 @@ fn test_backup_config_wire_field_names_match_spec() {
     assert_eq!(parsed.time_utc.as_deref(), Some("09:00"));
     assert_eq!(parsed.database_backup_time_utc.as_deref(), Some("09:00"));
 }
+
+#[tokio::test]
+async fn test_get_database_traffic() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/subscriptions/123/databases/456/traffic"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bdbId": 456,
+            "trafficStatus": "stopped",
+            "canResume": true,
+            "resumeInProgress": false,
+            "stopReason": "manual",
+            "resumeEligibleAt": "2026-06-01T00:00:00Z"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = DatabaseHandler::new(client);
+    let result = handler.get_traffic(123, 456).await.unwrap();
+
+    assert_eq!(result.bdb_id, Some(456));
+    assert_eq!(result.traffic_status.as_deref(), Some("stopped"));
+    assert_eq!(result.can_resume, Some(true));
+    assert_eq!(result.resume_in_progress, Some(false));
+}
+
+#[tokio::test]
+async fn test_resume_database_traffic() {
+    let mock_server = MockServer::start().await;
+
+    // The resume endpoint returns 204 No Content (empty body).
+    Mock::given(method("POST"))
+        .and(path("/subscriptions/123/databases/456/traffic/resume"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = DatabaseHandler::new(client);
+    // Empty 204 body must deserialize cleanly into `()`.
+    handler.resume_traffic(123, 456).await.unwrap();
+}

--- a/tests/fixed_databases_tests.rs
+++ b/tests/fixed_databases_tests.rs
@@ -501,3 +501,62 @@ async fn test_error_handling_500() {
         _ => panic!("Expected InternalServerError error"),
     }
 }
+
+#[tokio::test]
+async fn test_get_fixed_database_traffic() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions/123/databases/456/traffic"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bdbId": 456,
+            "trafficStatus": "active",
+            "canResume": false,
+            "resumeInProgress": false
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = FixedDatabaseHandler::new(client);
+    let result = handler.get_traffic(123, 456).await.unwrap();
+
+    assert_eq!(result.bdb_id, Some(456));
+    assert_eq!(result.traffic_status.as_deref(), Some("active"));
+    assert_eq!(result.can_resume, Some(false));
+}
+
+#[tokio::test]
+async fn test_resume_fixed_database_traffic() {
+    let mock_server = MockServer::start().await;
+
+    // The resume endpoint returns 204 No Content (empty body).
+    Mock::given(method("POST"))
+        .and(path(
+            "/fixed/subscriptions/123/databases/456/traffic/resume",
+        ))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = FixedDatabaseHandler::new(client);
+    // Empty 204 body must deserialize cleanly into `()`.
+    handler.resume_traffic(123, 456).await.unwrap();
+}

--- a/tests/fixtures/openapi_unsupported_routes.txt
+++ b/tests/fixtures/openapi_unsupported_routes.txt
@@ -7,17 +7,7 @@
 #
 # To remove an entry: implement the handler, then delete the line — the test
 # will fail if a listed route is actually covered (no stale entries allowed).
-DELETE /subscriptions/{}/regions/peerings/{}
-DELETE /subscriptions/{}/regions/{}/private-link
-GET /fixed/subscriptions/{}/databases/{}/traffic
-GET /subscriptions/{}/databases/{}/traffic
-GET /subscriptions/{}/private-service-connect/{}
-GET /subscriptions/{}/regions/peerings
-GET /subscriptions/{}/regions/{}/private-service-connect/{}
-POST /fixed/subscriptions/{}/databases/{}/traffic/resume
-POST /subscriptions/{}/databases/{}/traffic/resume
-POST /subscriptions/{}/private-link/connections/disassociate
-POST /subscriptions/{}/regions/peerings
-POST /subscriptions/{}/regions/{}/private-link/connections/disassociate
-PUT /subscriptions/{}/regions/peerings/{}
-PUT /subscriptions/{}/resource-tags
+#
+# As of #72 every advertised spec route is covered by a typed handler, so this
+# allowlist is intentionally empty. Add a `METHOD /path` line here only when a
+# new spec route is deliberately left unimplemented.

--- a/tests/private_link_tests.rs
+++ b/tests/private_link_tests.rs
@@ -1,5 +1,7 @@
 use redis_cloud::connectivity::{
-    PrincipalType, PrivateLinkAddPrincipalRequest, PrivateLinkCreateRequest,
+    PrincipalType, PrivateLinkActiveActiveConnectionsDisassociateRequest,
+    PrivateLinkAddPrincipalRequest, PrivateLinkConnectionDisassociate,
+    PrivateLinkConnectionsDisassociateRequest, PrivateLinkCreateRequest,
     PrivateLinkRemovePrincipalRequest,
 };
 use redis_cloud::types::TaskStatus;
@@ -373,4 +375,107 @@ async fn test_error_handling_500() {
     let result = handler.create(123, &request).await;
 
     assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_disassociate_connections() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(
+            "/subscriptions/123/private-link/connections/disassociate",
+        ))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(task_body(
+            "task-disassociate",
+            "PRIVATE_LINK_CONNECTIONS_DISASSOCIATE",
+            123456,
+        )))
+        .mount(&mock_server)
+        .await;
+
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
+
+    let request = PrivateLinkConnectionsDisassociateRequest {
+        subscription_id: None,
+        connections: vec![PrivateLinkConnectionDisassociate {
+            association_id: "assoc-1".to_string(),
+            connection_id: Some("conn-1".to_string()),
+            connection_type: "GATEWAY_LOAD_BALANCER".to_string(),
+            principal_id: "123456789012".to_string(),
+        }],
+        command_type: None,
+    };
+
+    let result = handler
+        .disassociate_connections(123, &request)
+        .await
+        .unwrap();
+
+    assert_eq!(result.task_id.as_deref(), Some("task-disassociate"));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingCompleted));
+}
+
+#[tokio::test]
+async fn test_delete_private_link_active_active() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/subscriptions/123/regions/5/private-link"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(task_body(
+            "task-aa-delete",
+            "PRIVATE_LINK_DELETE",
+            123456,
+        )))
+        .mount(&mock_server)
+        .await;
+
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
+    let result = handler.delete_active_active(123, 5).await.unwrap();
+
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-delete"));
+    assert_eq!(result.command_type.as_deref(), Some("PRIVATE_LINK_DELETE"));
+}
+
+#[tokio::test]
+async fn test_disassociate_connections_active_active() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(
+            "/subscriptions/123/regions/5/private-link/connections/disassociate",
+        ))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(task_body(
+            "task-aa-disassociate",
+            "PRIVATE_LINK_CONNECTIONS_DISASSOCIATE",
+            123456,
+        )))
+        .mount(&mock_server)
+        .await;
+
+    let handler = PrivateLinkHandler::new(test_client(mock_server.uri()));
+
+    let request = PrivateLinkActiveActiveConnectionsDisassociateRequest {
+        subscription_id: None,
+        region_id: None,
+        connections: vec![PrivateLinkConnectionDisassociate {
+            association_id: "assoc-2".to_string(),
+            connection_id: None,
+            connection_type: "INTERFACE".to_string(),
+            principal_id: "123456789012".to_string(),
+        }],
+        command_type: None,
+    };
+
+    let result = handler
+        .disassociate_connections_active_active(123, 5, &request)
+        .await
+        .unwrap();
+
+    assert_eq!(result.task_id.as_deref(), Some("task-aa-disassociate"));
 }

--- a/tests/subscriptions_tests.rs
+++ b/tests/subscriptions_tests.rs
@@ -668,3 +668,59 @@ async fn test_error_handling_500() {
         _ => panic!("Expected InternalServerError error"),
     }
 }
+
+#[tokio::test]
+async fn test_update_resource_tags() {
+    let mock_server = MockServer::start().await;
+
+    // The request must serialize tags under the `resourceTags` wire key.
+    let expected_body = json!({
+        "resourceTags": [
+            { "key": "env", "value": "prod" },
+            { "key": "team", "value": "data" }
+        ]
+    });
+
+    Mock::given(method("PUT"))
+        .and(path("/subscriptions/123/resource-tags"))
+        .and(body_json(&expected_body))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-update-tags",
+            "commandType": "SUBSCRIPTION_RESOURCE_TAGS_UPDATE",
+            "status": "processing-in-progress",
+            "description": "Updating resource tags"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = SubscriptionsHandler::new(client);
+    let request = redis_cloud::subscriptions::SubscriptionResourceTagsUpdateRequest {
+        subscription_id: None,
+        resource_tags: vec![
+            redis_cloud::types::Tag {
+                key: "env".to_string(),
+                value: "prod".to_string(),
+                command_type: None,
+            },
+            redis_cloud::types::Tag {
+                key: "team".to_string(),
+                value: "data".to_string(),
+                command_type: None,
+            },
+        ],
+        command_type: None,
+    };
+
+    let result = handler.update_resource_tags(123, &request).await.unwrap();
+    assert_eq!(result.task_id.as_deref(), Some("task-update-tags"));
+    assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
+}


### PR DESCRIPTION
## Summary

Second and final PR for #72. Implements **every previously-uncovered Redis Cloud spec route**, raising route coverage from **141/155 to 155/155 (100%)** and emptying `tests/fixtures/openapi_unsupported_routes.txt`.

Builds on PR 1 ([#110](https://github.com/redis-developer/redis-cloud-rs/pull/110)), which reconciled the TGW + PSC handler paths and cleared the non-spec allowlist.

## What's implemented (14 routes)

| Area | Routes | Handler |
|---|---|---|
| Active-Active VPC peerings | GET/POST/PUT/DELETE `/regions/peerings[/{peeringId}]` | `VpcPeeringHandler::*_active_active` |
| PrivateLink | POST `/private-link/connections/disassociate`, DELETE `/regions/{id}/private-link`, POST `/regions/{id}/private-link/connections/disassociate` | `PrivateLinkHandler` |
| PSC | GET `/private-service-connect/{pscServiceId}` (std + AA) | `PscHandler::get_endpoints[_active_active]` |
| Database traffic | GET `.../traffic`, POST `.../traffic/resume` (Pro + Essentials) | `DatabaseHandler` / `FixedDatabaseHandler` |
| Resource tags | PUT `/subscriptions/{id}/resource-tags` | `SubscriptionHandler::update_resource_tags` |

### New public types
`ActiveActiveVpcPeeringCreateRequest` (`for_aws`/`for_gcp`), `PrivateLinkConnectionsDisassociateRequest`, `PrivateLinkActiveActiveConnectionsDisassociateRequest`, `PrivateLinkConnectionDisassociate`, `SubscriptionResourceTagsUpdateRequest`, and a shared `types::DatabaseTrafficStateResponse`. Resource-tags reuses the canonical `types::Tag` (per #64).

### Client change
`CloudClient::handle_response` now treats an empty 2xx body as JSON `null`, so the 204-returning `resume` endpoints deserialize cleanly into `()`.

## ⚠️ Breaking change

The Active-Active VPC peering methods on `VpcPeeringHandler` previously **delegated to the standard `/subscriptions/{id}/peerings` endpoints** — a spec mismatch. They now target the correct `/subscriptions/{id}/regions/peerings[/{peeringId}]` surface:

- `create_active_active` now takes `&ActiveActiveVpcPeeringCreateRequest` (was `&VpcPeeringCreateRequest`)
- `update_active_active` now takes `&VpcPeeringUpdateAwsRequest`

No existing tests referenced these methods. Consistent with PR 1 being breaking.

## Tests

14 new wiremock tests (one per route), including two `resume` tests that assert a real empty **204 No Content** response. Full suite green: `fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, and `RUSTDOCFLAGS=-D warnings cargo doc` all pass. The `openapi_route_coverage` suite passes with the **emptied** allowlist, proving 100% coverage.

Closes #72.