### PR TITLE
feat(api): add simplified alias methods across remaining domain handlers (closes #65)

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -564,4 +564,118 @@ impl AccountHandler {
             .get(&format!("/session-logs{query_string}"))
             .await
     }
+
+    // ============================================================================
+    // Simplified aliases
+    // ============================================================================
+
+    /// Get the current account (simplified)
+    ///
+    /// Alias for [`get_current_account`](Self::get_current_account).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let root = client.account().get().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get(&self) -> Result<RootAccount> {
+        self.get_current_account().await
+    }
+
+    /// Get system logs (simplified)
+    ///
+    /// Alias for [`get_account_system_logs`](Self::get_account_system_logs).
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - Optional pagination offset
+    /// * `limit` - Optional page size limit
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let logs = client.account().system_logs(None, None).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn system_logs(
+        &self,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<AccountSystemLogEntries> {
+        self.get_account_system_logs(offset, limit).await
+    }
+
+    /// Get session logs (simplified)
+    ///
+    /// Alias for [`get_account_session_logs`](Self::get_account_session_logs).
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - Optional pagination offset
+    /// * `limit` - Optional page size limit
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let logs = client.account().session_logs(None, None).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn session_logs(
+        &self,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<AccountSessionLogEntries> {
+        self.get_account_session_logs(offset, limit).await
+    }
+
+    /// Get payment methods (simplified)
+    ///
+    /// Alias for [`get_account_payment_methods`](Self::get_account_payment_methods).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let methods = client.account().payment_methods().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn payment_methods(&self) -> Result<PaymentMethods> {
+        self.get_account_payment_methods().await
+    }
 }

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -564,4 +564,104 @@ impl AclHandler {
             .put(&format!("/acl/users/{acl_user_id}"), request)
             .await
     }
+
+    // ============================================================================
+    // Simplified aliases
+    // ============================================================================
+
+    /// List Redis ACL rules (simplified)
+    ///
+    /// Alias for [`get_all_redis_rules`](Self::get_all_redis_rules).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let rules = client.acl().list_redis_rules().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_redis_rules(&self) -> Result<AccountACLRedisRules> {
+        self.get_all_redis_rules().await
+    }
+
+    /// List database access roles (simplified)
+    ///
+    /// Alias for [`get_roles`](Self::get_roles).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let roles = client.acl().list_roles().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_roles(&self) -> Result<AccountACLRoles> {
+        self.get_roles().await
+    }
+
+    /// List access control users (simplified)
+    ///
+    /// Alias for [`get_all_acl_users`](Self::get_all_acl_users).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let users = client.acl().list_acl_users().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_acl_users(&self) -> Result<AccountACLUsers> {
+        self.get_all_acl_users().await
+    }
+
+    /// Get a single access control user (simplified)
+    ///
+    /// Alias for [`get_user_by_id`](Self::get_user_by_id).
+    ///
+    /// # Arguments
+    ///
+    /// * `acl_user_id` - The access control user ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let user = client.acl().get_acl_user(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_acl_user(&self, acl_user_id: i32) -> Result<ACLUser> {
+        self.get_user_by_id(acl_user_id).await
+    }
 }

--- a/src/cloud_accounts.rs
+++ b/src/cloud_accounts.rs
@@ -298,4 +298,168 @@ impl CloudAccountsHandler {
             .put(&format!("/cloud-accounts/{cloud_account_id}"), request)
             .await
     }
