### PR TITLE
feat(python): expand bindings to cover all major read domains, document parity scope (closes #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,16 @@ All examples read credentials from `REDIS_CLOUD_API_KEY` / `REDIS_CLOUD_API_SECR
 
 ## Python Bindings
 
-A thin PyO3 binding covering a subset of read operations is published at
+A PyO3 binding providing a convenience layer covering read operations across
+all major API domains is published at
 [redis-cloud on PyPI](https://pypi.org/project/redis-cloud/). See
-[`python/README.md`](python/README.md) for the supported API.
+[`python/README.md`](python/README.md) for the full supported API, the parity
+scope decision, and what is intentionally out of scope (connectivity handlers,
+cost reports, and write operations — all reachable via the raw HTTP helpers or
+the Rust client).
 
 The PyPI publish workflow has been failing since the `reqwest 0.13` upgrade
-([#48](https://github.com/redis-developer/redis-cloud-rs/issues/48)) and the
-overall scope is still being scoped under
-[#66](https://github.com/redis-developer/redis-cloud-rs/issues/66) — treat
-the Python surface as experimental for now.
+([#48](https://github.com/redis-developer/redis-cloud-rs/issues/48)).
 
 ## API Coverage
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,111 @@
+# redis-cloud (Python)
+
+PyO3-based Python bindings for the [`redis-cloud`](https://crates.io/crates/redis-cloud)
+Rust client for the Redis Cloud REST API.
+
+## Parity scope
+
+**Python is a deliberately smaller convenience layer.** It covers read-oriented
+operations across all major API domains — the methods you reach for when
+scripting, building dashboards, or doing field-engineering work. Write
+operations (create, update, delete) are available via the raw HTTP helpers
+(`post`, `put`, `patch`, `delete`) or the full-featured Rust client.
+
+Every domain method comes in two flavors:
+
+- An **async** variant (e.g. `subscriptions()`), which returns an awaitable.
+- A **sync** variant suffixed with `_sync` (e.g. `subscriptions_sync()`), which
+  blocks and returns the result directly.
+
+All methods return plain Python objects (dicts, lists, scalars) decoded from the
+API's JSON responses.
+
+## Supported API coverage
+
+| Domain | Methods |
+|--------|---------|
+| Account | `account`, `account_sync` |
+| Pro subscriptions | `subscriptions`, `subscriptions_sync`, `subscription`, `subscription_sync` |
+| Pro databases | `databases`, `databases_sync`, `database`, `database_sync`, `all_databases`, `all_databases_sync` |
+| Tasks | `tasks`, `tasks_sync`, `task`, `task_sync` |
+| Users | `users`, `users_sync`, `user`, `user_sync` |
+| ACL | `acl_redis_rules`, `acl_redis_rules_sync`, `acl_roles`, `acl_roles_sync`, `acl_users`, `acl_users_sync` |
+| Cloud accounts | `cloud_accounts`, `cloud_accounts_sync`, `cloud_account`, `cloud_account_sync` |
+| Essentials subscriptions | `fixed_subscriptions`, `fixed_subscriptions_sync`, `fixed_subscription`, `fixed_subscription_sync` |
+| Essentials databases | `fixed_databases`, `fixed_databases_sync`, `fixed_database`, `fixed_database_sync` |
+| Raw HTTP | `get`, `get_sync`, `post`, `post_sync`, `delete`, `delete_sync` |
+
+## Out of scope
+
+The following are intentionally deferred from the Python bindings for this
+parity round. They are fully supported by the Rust client, and most can be
+reached from Python via the raw HTTP helpers when needed:
+
+- **Write operations** (create / update / delete of subscriptions, databases,
+  users, etc.) — use `post`, `put`, `patch`, and `delete` with the relevant API
+  path, or the Rust client for typed request bodies.
+- **Connectivity handlers** — VPC peering, Transit Gateway, Private Service
+  Connect (PSC), and Private Link. These are complex, write-heavy networking
+  flows better served by the Rust client.
+- **Cost reports** (`cost_report`) — FOCUS-format billing exports.
+- **Pagination beyond `all_databases`** — the Pro `all_databases` helper is the
+  one auto-paginating convenience exposed; other list endpoints return a single
+  page (use the raw helpers with `offset`/`limit` for manual paging).
+
+## Quick start
+
+```python
+from redis_cloud import CloudClient
+
+# Construct from explicit credentials...
+client = CloudClient(api_key="your-api-key", api_secret="your-api-secret")
+
+# ...or from environment variables
+# (REDIS_CLOUD_API_KEY / REDIS_CLOUD_API_SECRET).
+client = CloudClient.from_env()
+
+# Synchronous calls — block and return the decoded JSON.
+account = client.account_sync()
+subs = client.subscriptions_sync()
+
+for sub in subs.get("subscriptions", []):
+    print(sub["id"], sub["name"])
+    for db in client.databases_sync(sub["id"]).get("subscription", []):
+        print("  ", db)
+
+# Async calls — await the awaitable.
+import asyncio
+
+async def main():
+    tasks = await client.tasks()
+    print(tasks)
+
+asyncio.run(main())
+
+# Raw HTTP for anything not covered by a typed method, including writes.
+created = client.post_sync("/subscriptions", {"name": "example"})
+```
+
+## Installation
+
+From PyPI:
+
+```bash
+pip install redis-cloud
+```
+
+### Building from source
+
+The extension is built with [maturin](https://www.maturin.rs/). From the
+`python/` directory, inside an activated virtualenv:
+
+```bash
+pip install maturin
+maturin develop   # build and install into the current virtualenv
+```
+
+To build a release wheel:
+
+```bash
+maturin build --release
+```

--- a/python/src/client.rs
+++ b/python/src/client.rs
@@ -4,7 +4,10 @@ use crate::error::IntoPyResult;
 use crate::runtime::{block_on, future_into_py};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
-use redis_cloud::{AccountHandler, CloudClient, DatabaseHandler, SubscriptionHandler};
+use redis_cloud::{
+    AccountHandler, AclHandler, CloudAccountHandler, CloudClient, DatabaseHandler,
+    FixedDatabaseHandler, FixedSubscriptionHandler, SubscriptionHandler, TaskHandler, UserHandler,
+};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -349,6 +352,373 @@ impl PyCloudClient {
             let handler = DatabaseHandler::new((*client).clone());
             handler
                 .get_all_databases(subscription_id as i32)
+                .await
+                .into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    // Tasks API
+
+    /// List all tasks (async)
+    fn tasks<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = TaskHandler::new((*client).clone());
+            let result = handler.list().await.into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// List all tasks (sync)
+    fn tasks_sync(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = TaskHandler::new((*client).clone());
+            handler.list().await.into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    /// Get a specific task by ID (async)
+    fn task<'py>(&self, py: Python<'py>, task_id: String) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = TaskHandler::new((*client).clone());
+            let result = handler.get(task_id).await.into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// Get a specific task by ID (sync)
+    fn task_sync(&self, py: Python<'_>, task_id: String) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = TaskHandler::new((*client).clone());
+            handler.get(task_id).await.into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    // Users API
+
+    /// List all users (async)
+    fn users<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = UserHandler::new((*client).clone());
+            let result = handler.list().await.into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// List all users (sync)
+    fn users_sync(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = UserHandler::new((*client).clone());
+            handler.list().await.into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    /// Get a specific user by ID (async)
+    fn user<'py>(&self, py: Python<'py>, user_id: i64) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = UserHandler::new((*client).clone());
+            let result = handler.get(user_id as i32).await.into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// Get a specific user by ID (sync)
+    fn user_sync(&self, py: Python<'_>, user_id: i64) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = UserHandler::new((*client).clone());
+            handler.get(user_id as i32).await.into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    // ACL API
+
+    /// List ACL Redis rules (async)
+    fn acl_redis_rules<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = AclHandler::new((*client).clone());
+            let result = handler.list_redis_rules().await.into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// List ACL Redis rules (sync)
+    fn acl_redis_rules_sync(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = AclHandler::new((*client).clone());
+            handler.list_redis_rules().await.into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    /// List ACL roles (async)
+    fn acl_roles<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = AclHandler::new((*client).clone());
+            let result = handler.list_roles().await.into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// List ACL roles (sync)
+    fn acl_roles_sync(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = AclHandler::new((*client).clone());
+            handler.list_roles().await.into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    /// List ACL users (async)
+    fn acl_users<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = AclHandler::new((*client).clone());
+            let result = handler.list_acl_users().await.into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// List ACL users (sync)
+    fn acl_users_sync(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = AclHandler::new((*client).clone());
+            handler.list_acl_users().await.into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    // Cloud accounts API
+
+    /// List all cloud accounts (async)
+    fn cloud_accounts<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = CloudAccountHandler::new((*client).clone());
+            let result = handler.list().await.into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// List all cloud accounts (sync)
+    fn cloud_accounts_sync(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = CloudAccountHandler::new((*client).clone());
+            handler.list().await.into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    /// Get a specific cloud account by ID (async)
+    fn cloud_account<'py>(
+        &self,
+        py: Python<'py>,
+        cloud_account_id: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = CloudAccountHandler::new((*client).clone());
+            let result = handler
+                .get(cloud_account_id as i32)
+                .await
+                .into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// Get a specific cloud account by ID (sync)
+    fn cloud_account_sync(&self, py: Python<'_>, cloud_account_id: i64) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = CloudAccountHandler::new((*client).clone());
+            handler.get(cloud_account_id as i32).await.into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    // Fixed (Essentials) subscriptions API
+
+    /// List all Essentials (fixed) subscriptions (async)
+    fn fixed_subscriptions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = FixedSubscriptionHandler::new((*client).clone());
+            let result = handler.list().await.into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// List all Essentials (fixed) subscriptions (sync)
+    fn fixed_subscriptions_sync(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = FixedSubscriptionHandler::new((*client).clone());
+            handler.list().await.into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    /// Get a specific Essentials (fixed) subscription by ID (async)
+    fn fixed_subscription<'py>(
+        &self,
+        py: Python<'py>,
+        subscription_id: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = FixedSubscriptionHandler::new((*client).clone());
+            let result = handler
+                .get_by_id(subscription_id as i32)
+                .await
+                .into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// Get a specific Essentials (fixed) subscription by ID (sync)
+    fn fixed_subscription_sync(&self, py: Python<'_>, subscription_id: i64) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = FixedSubscriptionHandler::new((*client).clone());
+            handler
+                .get_by_id(subscription_id as i32)
+                .await
+                .into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    // Fixed (Essentials) databases API
+
+    /// List databases in an Essentials (fixed) subscription (async)
+    fn fixed_databases<'py>(
+        &self,
+        py: Python<'py>,
+        subscription_id: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = FixedDatabaseHandler::new((*client).clone());
+            let result = handler
+                .list(subscription_id as i32, None, None)
+                .await
+                .into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// List databases in an Essentials (fixed) subscription (sync)
+    fn fixed_databases_sync(&self, py: Python<'_>, subscription_id: i64) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = FixedDatabaseHandler::new((*client).clone());
+            handler
+                .list(subscription_id as i32, None, None)
+                .await
+                .into_py_result()
+        })?;
+        let json = serde_json::to_value(&result)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(json_to_py(py, json))
+    }
+
+    /// Get a specific database in an Essentials (fixed) subscription (async)
+    fn fixed_database<'py>(
+        &self,
+        py: Python<'py>,
+        subscription_id: i64,
+        database_id: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let handler = FixedDatabaseHandler::new((*client).clone());
+            let result = handler
+                .get_by_id(subscription_id as i32, database_id as i32)
+                .await
+                .into_py_result()?;
+            let json = serde_json::to_value(&result)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Python::with_gil(|py| Ok(json_to_py(py, json)))
+        })
+    }
+
+    /// Get a specific database in an Essentials (fixed) subscription (sync)
+    fn fixed_database_sync(
+        &self,
+        py: Python<'_>,
+        subscription_id: i64,
+        database_id: i64,
+    ) -> PyResult<Py<PyAny>> {
+        let client = self.client.clone();
+        let result = block_on(py, async move {
+            let handler = FixedDatabaseHandler::new((*client).clone());
+            handler
+                .get_by_id(subscription_id as i32, database_id as i32)
                 .await
                 .into_py_result()
         })?;

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -145,6 +145,80 @@ class TestClientMethods:
         assert hasattr(client, "timeout")
 
 
+class TestNewDomainMethods:
+    """Tests that new domain methods are present on CloudClient."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a client for testing."""
+        return CloudClient(api_key="test-key", api_secret="test-secret")
+
+    def test_client_has_tasks_methods(self, client):
+        """Test that client has tasks list method."""
+        assert hasattr(client, "tasks")
+        assert hasattr(client, "tasks_sync")
+
+    def test_client_has_task_method(self, client):
+        """Test that client has task get method."""
+        assert hasattr(client, "task")
+        assert hasattr(client, "task_sync")
+
+    def test_client_has_users_methods(self, client):
+        """Test that client has users list method."""
+        assert hasattr(client, "users")
+        assert hasattr(client, "users_sync")
+
+    def test_client_has_user_method(self, client):
+        """Test that client has user get method."""
+        assert hasattr(client, "user")
+        assert hasattr(client, "user_sync")
+
+    def test_client_has_acl_redis_rules_methods(self, client):
+        """Test that client has acl_redis_rules method."""
+        assert hasattr(client, "acl_redis_rules")
+        assert hasattr(client, "acl_redis_rules_sync")
+
+    def test_client_has_acl_roles_methods(self, client):
+        """Test that client has acl_roles method."""
+        assert hasattr(client, "acl_roles")
+        assert hasattr(client, "acl_roles_sync")
+
+    def test_client_has_acl_users_methods(self, client):
+        """Test that client has acl_users method."""
+        assert hasattr(client, "acl_users")
+        assert hasattr(client, "acl_users_sync")
+
+    def test_client_has_cloud_accounts_methods(self, client):
+        """Test that client has cloud_accounts list method."""
+        assert hasattr(client, "cloud_accounts")
+        assert hasattr(client, "cloud_accounts_sync")
+
+    def test_client_has_cloud_account_method(self, client):
+        """Test that client has cloud_account get method."""
+        assert hasattr(client, "cloud_account")
+        assert hasattr(client, "cloud_account_sync")
+
+    def test_client_has_fixed_subscriptions_methods(self, client):
+        """Test that client has fixed_subscriptions list method."""
+        assert hasattr(client, "fixed_subscriptions")
+        assert hasattr(client, "fixed_subscriptions_sync")
+
+    def test_client_has_fixed_subscription_method(self, client):
+        """Test that client has fixed_subscription get method."""
+        assert hasattr(client, "fixed_subscription")
+        assert hasattr(client, "fixed_subscription_sync")
+
+    def test_client_has_fixed_databases_methods(self, client):
+        """Test that client has fixed_databases list method."""
+        assert hasattr(client, "fixed_databases")
+        assert hasattr(client, "fixed_databases_sync")
+
+    def test_client_has_fixed_database_method(self, client):
+        """Test that client has fixed_database get method."""
+        assert hasattr(client, "fixed_database")
+        assert hasattr(client, "fixed_database_sync")
+
+
 class TestErrorHandling:
     """Tests for error handling."""
 


### PR DESCRIPTION
# Task: Python bindings parity — define scope and implement high-value domains (issue #66)

## Setup (sequential — verify each step before proceeding)

1. Confirm you are in `/Users/josh.rotenberg/Code/active/redis-cloud-rs`
2. Confirm you are on branch `feat/66-python-parity`: `git branch --show-current`
3. Confirm the tree is clean: `git status`
4. Confirm baseline compiles (Rust library): `cargo check --workspace 2>&1 | tail -5`
5. Confirm the Python extension builds: `cd python && maturin develop --uv 2>&1 | tail -10`
6. Confirm baseline Python tests pass: `cd python && python -m pytest tests/ -v 2>&1 | tail -20`
7. Return to repo root after steps 5-6: `cd /Users/josh.rotenberg/Code/active/redis-cloud-rs`

## Context

This repo is a Rust client library (`redis-cloud`) for the Redis Cloud REST API, with PyO3-based
Python bindings in the `python/` subdirectory. The Python extension is built with `maturin`.

The Rust library was harmonized in issue #65 (PR #112, merged): every domain handler now has
both verbose legacy names (`get_all_subscriptions`, `get_subscription_by_id`, etc.) AND simplified
alias methods (`list`, `get`, `create`, `update`, `delete`). The Python bindings should align with
the **simplified alias names** where possible.

### Current Python surface (`python/src/client.rs`)

Read `/Users/josh.rotenberg/Code/active/redis-cloud-rs/python/src/client.rs` completely.

Currently exposed:
- `account` / `account_sync` — via `AccountHandler::get_current_account()`
- `subscriptions` / `subscriptions_sync` — via `SubscriptionHandler::get_all_subscriptions()`
- `subscription` / `subscription_sync` — via `SubscriptionHandler::get_subscription_by_id()`
- `databases` / `databases_sync` — via `DatabaseHandler::get_subscription_databases()`
- `database` / `database_sync` — via `DatabaseHandler::get_subscription_database_by_id()`
- `all_databases` / `all_databases_sync` — via `DatabaseHandler::get_all_databases()`
- `get`, `get_sync`, `post`, `post_sync`, `delete`, `delete_sync` — raw HTTP
- `timeout` property

### Rust handler inventory (after #65)

Read these files to understand available handlers and method signatures:

- `/Users/josh.rotenberg/Code/active/redis-cloud-rs/src/lib.rs` — re-exports and handler overview
- `/Users/josh.rotenberg/Code/active/redis-cloud-rs/src/tasks.rs` — `TasksHandler`: `list()`, `get(task_id: String)`
- `/Users/josh.rotenberg/Code/active/redis-cloud-rs/src/users.rs` — `UsersHandler`: `list()`, `get(user_id: i32)`, `delete(user_id: i32)`
- `/Users/josh.rotenberg/Code/active/redis-cloud-rs/src/acl.rs` — `AclHandler`: `list_redis_rules()`, `list_roles()`, `list_acl_users()`, `get_acl_user(id)`
- `/Users/josh.rotenberg/Code/active/redis-cloud-rs/src/cloud_accounts.rs` — `CloudAccountsHandler`: `list()`, `get(id)`, `delete(id)`
- `/Users/josh.rotenberg/Code/active/redis-cloud-rs/src/fixed/subscriptions.rs` — `FixedSubscriptionHandler`: `list()`, `get_by_id(id)`, `delete_by_id(id)`
- `/Users/josh.rotenberg/Code/active/redis-cloud-rs/src/fixed/databases.rs` — `FixedDatabaseHandler`: `list(sub_id)`, `get_by_id(sub_id, db_id)`, `backup(sub_id, db_id)`
- `/Users/josh.rotenberg/Code/active/redis-cloud-rs/src/account.rs` — `AccountHandler`: `get()`, `system_logs(...)`, `payment_methods()`

## Decision: Python parity scope

**This task implements option 1 from the issue: Python is a deliberately smaller convenience
layer.** The rationale:

- The Python bindings are a read-oriented convenience layer for scripting, dashboards, and
  field engineering tooling.
- Write operations (create, update complex configs) are better served by the Rust client or
  the raw HTTP helpers (`post`, `put`, `patch`) that are already exposed.
- The Python surface should be **predictable and complete for reads**, covering all major
  domains with at minimum a `list` and/or `get` method.

The scope decision must be documented in two places:
1. `python/README.md` (create this file — it does not currently exist)
2. `README.md` (update the "Python Bindings" section to reference the scope decision)

## Task: what exactly to implement

### Phase 1: Update `python/src/client.rs` — add new domain methods

Add the following methods to `PyCloudClient`. Each method needs an async variant and a
`_sync` variant, following the exact same pattern as the existing methods.

**The pattern (study before coding):**

Async variant:
```rust
/// <Docstring> (async)
fn method_name<'py>(&self, py: Python<'py>, ...args) -> PyResult<Bound<'py, PyAny>> {
    let client = self.client.clone();
    future_into_py(py, async move {
        let handler = XxxHandler::new((*client).clone());
        let result = handler.simplified_method(...args).await.into_py_result()?;
        let json = serde_json::to_value(&result)
            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
        Python::with_gil(|py| Ok(json_to_py(py, json)))
    })
}
```

Sync variant:
```rust
/// <Docstring> (sync)
fn method_name_sync(&self, py: Python<'_>, ...args) -> PyResult<Py<PyAny>> {
    let client = self.client.clone();
    let result = block_on(py, async move {
        let handler = XxxHandler::new((*client).clone());
        handler.simplified_method(...args).await.into_py_result()
    })?;
    let json = serde_json::to_value(&result)
        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
    Ok(json_to_py(py, json))
}
```

**Methods to add, grouped by domain:**

#### Tasks domain
- `tasks()` / `tasks_sync()` — calls `TasksHandler::list()`, returns all tasks
- `task(task_id: String)` / `task_sync(task_id: String)` — calls `TasksHandler::get(task_id)`

#### Users domain
- `users()` / `users_sync()` — calls `UsersHandler::list()`
- `user(user_id: i64)` / `user_sync(user_id: i64)` — calls `UsersHandler::get(user_id as i32)`

#### ACL domain
- `acl_redis_rules()` / `acl_redis_rules_sync()` — calls `AclHandler::list_redis_rules()`
- `acl_roles()` / `acl_roles_sync()` — calls `AclHandler::list_roles()`
- `acl_users()` / `acl_users_sync()` — calls `AclHandler::list_acl_users()`

#### Cloud accounts domain
- `cloud_accounts()` / `cloud_accounts_sync()` — calls `CloudAccountsHandler::list()`
- `cloud_account(cloud_account_id: i64)` / `cloud_account_sync(cloud_account_id: i64)` — calls `CloudAccountsHandler::get(id as i32)`

#### Fixed (Essentials) subscriptions domain
- `fixed_subscriptions()` / `fixed_subscriptions_sync()` — calls `FixedSubscriptionHandler::list()`
- `fixed_subscription(subscription_id: i64)` / `fixed_subscription_sync(subscription_id: i64)` — calls `FixedSubscriptionHandler::get_by_id(id as i32)`

#### Fixed (Essentials) databases domain
- `fixed_databases(subscription_id: i64)` / `fixed_databases_sync(subscription_id: i64)` — calls `FixedDatabaseHandler::list(sub_id as i32)`
- `fixed_database(subscription_id: i64, database_id: i64)` / `fixed_database_sync(...)` — calls `FixedDatabaseHandler::get_by_id(sub_id as i32, db_id as i32)`

**Import additions needed in `python/src/client.rs`:**

```rust
use redis_cloud::{
    AccountHandler, AclHandler, CloudAccountHandler, CloudClient,
    DatabaseHandler, FixedDatabaseHandler, FixedSubscriptionHandler,
    SubscriptionHandler, TaskHandler, UserHandler,
};
```

Check the actual re-export names in `src/lib.rs` carefully before writing the imports:
- `TasksHandler` is re-exported as `TaskHandler`
- `UsersHandler` is re-exported as `UserHandler`
- `CloudAccountsHandler` is re-exported as `CloudAccountHandler`

### Phase 2: Update `python/src/lib.rs` — no changes needed unless new types are exported

Review `python/src/lib.rs`. No changes are expected unless new types need to be registered
as Python classes (they don't for this task — we continue using the JSON-to-Python pattern).

### Phase 3: Update Python tests (`python/tests/test_client.py`)

Add a new test class `TestNewDomainMethods` with `hasattr` existence checks for each new
method pair. Follow the existing `TestClientMethods` pattern exactly:

```python
class TestNewDomainMethods:
    """Tests that new domain methods are present on CloudClient."""

    @pytest.fixture
    def client(self):
        return CloudClient(api_key="test-key", api_secret="test-secret")

    def test_client_has_tasks_methods(self, client):
        assert hasattr(client, "tasks")
        assert hasattr(client, "tasks_sync")

    def test_client_has_task_method(self, client):
        assert hasattr(client, "task")
        assert hasattr(client, "task_sync")

    # ... one test per method pair
```

Add tests for: tasks, task, users, user, acl_redis_rules, acl_roles, acl_users,
cloud_accounts, cloud_account, fixed_subscriptions, fixed_subscription,
fixed_databases, fixed_database.

### Phase 4: Create `python/README.md`

Create `/Users/josh.rotenberg/Code/active/redis-cloud-rs/python/README.md` with:

1. **Parity scope statement** (first section, not buried): "Python is a deliberately
   smaller convenience layer. It covers read-oriented operations across all major API
   domains. Write operations (create, update, delete) are available via the raw HTTP
   helpers (`post`, `put`, `patch`, `delete`) or the Rust client."
2. **Supported API coverage table** — one row per domain with the methods exposed:

| Domain | Methods |
|--------|---------|
| Account | `account`, `account_sync` |
| Pro subscriptions | `subscriptions`, `subscriptions_sync`, `subscription`, `subscription_sync` |
| Pro databases | `databases`, `databases_sync`, `database`, `database_sync`, `all_databases`, `all_databases_sync` |
| Tasks | `tasks`, `tasks_sync`, `task`, `task_sync` |
| Users | `users`, `users_sync`, `user`, `user_sync` |
| ACL | `acl_redis_rules`, `acl_redis_rules_sync`, `acl_roles`, `acl_roles_sync`, `acl_users`, `acl_users_sync` |
| Cloud accounts | `cloud_accounts`, `cloud_accounts_sync`, `cloud_account`, `cloud_account_sync` |
| Essentials subscriptions | `fixed_subscriptions`, `fixed_subscriptions_sync`, `fixed_subscription`, `fixed_subscription_sync` |
| Essentials databases | `fixed_databases`, `fixed_databases_sync`, `fixed_database`, `fixed_database_sync` |
| Raw HTTP | `get`, `get_sync`, `post`, `post_sync`, `delete`, `delete_sync` |

3. **Out-of-scope section**: List what's intentionally deferred and why (connectivity
   handlers, cost_report, write operations, pagination beyond `all_databases`).

4. **Quick start example** in Python showing how to use the client.

5. **Installation instructions** (maturin / PyPI).

### Phase 5: Update `README.md` Python Bindings section

Find the "Python Bindings" section in the root `README.md` (around line 132-142). Update it to:
- Reference `python/README.md` for the full supported API.
- Replace the vague "thin PyO3 binding covering a subset of read operations" description with
  "a convenience layer covering read operations across all major API domains."
- Remove or update the "still being scoped under #66" reference since this PR closes #66.

## Verification gates

After each phase:

**After Phase 1 (Rust changes):**
1. `cargo check --workspace 2>&1 | tail -10` — must be clean
2. `cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tail -20` — must be clean
3. `cargo fmt --all`

**After Phase 2 (build Python extension):**
4. `cd /Users/josh.rotenberg/Code/active/redis-cloud-rs/python && maturin develop --uv 2>&1 | tail -15`
   Must complete without error. If it fails, read the full error and fix.

**After Phase 3 (Python tests):**
5. `cd /Users/josh.rotenberg/Code/active/redis-cloud-rs/python && python -m pytest tests/ -v 2>&1`
   All tests must pass. The new `TestNewDomainMethods` tests must all be present and green.

**Final:**
6. `cargo test --workspace 2>&1 | tail -20` — Rust tests must pass
7. `cd /Users/josh.rotenberg/Code/active/redis-cloud-rs && cargo test --test openapi_route_coverage 2>&1` — must stay green

## Tool-call discipline

- Read each file completely before editing it.
- For `client.rs`, read the whole file before adding any new methods.
- After a compilation failure, read the full error output before fixing. Do not guess.
- Check `src/lib.rs` re-exports to confirm the exact Rust type names to import.
- Do not modify any existing method signatures.
- Do not add new Rust dependencies (no new `Cargo.toml` entries).
- The `json_to_py` and `py_to_json` helpers are already in `python/src/client.rs` — use them.

## Constraints

- Do NOT push to remote (the runner handles push after roba completes).
- Do NOT run `gh pr create` (the runner created the draft PR).
- Do NOT run `git push`.
- Do NOT remove or modify existing methods in `python/src/client.rs`.
- Do NOT change `python/Cargo.toml` dependencies.
- Do NOT modify files under `src/` (Rust library) except as needed to satisfy compilation.
  Actually: do NOT modify the Rust library files at all — they were settled in #65.
- Do NOT add connectivity (vpc_peering, transit_gateway, psc, private_link) domain methods
  to the Python bindings — these are explicitly out of scope for this parity round.
- Do NOT add cost_report domain methods — out of scope for this round.

## Commit (at the end, after all checks pass)

```bash
git add python/src/client.rs python/tests/test_client.py python/README.md README.md
git commit -m "feat(python): expand bindings to cover all major read domains, document parity scope (closes #66)"
```