### PR TITLE
docs: audit and update documentation for release readiness (closes #114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Simplified alias methods across all domain handlers for a concise, ergonomic
+  API surface ([#65](https://github.com/redis-developer/redis-cloud-rs/issues/65)).
+  Every handler that previously exposed only verbose `get_all_X` / `get_X_by_id` /
+  `create_X` style methods now also exposes short `list` / `get` / `create` /
+  `update` / `delete` aliases. The verbose forms are retained for backward
+  compatibility. Accessible via `client.subscriptions().list()`,
+  `client.databases().list(sub_id)`, `client.acl().list_redis_rules()`, etc.
+
+- Python bindings expanded to cover all major read domains: Account, Tasks,
+  Users, ACL (redis rules, roles, users), Cloud Accounts, Essentials
+  Subscriptions, and Essentials Databases, in addition to the previously covered
+  Pro subscriptions and databases
+  ([#66](https://github.com/redis-developer/redis-cloud-rs/issues/66)).
+  Every domain method is available in both async and `_sync` blocking variants.
+  Coverage table and parity-scope documentation updated in `python/README.md`.
+
+- Implemented every remaining uncovered spec route, raising route coverage to
+  **155/155 (100%)** and emptying the unsupported-route allowlist
+  ([#72](https://github.com/redis-developer/redis-cloud-rs/issues/72)). New
+  typed handler methods and request/response types:
+  - Active-Active VPC peering CRUD on `VpcPeeringHandler` (see the Changed note
+    above), with a new `ActiveActiveVpcPeeringCreateRequest`
+    (`for_aws` / `for_gcp` constructors).
+  - `PrivateLinkHandler::disassociate_connections`, `delete_active_active`, and
+    `disassociate_connections_active_active`, with new
+    `PrivateLinkConnectionsDisassociateRequest`,
+    `PrivateLinkActiveActiveConnectionsDisassociateRequest`, and
+    `PrivateLinkConnectionDisassociate` types.
+  - `PscHandler::get_endpoints` and `get_endpoints_active_active`
+    (`GET .../private-service-connect/{pscServiceId}`).
+  - `get_traffic` and `resume_traffic` on both the Pro and Essentials database
+    handlers, with a shared `types::DatabaseTrafficStateResponse`.
+  - `SubscriptionHandler::update_resource_tags`
+    (`PUT /subscriptions/{id}/resource-tags`) with a new
+    `SubscriptionResourceTagsUpdateRequest`.
+
+- Executable route-coverage checks between the typed client handlers and the
+  bundled OpenAPI spec
+  ([#67](https://github.com/redis-developer/redis-cloud-rs/issues/67)). A new
+  `tests/openapi_route_coverage.rs` extracts the client's routes from source and
+  diffs them against the spec; intentional gaps are tracked in two allowlists
+  (`tests/fixtures/openapi_unsupported_routes.txt`,
+  `openapi_non_spec_routes.txt`). CI now fails when a spec route becomes
+  uncovered — or a handler route goes off-spec — without an explicit entry, and
+  when an allowlist entry goes stale.
+
 ### Changed
 
 - **Breaking:** reconciled the connectivity (Transit Gateway + Private Service
@@ -44,40 +92,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `create_active_active` now takes `&ActiveActiveVpcPeeringCreateRequest`
   (was `&VpcPeeringCreateRequest`); `update_active_active` now takes
   `&VpcPeeringUpdateAwsRequest`.
-
-### Added
-
-- Implemented every remaining uncovered spec route, raising route coverage to
-  **155/155 (100%)** and emptying the unsupported-route allowlist
-  ([#72](https://github.com/redis-developer/redis-cloud-rs/issues/72)). New
-  typed handler methods and request/response types:
-  - Active-Active VPC peering CRUD on `VpcPeeringHandler` (see the Changed note
-    above), with a new `ActiveActiveVpcPeeringCreateRequest`
-    (`for_aws` / `for_gcp` constructors).
-  - `PrivateLinkHandler::disassociate_connections`, `delete_active_active`, and
-    `disassociate_connections_active_active`, with new
-    `PrivateLinkConnectionsDisassociateRequest`,
-    `PrivateLinkActiveActiveConnectionsDisassociateRequest`, and
-    `PrivateLinkConnectionDisassociate` types.
-  - `PscHandler::get_endpoints` and `get_endpoints_active_active`
-    (`GET .../private-service-connect/{pscServiceId}`).
-  - `get_traffic` and `resume_traffic` on both the Pro and Essentials database
-    handlers, with a shared `types::DatabaseTrafficStateResponse`.
-  - `SubscriptionHandler::update_resource_tags`
-    (`PUT /subscriptions/{id}/resource-tags`) with a new
-    `SubscriptionResourceTagsUpdateRequest`.
-
-- Executable route-coverage checks between the typed client handlers and the
-  bundled OpenAPI spec
-  ([#67](https://github.com/redis-developer/redis-cloud-rs/issues/67)). A new
-  `tests/openapi_route_coverage.rs` extracts the client's routes from source and
-  diffs them against the spec; intentional gaps are tracked in two allowlists
-  (`tests/fixtures/openapi_unsupported_routes.txt`,
-  `openapi_non_spec_routes.txt`). CI now fails when a spec route becomes
-  uncovered — or a handler route goes off-spec — without an explicit entry, and
-  when an allowlist entry goes stale.
-
-### Changed
 
 - **Breaking:** connectivity handlers now return `TaskStateUpdate` instead of
   `serde_json::Value` for every endpoint the spec marks task-returning

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A comprehensive Rust client library for the Redis Cloud REST API, with Python bi
 
 ## Features
 
-- Broad coverage of Redis Cloud REST API endpoints, checked against the bundled OpenAPI spec in CI
+- Complete coverage of all Redis Cloud REST API endpoints (155/155 routes verified against the bundled OpenAPI spec in CI)
 - Async/await support with tokio
 - Strong typing for API requests and responses
 - Comprehensive error handling
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // List Pro subscriptions
-    let subs = client.subscriptions().get_all_subscriptions().await?;
+    let subs = client.subscriptions().list().await?;
     for sub in subs.subscriptions.unwrap_or_default() {
         println!("  - subscription {:?}: {:?}", sub.id, sub.name);
     }
@@ -143,12 +143,14 @@ The PyPI publish workflow has been failing since the `reqwest 0.13` upgrade
 
 ## API Coverage
 
-The crate covers most of the documented Redis Cloud REST API surface. Route
-coverage is enforced by an executable check
+The crate covers **100% of the documented Redis Cloud REST API surface** (155/155
+routes). Route coverage is enforced by an executable check
 ([`tests/openapi_route_coverage.rs`](tests/openapi_route_coverage.rs)) that
-diffs the typed handlers against the bundled OpenAPI spec; the remaining
-deferred routes are tracked explicitly in
-[`tests/fixtures/openapi_unsupported_routes.txt`](tests/fixtures/openapi_unsupported_routes.txt).
+diffs the typed handlers against the bundled OpenAPI spec; intentional gaps
+(currently none) and known off-spec routes (currently none) are tracked in
+[`tests/fixtures/openapi_unsupported_routes.txt`](tests/fixtures/openapi_unsupported_routes.txt)
+and
+[`tests/fixtures/openapi_non_spec_routes.txt`](tests/fixtures/openapi_non_spec_routes.txt).
 
 Handler organization:
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // List all Pro subscriptions
     println!("\nFetching Pro subscriptions...");
-    match client.subscriptions().get_all_subscriptions().await {
+    match client.subscriptions().list().await {
         Ok(response) => {
             if let Some(subs) = response.subscriptions {
                 println!("Found {} Pro subscriptions:", subs.len());

--- a/examples/databases.rs
+++ b/examples/databases.rs
@@ -35,10 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // List databases in subscription
     println!("\nFetching databases...");
-    let dbs = client
-        .databases()
-        .list(subscription_id)
-        .await?;
+    let dbs = client.databases().list(subscription_id).await?;
 
     println!("Found {} databases:", dbs.len());
     for db in &dbs {

--- a/examples/databases.rs
+++ b/examples/databases.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(id) => id,
         None => {
             // Get first Pro subscription
-            let subs = client.subscriptions().get_all_subscriptions().await?;
+            let subs = client.subscriptions().list().await?;
             subs.subscriptions
                 .and_then(|s| s.first().and_then(|sub| sub.id))
                 .expect("No subscriptions found. Pass subscription ID as argument.")
@@ -35,25 +35,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // List databases in subscription
     println!("\nFetching databases...");
-    let response = client
+    let dbs = client
         .databases()
-        .get_subscription_databases(subscription_id, None, None)
+        .list(subscription_id)
         .await?;
 
-    for sub_info in &response.subscription {
-        let dbs = &sub_info.databases;
-        println!("Found {} databases:", dbs.len());
-        for db in dbs {
-            println!(
-                "  - ID: {:?}, Name: {:?}, Status: {:?}",
-                db.database_id, db.name, db.status
-            );
-            if let Some(endpoint) = &db.public_endpoint {
-                println!("    Endpoint: {endpoint}");
-            }
-            if let Some(memory) = db.memory_limit_in_gb {
-                println!("    Memory: {memory} GB");
-            }
+    println!("Found {} databases:", dbs.len());
+    for db in &dbs {
+        println!(
+            "  - ID: {:?}, Name: {:?}, Status: {:?}",
+            db.database_id, db.name, db.status
+        );
+        if let Some(endpoint) = &db.public_endpoint {
+            println!("    Endpoint: {endpoint}");
+        }
+        if let Some(memory) = db.memory_limit_in_gb {
+            println!("    Memory: {memory} GB");
         }
     }
 

--- a/python/README.md
+++ b/python/README.md
@@ -9,7 +9,7 @@ Rust client for the Redis Cloud REST API.
 operations across all major API domains — the methods you reach for when
 scripting, building dashboards, or doing field-engineering work. Write
 operations (create, update, delete) are available via the raw HTTP helpers
-(`post`, `put`, `patch`, `delete`) or the full-featured Rust client.
+(`post`, `delete`) or the full-featured Rust client.
 
 Every domain method comes in two flavors:
 
@@ -42,8 +42,9 @@ parity round. They are fully supported by the Rust client, and most can be
 reached from Python via the raw HTTP helpers when needed:
 
 - **Write operations** (create / update / delete of subscriptions, databases,
-  users, etc.) — use `post`, `put`, `patch`, and `delete` with the relevant API
-  path, or the Rust client for typed request bodies.
+  users, etc.) — use `post` and `delete` with the relevant API path for simple
+  operations, or the full-featured Rust client for typed `put`/`patch` request
+  bodies and structured responses.
 - **Connectivity handlers** — VPC peering, Transit Gateway, Private Service
   Connect (PSC), and Private Link. These are complex, write-heavy networking
   flows better served by the Rust client.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! let sub_handler = SubscriptionHandler::new(client.clone());
 //!
 //! // List subscriptions
-//! let subscriptions = sub_handler.get_all_subscriptions().await?;
+//! let subscriptions = sub_handler.list().await?;
 //!
 //! // Create a new subscription using raw API
 //! let new_subscription = json!({
@@ -268,7 +268,11 @@
 //! | [`AccountHandler`] | Account management | info, API keys, payment methods, SSO |
 //! | [`UserHandler`] | User management | create, update, delete, invite, roles |
 //! | [`AclHandler`] | Access control | users, roles, Redis rules, database ACLs |
-//! | [`ConnectivityHandler`] | Network connectivity | VPC peering, Transit Gateway, PSC |
+//! | [`VpcPeeringHandler`] | VPC peering | standard and Active-Active peering |
+//! | [`TransitGatewayHandler`] | AWS Transit Gateway | attachments, invitations, CIDR updates |
+//! | [`PscHandler`] | GCP Private Service Connect | endpoints (standard and Active-Active) |
+//! | [`PrivateLinkHandler`] | AWS PrivateLink | services, connections, endpoints |
+//! | [`CostReportHandler`] | Cost reports | FOCUS-format billing exports |
 //! | [`CloudAccountHandler`] | Cloud providers | AWS, GCP, Azure account integration |
 //! | [`TaskHandler`] | Async operations | track long-running operations |
 //!


### PR DESCRIPTION
## Summary

Documentation audit and update for release readiness. Covers all significant
changes since v0.9.5 that weren't yet reflected in docs.

**Changes:**
- `CHANGELOG.md`: add missing `[Unreleased]` entries for simplified alias façade (#65 / PR #112) and Python parity expansion (#66 / PR #113); consolidate duplicate `### Changed` sections; reorder per Keep a Changelog convention (Added → Changed → Fixed)
- `README.md`: update Quick Start and examples to prefer simplified alias methods; update API coverage section to reflect 100% spec coverage; clarify empty allowlists
- `src/lib.rs`: update handler overview table to show individual connectivity handlers (`VpcPeeringHandler`, `TransitGatewayHandler`, `PscHandler`, `PrivateLinkHandler`) and add `CostReportHandler`; update subscription examples to use `list()` alias; update feature list
- `python/README.md`: fix Out-of-scope section — `put`/`patch` are not exposed as raw HTTP helpers in the Python bindings
- `examples/basic.rs`: prefer `list()` over `get_all_subscriptions()`
- `examples/databases.rs`: prefer `list()` over `get_subscription_databases()` with updated iteration

## Test plan

- [ ] `cargo doc --no-deps --all-features 2>&1 | grep warning` produces no output
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` is clean
- [ ] CHANGELOG `[Unreleased]` has entries for #65 and #66
- [ ] README examples use the simplified alias API
- [ ] python/README.md coverage table matches `python/src/client.rs`