+
+    // ============================================================================
+    // Simplified aliases
+    // ============================================================================
+
+    /// List cloud accounts (simplified)
+    ///
+    /// Alias for [`get_cloud_accounts`](Self::get_cloud_accounts).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let accounts = client.cloud_accounts().list().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self) -> Result<CloudAccounts> {
+        self.get_cloud_accounts().await
+    }
+
+    /// Create a cloud account (simplified)
+    ///
+    /// Alias for [`create_cloud_account`](Self::create_cloud_account).
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The cloud account creation request
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    /// use redis_cloud::cloud_accounts::CloudAccountCreateRequest;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let request = CloudAccountCreateRequest {
+    ///     name: "my-aws-account".to_string(),
+    ///     provider: Some("AWS".to_string()),
+    ///     access_key_id: "key".to_string(),
+    ///     access_secret_key: "secret".to_string(),
+    ///     console_username: "user".to_string(),
+    ///     console_password: "pass".to_string(),
+    ///     sign_in_login_url: "https://console.aws.amazon.com".to_string(),
+    ///     command_type: None,
+    /// };
+    ///
+    /// let task = client.cloud_accounts().create(&request).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(&self, request: &CloudAccountCreateRequest) -> Result<TaskStateUpdate> {
+        self.create_cloud_account(request).await
+    }
+
+    /// Delete a cloud account (simplified)
+    ///
+    /// Alias for [`delete_cloud_account`](Self::delete_cloud_account).
+    ///
+    /// # Arguments
+    ///
+    /// * `cloud_account_id` - The cloud account ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let task = client.cloud_accounts().delete(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(&self, cloud_account_id: i32) -> Result<TaskStateUpdate> {
+        self.delete_cloud_account(cloud_account_id).await
+    }
+
+    /// Get a cloud account by ID (simplified)
+    ///
+    /// Alias for [`get_cloud_account_by_id`](Self::get_cloud_account_by_id).
+    ///
+    /// # Arguments
+    ///
+    /// * `cloud_account_id` - The cloud account ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let account = client.cloud_accounts().get(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get(&self, cloud_account_id: i32) -> Result<CloudAccount> {
+        self.get_cloud_account_by_id(cloud_account_id).await
+    }
+
+    /// Update a cloud account (simplified)
+    ///
+    /// Alias for [`update_cloud_account`](Self::update_cloud_account).
+    ///
+    /// # Arguments
+    ///
+    /// * `cloud_account_id` - The cloud account ID
+    /// * `request` - The cloud account update request
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    /// use redis_cloud::cloud_accounts::CloudAccountUpdateRequest;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let request = CloudAccountUpdateRequest {
+    ///     name: Some("renamed-account".to_string()),
+    ///     cloud_account_id: None,
+    ///     access_key_id: "key".to_string(),
+    ///     access_secret_key: "secret".to_string(),
+    ///     console_username: "user".to_string(),
+    ///     console_password: "pass".to_string(),
+    ///     sign_in_login_url: None,
+    ///     command_type: None,
+    /// };
+    ///
+    /// let task = client.cloud_accounts().update(123, &request).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(
+        &self,
+        cloud_account_id: i32,
+        request: &CloudAccountUpdateRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.update_cloud_account(cloud_account_id, request).await
+    }
 }

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -406,4 +406,43 @@ impl ConnectivityHandler {
         self.update_tgw_cidrs(subscription_id, attachment_id, request)
             .await
     }
+
+    // ========================================================================
+    // Simplified aliases
+    // ========================================================================
+
+    /// List Transit Gateway attachments for a Pro subscription (simplified).
+    ///
+    /// Preferred alias for [`get_tgws`](Self::get_tgws), whose name is
+    /// ambiguous. `get_tgws` is retained as a backward-compatibility shim.
+    ///
+    /// `GET /subscriptions/{subscriptionId}/transitGateways`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CloudError`] for transport, auth, or 4xx/5xx
+    /// responses.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::{CloudClient, ConnectivityHandler};
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let connectivity = ConnectivityHandler::new(client);
+    /// let attachments = connectivity.list_tgw_attachments(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_tgw_attachments(
+        &self,
+        subscription_id: i32,
+    ) -> crate::Result<crate::types::TaskStateUpdate> {
+        self.get_tgws(subscription_id).await
+    }
 }

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -1174,4 +1174,318 @@ impl SubscriptionHandler {
             )
             .await
     }
