### PR TITLE
test: audit and expand coverage for alias layer and new domains

### DIFF
--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1,6 +1,10 @@
 """Tests for the Redis Cloud Python client."""
 
+import json
 import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
 import pytest
 from redis_cloud import CloudClient, RedisCloudError
 
@@ -252,3 +256,130 @@ class TestModuleExports:
 
         assert hasattr(redis_cloud, "__version__")
         assert isinstance(redis_cloud.__version__, str)
+
+
+class _JsonMockHandler(BaseHTTPRequestHandler):
+    """Dispatch GET requests to pre-registered JSON routes."""
+
+    routes: dict = {}
+
+    def do_GET(self):
+        body = self.routes.get(self.path)
+        if body is None:
+            self.send_response(404)
+            self.end_headers()
+            return
+        data = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, *_args):
+        pass  # silence
+
+
+@pytest.fixture(scope="class")
+def mock_server():
+    # NOTE: list endpoints (/fixed/subscriptions, .../databases) deserialize
+    # into wrapper *objects* on the Rust side, not bare arrays, so their
+    # fixtures are `{}` rather than `[]`.
+    routes = {
+        "/tasks": {"tasks": []},
+        "/tasks/task-1": {"taskId": "task-1", "status": "processing-completed"},
+        "/users": {"account": 1},
+        "/users/1": {"id": 1, "name": "Test User", "email": "t@example.com"},
+        "/acl/redisRules": {},
+        "/acl/roles": {},
+        "/acl/users": {},
+        "/acl/users/1": {"id": 1},
+        "/cloud-accounts": {"accountId": 1},
+        "/cloud-accounts/1": {
+            "id": 1,
+            "name": "test",
+            "accessKeyId": "AKID",
+            "status": "active",
+            "provider": "AWS",
+        },
+        "/fixed/subscriptions": {},
+        "/fixed/subscriptions/1": {"id": 1, "name": "test-fixed"},
+        "/fixed/subscriptions/1/databases": {},
+        "/fixed/subscriptions/1/databases/1": {"id": 1, "name": "test-db"},
+    }
+
+    class _Handler(_JsonMockHandler):
+        pass
+
+    _Handler.routes = routes
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{port}"
+    server.shutdown()
+
+
+class TestDomainCallsSync:
+    """Smoke: each new domain binding makes a real HTTP call through the Rust layer."""
+
+    @pytest.fixture
+    def client(self, mock_server):
+        return CloudClient(
+            api_key="test-key",
+            api_secret="test-secret",
+            base_url=mock_server,
+        )
+
+    def test_tasks_list_sync(self, client):
+        result = client.tasks_sync()
+        assert isinstance(result, list)
+
+    def test_task_get_sync(self, client):
+        result = client.task_sync("task-1")
+        assert result is not None
+
+    def test_users_list_sync(self, client):
+        result = client.users_sync()
+        assert result is not None
+
+    def test_user_get_sync(self, client):
+        result = client.user_sync(1)
+        assert result is not None
+
+    def test_acl_redis_rules_sync(self, client):
+        result = client.acl_redis_rules_sync()
+        assert result is not None
+
+    def test_acl_roles_sync(self, client):
+        result = client.acl_roles_sync()
+        assert result is not None
+
+    def test_acl_users_sync(self, client):
+        result = client.acl_users_sync()
+        assert result is not None
+
+    def test_cloud_accounts_sync(self, client):
+        result = client.cloud_accounts_sync()
+        assert result is not None
+
+    def test_cloud_account_get_sync(self, client):
+        result = client.cloud_account_sync(1)
+        assert result is not None
+
+    def test_fixed_subscriptions_sync(self, client):
+        result = client.fixed_subscriptions_sync()
+        assert result is not None
+
+    def test_fixed_subscription_get_sync(self, client):
+        result = client.fixed_subscription_sync(1)
+        assert result is not None
+
+    def test_fixed_databases_sync(self, client):
+        result = client.fixed_databases_sync(1)
+        assert result is not None
+
+    def test_fixed_database_get_sync(self, client):
+        result = client.fixed_database_sync(1, 1)
+        assert result is not None

--- a/tests/acl_tests.rs
+++ b/tests/acl_tests.rs
@@ -854,3 +854,89 @@ async fn test_create_user_with_full_response() {
     assert_eq!(response.resource_id, Some(999));
     assert_eq!(response.additional_resource_id, Some(888));
 }
