### PR TITLE
docs(examples): fix cost-report id extraction and output filename

### DIFF
--- a/examples/cost_report.rs
+++ b/examples/cost_report.rs
@@ -57,17 +57,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("  status={:?} progress={:?}", state.status, state.progress);
         match state.status {
             Some(TaskStatus::ProcessingCompleted) => {
-                // ProcessorResponse shape varies; raw JSON is the safest read.
-                let raw = serde_json::to_value(&state.response)?;
-                break raw
-                    .get("resourceId")
+                // The live API nests the id at `response.resource.costReportId`;
+                // `ProcessorResponse::resource` captures that object as a map.
+                break state
+                    .response
+                    .as_ref()
+                    .and_then(|r| r.resource.as_ref())
+                    .and_then(|res| res.get("costReportId"))
                     .and_then(|v| v.as_str())
                     .map(str::to_string)
-                    .or_else(|| {
-                        raw.get("costReportId")
-                            .and_then(|v| v.as_str())
-                            .map(str::to_string)
-                    })
                     .ok_or("task completed but did not return a costReportId")?;
             }
             Some(TaskStatus::ProcessingError) => {
@@ -89,7 +87,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .download_cost_report(&report_id)
         .await?;
 
-    let out_path = format!("cost-report-{report_id}.json");
+    // `report_id` already carries the report's own extension (e.g. `.csv`).
+    let out_path = format!("cost-report-{report_id}");
     std::fs::write(&out_path, &bytes)?;
     println!("wrote {} bytes to {out_path}", bytes.len());
 


### PR DESCRIPTION
## What

The `cost_report` example never completed against the live Redis Cloud API. Two issues, both found while smoke-testing the examples against a real Cloud account:

1. **Report-id extraction looked in the wrong place.** The example read the id from `response.resourceId` / `response.costReportId`, but the live API nests it one level deeper:

   ```json
   "response": { "resource": { "costReportId": "RedisCloudCosts_..._.csv" } }
   ```

   This now reads from the typed `ProcessorResponse::resource` map, which already models that shape correctly — so the bug was purely in the example, not the library.

2. **Redundant output extension.** `report_id` already carries the report's own extension (e.g. `.csv`), so the file was written as `...csv.json`. Dropped the extra `.json`.

## Verification

Ran end-to-end against a live account (`Developer Experience Redis`): POST `/cost-report` → poll task to `processing-completed` → extract id → download report bytes. Before the fix it errored with *"task completed but did not return a costReportId"*; after, it downloads the report cleanly.

`cargo fmt --all` and `cargo clippy --example cost_report --all-features` clean.

## Scope

Example-only change (no library/API change), hence `docs:` — does not affect the published crate's surface.