+
+    // ============================================================================
+    // Simplified aliases
+    // ============================================================================
+
+    /// List Pro subscriptions (simplified)
+    ///
+    /// Alias for [`get_all_subscriptions`](Self::get_all_subscriptions).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let subscriptions = client.subscriptions().list().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self) -> Result<AccountSubscriptions> {
+        self.get_all_subscriptions().await
+    }
+
+    /// Create a Pro subscription (simplified)
+    ///
+    /// Alias for [`create_subscription`](Self::create_subscription).
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The subscription creation request
+    pub async fn create(&self, request: &SubscriptionCreateRequest) -> Result<TaskStateUpdate> {
+        self.create_subscription(request).await
+    }
+
+    /// Delete a Pro subscription (simplified)
+    ///
+    /// Alias for [`delete_subscription_by_id`](Self::delete_subscription_by_id).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let task = client.subscriptions().delete(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
+        self.delete_subscription_by_id(subscription_id).await
+    }
+
+    /// Get a Pro subscription by ID (simplified)
+    ///
+    /// Alias for [`get_subscription_by_id`](Self::get_subscription_by_id).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let subscription = client.subscriptions().get(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get(&self, subscription_id: i32) -> Result<Subscription> {
+        self.get_subscription_by_id(subscription_id).await
+    }
+
+    /// Update a Pro subscription (simplified)
+    ///
+    /// Alias for [`update_subscription`](Self::update_subscription).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `request` - The subscription update request
+    pub async fn update(
+        &self,
+        subscription_id: i32,
+        request: &BaseSubscriptionUpdateRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.update_subscription(subscription_id, request).await
+    }
+
+    /// Get a Pro subscription's CIDR allowlist (simplified)
+    ///
+    /// Alias for [`get_cidr_allowlist`](Self::get_cidr_allowlist).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let allowlist = client.subscriptions().cidr_allowlist(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn cidr_allowlist(&self, subscription_id: i32) -> Result<TaskStateUpdate> {
+        self.get_cidr_allowlist(subscription_id).await
+    }
+
+    /// Update a Pro subscription's CIDR allowlist (simplified)
+    ///
+    /// Alias for
+    /// [`update_subscription_cidr_allowlist`](Self::update_subscription_cidr_allowlist).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `request` - The CIDR allowlist update request
+    pub async fn update_cidr_allowlist(
+        &self,
+        subscription_id: i32,
+        request: &CidrAllowlistUpdateRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.update_subscription_cidr_allowlist(subscription_id, request)
+            .await
+    }
+
+    /// Get a Pro subscription's maintenance windows (simplified)
+    ///
+    /// Alias for
+    /// [`get_subscription_maintenance_windows`](Self::get_subscription_maintenance_windows).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let windows = client.subscriptions().maintenance_windows(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn maintenance_windows(
+        &self,
+        subscription_id: i32,
+    ) -> Result<SubscriptionMaintenanceWindows> {
+        self.get_subscription_maintenance_windows(subscription_id)
+            .await
+    }
+
+    /// Update a Pro subscription's maintenance windows (simplified)
+    ///
+    /// Alias for
+    /// [`update_subscription_maintenance_windows`](Self::update_subscription_maintenance_windows).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `request` - The maintenance windows specification
+    pub async fn update_maintenance_windows(
+        &self,
+        subscription_id: i32,
+        request: &SubscriptionMaintenanceWindowsSpec,
+    ) -> Result<TaskStateUpdate> {
+        self.update_subscription_maintenance_windows(subscription_id, request)
+            .await
+    }
+
+    /// Get a Pro subscription's pricing (simplified)
+    ///
+    /// Alias for [`get_subscription_pricing`](Self::get_subscription_pricing).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let pricing = client.subscriptions().pricing(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn pricing(&self, subscription_id: i32) -> Result<SubscriptionPricings> {
+        self.get_subscription_pricing(subscription_id).await
+    }
+
+    /// Get the regions of an Active-Active subscription (simplified)
+    ///
+    /// Alias for
+    /// [`get_regions_from_active_active_subscription`](Self::get_regions_from_active_active_subscription).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let regions = client.subscriptions().active_active_regions(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn active_active_regions(
+        &self,
+        subscription_id: i32,
+    ) -> Result<ActiveActiveSubscriptionRegions> {
+        self.get_regions_from_active_active_subscription(subscription_id)
+            .await
+    }
+
+    /// Add a region to an Active-Active subscription (simplified)
+    ///
+    /// Alias for
+    /// [`add_new_region_to_active_active_subscription`](Self::add_new_region_to_active_active_subscription).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `request` - The region creation request
+    pub async fn add_active_active_region(
+        &self,
+        subscription_id: i32,
+        request: &ActiveActiveRegionCreateRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.add_new_region_to_active_active_subscription(subscription_id, request)
+            .await
+    }
+
+    /// Delete regions from an Active-Active subscription (simplified)
+    ///
+    /// Alias for
+    /// [`delete_regions_from_active_active_subscription`](Self::delete_regions_from_active_active_subscription).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `request` - The region deletion request
+    pub async fn delete_active_active_regions(
+        &self,
+        subscription_id: i32,
+        request: &ActiveActiveRegionDeleteRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.delete_regions_from_active_active_subscription(subscription_id, request)
+            .await
+    }
+
+    /// Update a Pro subscription's resource tags (simplified)
+    ///
+    /// Alias for [`update_resource_tags`](Self::update_resource_tags).
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `request` - The resource tags update request
+    pub async fn update_tags(
+        &self,
+        subscription_id: i32,
+        request: &SubscriptionResourceTagsUpdateRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.update_resource_tags(subscription_id, request).await
+    }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -147,4 +147,58 @@ impl TasksHandler {
     pub async fn get_task_by_id(&self, task_id: String) -> Result<TaskStateUpdate> {
         self.client.get(&format!("/tasks/{task_id}")).await
     }
+
+    // ============================================================================
+    // Simplified aliases
+    // ============================================================================
+
+    /// List tasks (simplified)
+    ///
+    /// Alias for [`get_all_tasks`](Self::get_all_tasks).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let tasks = client.tasks().list().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self) -> Result<Vec<TaskStateUpdate>> {
+        self.get_all_tasks().await
+    }
+
+    /// Get a task by ID (simplified)
+    ///
+    /// Alias for [`get_task_by_id`](Self::get_task_by_id).
+    ///
+    /// # Arguments
+    ///
+    /// * `task_id` - The task ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let task = client.tasks().get("task-id".to_string()).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get(&self, task_id: String) -> Result<TaskStateUpdate> {
+        self.get_task_by_id(task_id).await
+    }
 }