+
+// Helper: build a Cloud client wired to the given mock server URI.
+fn test_client(uri: String) -> CloudClient {
+    CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(uri)
+        .build()
+        .unwrap()
+}
+
+// Alias round-trip: `list_redis_rules()` delegates to `get_all_redis_rules()`.
+#[tokio::test]
+async fn test_acl_list_redis_rules_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/acl/redisRules"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&mock_server)
+        .await;
+
+    let handler = AclHandler::new(test_client(mock_server.uri()));
+    let result = handler.list_redis_rules().await.unwrap();
+
+    assert_eq!(result.account_id, None);
+}
+
+// Alias round-trip: `list_roles()` delegates to `get_all_roles()`.
+#[tokio::test]
+async fn test_acl_list_roles_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/acl/roles"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&mock_server)
+        .await;
+
+    let handler = AclHandler::new(test_client(mock_server.uri()));
+    let result = handler.list_roles().await.unwrap();
+
+    assert_eq!(result.account_id, None);
+}
+
+// Alias round-trip: `list_acl_users()` delegates to `get_all_acl_users()`.
+#[tokio::test]
+async fn test_acl_list_acl_users_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/acl/users"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&mock_server)
+        .await;
+
+    let handler = AclHandler::new(test_client(mock_server.uri()));
+    let result = handler.list_acl_users().await.unwrap();
+
+    assert_eq!(result.account_id, None);
+}
+
+// Alias round-trip: `get_acl_user(id)` delegates to `get_acl_user_by_id()`.
+#[tokio::test]
+async fn test_acl_get_acl_user_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/acl/users/5"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 5 })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = AclHandler::new(test_client(mock_server.uri()));
+    let result = handler.get_acl_user(5).await.unwrap();
+
+    assert_eq!(result.id, Some(5));
+}

--- a/tests/cloud_accounts_tests.rs
+++ b/tests/cloud_accounts_tests.rs
@@ -793,3 +793,79 @@ async fn test_error_handling_500() {
         _ => panic!("Expected InternalServerError error"),
     }
 }
+
+// Helper: build a Cloud client wired to the given mock server URI.
+fn test_client(uri: String) -> CloudClient {
+    CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(uri)
+        .build()
+        .unwrap()
+}
+
+// Alias round-trip: `list()` delegates to `get_cloud_accounts()`.
+#[tokio::test]
+async fn test_cloud_accounts_list_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/cloud-accounts"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "accountId": 1 })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = CloudAccountHandler::new(test_client(mock_server.uri()));
+    let result = handler.list().await.unwrap();
+
+    assert_eq!(result.account_id, Some(1));
+}
+
+// Alias round-trip: `get(id)` delegates to `get_cloud_account_by_id()`.
+#[tokio::test]
+async fn test_cloud_account_get_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/cloud-accounts/42"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 42,
+            "name": "my-account",
+            "accessKeyId": "AKID",
+            "status": "active",
+            "provider": "AWS"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = CloudAccountHandler::new(test_client(mock_server.uri()));
+    let result = handler.get(42).await.unwrap();
+
+    assert_eq!(result.id, Some(42));
+}
+
+// Alias round-trip: `delete(id)` delegates to `delete_cloud_account()`.
+#[tokio::test]
+async fn test_cloud_account_delete_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/cloud-accounts/43"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-del-ca",
+            "status": "processing-completed"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = CloudAccountHandler::new(test_client(mock_server.uri()));
+    let result = handler.delete(43).await.unwrap();
+
+    assert_eq!(result.task_id, Some("task-del-ca".to_string()));
+}

--- a/tests/connectivity_tests.rs
+++ b/tests/connectivity_tests.rs
@@ -967,3 +967,25 @@ async fn test_get_psc_service_endpoints_active_active() {
 
     assert_eq!(result.task_id.as_deref(), Some("task-aa-get-psc-endpoints"));
 }
+
+// Alias round-trip: `list_tgw_attachments(id)` delegates to `get_tgws(id)`.
+#[tokio::test]
+async fn test_list_tgw_attachments_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/subscriptions/123/transitGateways"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-tgw-list",
+            "status": "processing-completed"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = ConnectivityHandler::new(test_client(mock_server.uri()));
+    let result = handler.list_tgw_attachments(123).await.unwrap();
+
+    assert_eq!(result.task_id, Some("task-tgw-list".to_string()));
+}

--- a/tests/subscriptions_tests.rs
+++ b/tests/subscriptions_tests.rs
@@ -724,3 +724,79 @@ async fn test_update_resource_tags() {
     assert_eq!(result.task_id.as_deref(), Some("task-update-tags"));
     assert_eq!(result.status, Some(TaskStatus::ProcessingInProgress));
 }
+
+// Helper: build a Cloud client wired to the given mock server URI.
+fn test_client(uri: String) -> CloudClient {
+    CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(uri)
+        .build()
+        .unwrap()
+}
+
+// Alias round-trip: `list()` delegates to `get_all_subscriptions()`.
+#[tokio::test]
+async fn test_subscriptions_list_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/subscriptions"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "accountId": 5,
+            "subscriptions": []
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = SubscriptionsHandler::new(test_client(mock_server.uri()));
+    let result = handler.list().await.unwrap();
+
+    assert_eq!(result.account_id, Some(5));
+}
+
+// Alias round-trip: `get(id)` delegates to `get_subscription_by_id()`.
+#[tokio::test]
+async fn test_subscription_get_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/subscriptions/200"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 200,
+            "name": "alias-sub"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = SubscriptionsHandler::new(test_client(mock_server.uri()));
+    let result = handler.get(200).await.unwrap();
+
+    assert_eq!(result.id, Some(200));
+}
+
+// Alias round-trip: `delete(id)` delegates to `delete_subscription_by_id()`.
+#[tokio::test]
+async fn test_subscription_delete_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/subscriptions/201"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-del-sub",
+            "status": "processing-completed"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = SubscriptionsHandler::new(test_client(mock_server.uri()));
+    let result = handler.delete(201).await.unwrap();
+
+    assert_eq!(result.task_id, Some("task-del-sub".to_string()));
+}