--- a/src/users.rs
+++ b/src/users.rs
@@ -213,4 +213,125 @@ impl UsersHandler {
     ) -> Result<TaskStateUpdate> {
         self.client.put(&format!("/users/{user_id}"), request).await
     }
+
+    // ============================================================================
+    // Simplified aliases
+    // ============================================================================
+
+    /// List users (simplified)
+    ///
+    /// Alias for [`get_all_users`](Self::get_all_users).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let users = client.users().list().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self) -> Result<AccountUsers> {
+        self.get_all_users().await
+    }
+
+    /// Get a user by ID (simplified)
+    ///
+    /// Alias for [`get_user_by_id`](Self::get_user_by_id).
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The user ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let user = client.users().get(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get(&self, user_id: i32) -> Result<AccountUser> {
+        self.get_user_by_id(user_id).await
+    }
+
+    /// Update a user (simplified)
+    ///
+    /// Alias for [`update_user`](Self::update_user).
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The user ID
+    /// * `request` - The user update request
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    /// use redis_cloud::users::AccountUserUpdateRequest;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let request = AccountUserUpdateRequest {
+    ///     user_id: None,
+    ///     name: "Updated Name".to_string(),
+    ///     role: Some("Manager".to_string()),
+    ///     command_type: None,
+    /// };
+    ///
+    /// let task = client.users().update(123, &request).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(
+        &self,
+        user_id: i32,
+        request: &AccountUserUpdateRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.update_user(user_id, request).await
+    }
+
+    /// Delete a user (simplified)
+    ///
+    /// Alias for [`delete_user_by_id`](Self::delete_user_by_id).
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The user ID
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_cloud::CloudClient;
+    ///
+    /// # async fn example() -> redis_cloud::Result<()> {
+    /// let client = CloudClient::builder()
+    ///     .api_key("your-api-key")
+    ///     .api_secret("your-api-secret")
+    ///     .build()?;
+    ///
+    /// let task = client.users().delete(123).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(&self, user_id: i32) -> Result<TaskStateUpdate> {
+        self.delete_user_by_id(user_id).await
+    }
 }