--- a/tests/tasks_tests.rs
+++ b/tests/tasks_tests.rs
@@ -363,6 +363,47 @@ async fn test_error_handling_404() {
     }
 }
 
+// Alias round-trip: `list()` delegates to `get_all_tasks()`.
+#[tokio::test]
+async fn test_tasks_list_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/tasks"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "tasks": [] })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = TasksHandler::new(test_client(mock_server.uri()));
+    let result = handler.list().await.unwrap();
+
+    assert!(result.is_empty());
+}
+
+// Alias round-trip: `get(id)` delegates to `get_task_by_id(id)`.
+#[tokio::test]
+async fn test_tasks_get_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/tasks/task-alias-1"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-alias-1",
+            "status": "processing-completed"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = TasksHandler::new(test_client(mock_server.uri()));
+    let result = handler.get("task-alias-1".to_string()).await.unwrap();
+
+    assert_eq!(result.task_id, Some("task-alias-1".to_string()));
+}
+
 #[tokio::test]
 async fn test_error_handling_500() {
     let mock_server = MockServer::start().await;

--- a/tests/types_tests.rs
+++ b/tests/types_tests.rs
@@ -297,3 +297,12 @@ fn test_extra_fields_ignored() {
     let tags: CloudTags = serde_json::from_value(json).unwrap();
     assert_eq!(tags.account_id, Some(7));
 }
+
+// An unrecognized status string must map to `TaskStatus::Unknown` (via
+// `#[serde(other)]`) rather than failing deserialization — this keeps task
+// polling resilient to new server-side statuses.
+#[test]
+fn test_task_status_unknown_deserializes() {
+    let s: TaskStatus = serde_json::from_str("\"some-future-status\"").unwrap();
+    assert!(matches!(s, TaskStatus::Unknown));
+}

--- a/tests/users_tests.rs
+++ b/tests/users_tests.rs
@@ -1,3 +1,4 @@
+use redis_cloud::users::AccountUserUpdateRequest;
 use redis_cloud::{CloudClient, UserHandler};
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
@@ -171,4 +172,102 @@ async fn test_error_handling_404() {
     } else {
         panic!("Expected NotFound error");
     }
+}
+
+// Helper: build a Cloud client wired to the given mock server URI.
+fn test_client(uri: String) -> CloudClient {
+    CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(uri)
+        .build()
+        .unwrap()
+}
+
+// Alias round-trip: `list()` delegates to `get_all_users()`.
+#[tokio::test]
+async fn test_users_list_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/users"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "account": 1 })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = UserHandler::new(test_client(mock_server.uri()));
+    let result = handler.list().await.unwrap();
+
+    assert_eq!(result.account, Some(1));
+}
+
+// Alias round-trip: `get(id)` delegates to `get_user_by_id(id)`.
+#[tokio::test]
+async fn test_users_get_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/users/77"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 77 })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = UserHandler::new(test_client(mock_server.uri()));
+    let result = handler.get(77).await.unwrap();
+
+    assert_eq!(result.id, Some(77));
+}
+
+// Alias round-trip: `delete(id)` delegates to `delete_user_by_id(id)`.
+#[tokio::test]
+async fn test_users_delete_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/users/88"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-del-user",
+            "status": "processing-completed"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = UserHandler::new(test_client(mock_server.uri()));
+    let result = handler.delete(88).await.unwrap();
+
+    assert_eq!(result.task_id, Some("task-del-user".to_string()));
+}
+
+// Alias round-trip: `update(id, req)` delegates to `update_user(id, req)`.
+#[tokio::test]
+async fn test_users_update_alias() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/users/99"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-upd-user",
+            "status": "processing-completed"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let handler = UserHandler::new(test_client(mock_server.uri()));
+    let request = AccountUserUpdateRequest {
+        user_id: None,
+        name: "Updated Name".to_string(),
+        role: None,
+        command_type: None,
+    };
+    let result = handler.update(99, &request).await.unwrap();
+
+    assert_eq!(result.task_id, Some("task-upd-user".to_string()));
 }


### PR DESCRIPTION
Closes #115

## Summary
- Add wiremock round-trip tests for all simplified alias methods added in #65 (tasks, users, cloud_accounts, subscriptions, acl, connectivity)
- Add `TaskStatus::Unknown` serde-other deserialization test
- Upgrade Python `TestNewDomainMethods` from `hasattr`-only to smoke call-level tests for all 6 new domains added in #66, using a local HTTP mock server

## Test plan
- [ ] `cargo test --workspace` passes clean
- [ ] Each alias method (`list()`, `get()`, etc.) has at least one wiremock round-trip test
- [ ] `TaskStatus::Unknown` is exercised via the `#[serde(other)]` path
- [ ] Python call-level tests pass with `maturin develop` + `pytest`
- [ ] `openapi_route_coverage` still passes