### PR DESCRIPTION
# Task: Harmonize public handler surface across remaining domains (issue #65)

## Setup (sequential — verify each step before proceeding)

1. `cd /Users/josh.rotenberg/Code/active/redis-cloud-rs`
2. Confirm you are on branch `feat/65-api-consistency`: `git branch --show-current`
3. Confirm the tree is clean: `git status`
4. Confirm baseline compiles: `cargo check --workspace 2>&1 | tail -5`
5. Confirm baseline tests pass: `cargo test --workspace 2>&1 | tail -10`

## Context

This repo is a Rust client library for the Redis Cloud REST API. It is structured around
domain *handlers*, each with a `new(client) -> Self` constructor and a set of `async fn`
methods wrapping HTTP calls.

The ergonomics pass is partially done: `flexible::databases` and `fixed::subscriptions`/
`fixed::databases` already expose a simplified `list/get/create/update/delete` façade on top
of the verbose legacy names. All other domain handlers still use only the verbose names.

The goal is to add simplified alias methods (thin delegates) to the remaining handlers,
following the established pattern.

### Reference (already-harmonized) — study these before touching anything

- `/Users/josh.rotenberg/Code/active/redis-cloud-rs/src/flexible/databases.rs`
  — `list`, `get`, `create`, `update`, `delete` methods starting around line 2073.
  Each is a one-liner that calls the verbose method. The rustdoc on each simplified
  method says "Alias for [`verbose_name`](Self::verbose_name)."

- `/Users/josh.rotenberg/Code/active/redis-cloud-rs/src/fixed/subscriptions.rs`
  — `list`, `create`, `delete_by_id`, `get`, `update` methods starting around line 511.

### HARMONIZATION-PLAN.md

The file `/Users/josh.rotenberg/Code/active/redis-cloud-rs/HARMONIZATION-PLAN.md` has the
agreed method-name mapping table (section 3). Read it; the table in it is authoritative
for the naming convention.

## Decision / Task: what exactly to add

Add simplified alias methods to each of the following handler impls. Do NOT remove or
deprecate any existing method. Add ONLY the new aliases. Follow the rustdoc pattern
in the reference files exactly.

---

### 1. `src/users.rs` — `UsersHandler`

Current verbose names and their simplified aliases to add:

| Verbose name             | Simplified alias   | Signature change?       |
|--------------------------|--------------------|-------------------------|
| `get_all_users`          | `list`             | returns `Result<AccountUsers>` (same) |
| `get_user_by_id`         | `get`              | `(id: i32) -> Result<AccountUser>` (same) |
| `update_user`            | `update`           | `(id: i32, req: &AccountUserUpdateRequest) -> Result<TaskStateUpdate>` |
| `delete_user_by_id`      | `delete`           | `(id: i32) -> Result<TaskStateUpdate>` |

No `create` alias is needed for `users.rs` — the API does not have a create-user endpoint
in this handler.

---

### 2. `src/acl.rs` — `AclHandler`

The ACL handler manages three sub-resources: redis-rules, roles, and acl-users.
Each sub-resource has its own CRUD verbs. The naming convention here is:

**Redis rules sub-resource:**

| Verbose name             | Simplified alias       |
|--------------------------|------------------------|
| `get_all_redis_rules`    | `list_redis_rules`     |
| `create_redis_rule`      | — (already clear)      |
| `delete_redis_rule`      | — (already clear)      |
| `update_redis_rule`      | — (already clear)      |

Wait — check the actual ACL handler. The issue line reference is `src/acl.rs:436`.
Read lines 400–567 in `src/acl.rs` carefully. The methods to add simplified aliases for:

| Verbose name          | Simplified alias  |
|-----------------------|-------------------|
| `get_all_redis_rules` | `list_redis_rules` |
| `get_roles`           | `list_roles`       |
| `get_all_acl_users`   | `list_acl_users`   |
| `get_user_by_id`      | `get_acl_user`     |

These are the only name-smoothing aliases needed. The `create_*`, `delete_*`, `update_*`
are already clear.

---

### 3. `src/cloud_accounts.rs` — `CloudAccountsHandler`

| Verbose name              | Simplified alias        |
|---------------------------|-------------------------|
| `get_cloud_accounts`      | `list`                  |
| `create_cloud_account`    | `create`                |
| `delete_cloud_account`    | `delete`                |
| `get_cloud_account_by_id` | `get`                   |
| `update_cloud_account`    | `update`                |

---

### 4. `src/tasks.rs` — `TasksHandler`

| Verbose name       | Simplified alias  |
|--------------------|-------------------|
| `get_all_tasks`    | `list`            |
| `get_task_by_id`   | `get`             |

The `get_all_tasks_raw` method returns `serde_json::Value` and is genuinely dynamic —
do NOT add an alias for it; leave it as-is.

---

### 5. `src/account.rs` — `AccountHandler`

The account handler is not pure CRUD; it has multiple distinct endpoints. The
simplified alias pattern applies to a few of them:

| Verbose name                      | Simplified alias         |
|-----------------------------------|--------------------------|
| `get_current_account`             | `get`                    |
| `get_account_system_logs`         | `system_logs`            |
| `get_account_session_logs`        | `session_logs`           |
| `get_account_payment_methods`     | `payment_methods`        |

The remaining methods (`get_data_persistence_options`, `get_supported_database_modules`,
`get_supported_regions`, `get_supported_search_scaling_factors`) are already descriptive
query-style endpoints — no alias needed.

---

### 6. `src/connectivity/private_link.rs` — `PrivateLinkHandler`

The issue line reference is `src/connectivity/private_link.rs:277`. Read the full handler.
The handler already uses short method names (`get`, `create`, `add_principals`,
`remove_principals`). Check for any remaining verbose names and add aliases if needed.
In particular verify:
- `get` — already short: no alias needed
- `create` — already short: no alias needed
- `add_principals` — already short: no alias needed
- `remove_principals` — already short: no alias needed

If no verbose names remain in `PrivateLinkHandler`, skip this file (no changes).

---

### 7. `src/connectivity/psc.rs` — `PscHandler`

The handler already uses method names like `get_service`, `create_service`,
`delete_service`. The issue references `src/connectivity/psc.rs:177`.
Read the full handler (lines 198 to end). Check for any remaining verbose names.
The PSC handler sub-resources (service, endpoint) each have short names already.
If no verbose names remain, skip this file.

---

### 8. `src/connectivity/transit_gateway.rs` — `TransitGatewayHandler`

Read the full handler. Check for any remaining verbose names. The handler methods
(`get_attachments`, `delete_attachment`, `create_attachment_with_id`,
`update_attachment_cidrs`, etc.) are already descriptive.
If no verbose names remain, skip this file.

---

### 9. `src/connectivity/mod.rs` — `ConnectivityHandler`

The issue line reference is `src/connectivity/mod.rs:74`. This is a delegation façade.
The ConnectivityHandler method names delegate to sub-handlers. Review and add
any aliases that improve consistency. Specifically:

| Existing name          | Add alias if warranted  |
|------------------------|-------------------------|
| `get_vpc_peering`      | — (already clear)       |
| `create_vpc_peering`   | — (already clear)       |
| `delete_vpc_peering`   | — (already clear)       |
| `update_vpc_peering`   | — (already clear)       |
| `get_psc_service`      | — (already clear)       |
| `create_psc_service`   | — (already clear)       |
| `delete_psc_service`   | — (already clear)       |
| `create_psc_endpoint`  | — (already clear)       |
| `get_tgws`             | rename-alias: `list_tgw_attachments` (current `get_tgws` is ambiguous) |
| `create_tgw_attachment`| — (already clear)       |
| `delete_tgw_attachment`| — (already clear)       |
| `update_tgw_cidrs`     | — (already clear)       |

For `get_tgws`: add `list_tgw_attachments` as a preferred alias. Keep `get_tgws`
as a backward-compat shim.

---

### 10. `src/flexible/subscriptions.rs` — `SubscriptionHandler`

The issue references `src/flexible/subscriptions.rs:906` and related methods.
Read lines 920 to end.

Current verbose names and their simplified aliases:

| Verbose name                                         | Simplified alias         |
|------------------------------------------------------|--------------------------|
| `get_all_subscriptions`                              | `list`                   |
| `create_subscription`                                | `create`                 |
| `delete_subscription_by_id`                          | `delete`                 |
| `get_subscription_by_id`                             | `get`                    |
| `update_subscription`                                | `update`                 |
| `get_cidr_allowlist`                                 | `cidr_allowlist`         |
| `update_subscription_cidr_allowlist`                 | `update_cidr_allowlist`  |
| `get_subscription_maintenance_windows`               | `maintenance_windows`    |
| `update_subscription_maintenance_windows`            | `update_maintenance_windows` |
| `get_subscription_pricing`                           | `pricing`                |
| `get_regions_from_active_active_subscription`        | `active_active_regions`  |
| `add_new_region_to_active_active_subscription`       | `add_active_active_region` |
| `delete_regions_from_active_active_subscription`     | `delete_active_active_regions` |
| `update_resource_tags`                               | `update_tags`            |

If `update_resource_tags` already ends in a concise form, only add the alias if it
meaningfully shortens it.

---

## Pattern to follow for each new alias method

```rust
/// <Operation> (simplified)
///
/// Alias for [`verbose_name`](Self::verbose_name).
///
/// # Arguments
///
/// * `param` - description
///
/// # Example
///
/// ```no_run
/// use redis_cloud::CloudClient;
///
/// # async fn example() -> redis_cloud::Result<()> {
/// let client = CloudClient::builder()
///     .api_key("your-api-key")
///     .api_secret("your-api-secret")
///     .build()?;
///
/// let result = client.handler().simplified_name(args).await?;
/// # Ok(())
/// # }
/// ```
pub async fn simplified_name(&self, ...) -> Result<T> {
    self.verbose_name(...).await
}
```

Add the simplified methods immediately AFTER the last existing method in the `impl`
block (before the closing `}`), grouped together under a comment:

```rust
    // ============================================================================
    // Simplified aliases
    // ============================================================================
```

---

## Verification gates (run after each file)

After each file edit:
1. `cargo check --workspace 2>&1 | tail -5` — must be clean
2. If it fails, fix before proceeding to the next file

After all files are edited:
3. `cargo fmt --all` — apply formatting
4. `cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tail -20` — must be clean
5. `cargo test --workspace 2>&1 | tail -20` — all tests must pass
6. `cargo test --test openapi_route_coverage 2>&1` — must stay green

---

## Tool-call discipline

- Read each file completely before editing it.
- Make one edit per file per logical change. Do not interleave edits and reads.
- After a `cargo check` failure, read the compiler error in full, then fix.
- Do not guess at compilation errors. Read the types. Check `src/types.rs` if needed.
- Never produce partial edits. Always produce the full insertion block.
- Never use `cargo fix --allow-dirty`.

---

## Constraints

- Do NOT remove or modify any existing public method.
- Do NOT change any return types on existing methods.
- Do NOT add new traits, derive macros, or dependencies.
- Do NOT run `gh pr create` — the PR already exists.
- Do NOT run `git push` — the runner will push after roba completes.
- Do NOT commit — the runner will commit.
- Do NOT modify `tests/` files unless needed to fix a test that your changes broke.
- Do NOT modify `src/types.rs` (no new types needed for this task).
- The `openapi_route_coverage` test must remain green throughout.

---

## Commit (at the end, after all checks pass)

```bash
git add src/account.rs src/users.rs src/acl.rs src/cloud_accounts.rs src/tasks.rs \
    src/connectivity/mod.rs src/flexible/subscriptions.rs
# Only add files you actually modified
git commit -m "feat(api): add simplified alias methods across remaining domain handlers (#65)"
```