### PR TITLE
fix(databases): accept array-shaped module `parameters` on reads

### DIFF
--- a/src/fixed/databases.rs
+++ b/src/fixed/databases.rs
@@ -285,8 +285,13 @@ pub struct DatabaseModuleSpec {
     pub name: String,
 
     /// Optional. Redis advanced capability parameters. Use GET /database-modules to get the available capabilities and their parameters.
+    ///
+    /// Kept as a [`Value`] because the wire shape is asymmetric: create
+    /// requests send an object (capability name → parameter map), while
+    /// database reads return an array. A typed map only matched the request
+    /// side and failed to deserialize real responses.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parameters: Option<HashMap<String, Value>>,
+    pub parameters: Option<Value>,
 }
 
 /// Optional. Changes Replica Of (also known as Active-Passive) configuration details.

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -453,8 +453,13 @@ pub struct DatabaseModuleSpec {
     pub name: String,
 
     /// Optional. Redis advanced capability parameters. Use GET /database-modules to get the available capabilities and their parameters.
+    ///
+    /// Kept as a [`Value`] because the wire shape is asymmetric: create
+    /// requests send an object (capability name → parameter map), while
+    /// database reads return an array. A typed map only matched the request
+    /// side and failed to deserialize real responses.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parameters: Option<HashMap<String, Value>>,
+    pub parameters: Option<Value>,
 }
 
 /// Optional. Changes Replica Of (also known as Active-Passive) configuration details.

--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -222,8 +222,13 @@ pub struct DatabaseModuleSpec {
     pub name: String,
 
     /// Optional. Redis advanced capability parameters. Use GET /database-modules to get the available capabilities and their parameters.
+    ///
+    /// Kept as a [`Value`] because the wire shape is asymmetric: create
+    /// requests send an object (capability name → parameter map), while
+    /// database reads return an array. A typed map only matched the request
+    /// side and failed to deserialize real responses.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parameters: Option<HashMap<String, Value>>,
+    pub parameters: Option<Value>,
 }
 
 /// Update Pro subscription

--- a/tests/fixed_databases_tests.rs
+++ b/tests/fixed_databases_tests.rs
@@ -560,3 +560,97 @@ async fn test_resume_fixed_database_traffic() {
     // Empty 204 body must deserialize cleanly into `()`.
     handler.resume_traffic(123, 456).await.unwrap();
 }
+
+// Regression for #119: the live API returns `modules[].parameters` as a JSON
+// array (`[]` when empty, objects otherwise), but the field used to be typed
+// as a map, so real database reads failed to deserialize. This mirrors the
+// real `GET /fixed/subscriptions/{id}/databases` response shape — including the
+// extra module metadata and nested `security`/`clustering`/`backup` objects the
+// API actually sends — and asserts the call succeeds.
+#[tokio::test]
+async fn test_fixed_database_modules_parameters_array_deserializes() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions/123/databases"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "accountId": 456,
+            "subscription": {
+                "subscriptionId": 123,
+                "numberOfDatabases": 1,
+                "databases": [
+                    {
+                        "databaseId": 13926356,
+                        "name": "with-modules",
+                        "protocol": "stack",
+                        "provider": "AWS",
+                        "region": "us-east-1",
+                        "redisVersion": "8.2",
+                        "status": "active",
+                        "planMemoryLimit": 12.0,
+                        "memoryLimitMeasurementUnit": "MB",
+                        "memoryStorage": "ram",
+                        "networkMonthlyUsageInByte": 1.83615528E+10,
+                        "security": {
+                            "defaultUserEnabled": false,
+                            "enableTls": false,
+                            "sourceIps": ["0.0.0.0/0"]
+                        },
+                        "clustering": {
+                            "enabled": false,
+                            "regexRules": [{ "ordinal": 0, "pattern": ".*" }],
+                            "hashingPolicy": "standard"
+                        },
+                        "modules": [
+                            {
+                                "id": 7778767,
+                                "name": "RedisTimeSeries",
+                                "capabilityName": "Time series",
+                                "version": "8.2.9",
+                                "description": "Time-Series data structure for redis",
+                                "parameters": []
+                            },
+                            {
+                                "id": 8131105,
+                                "name": "RedisBloom",
+                                "version": "8.2.13",
+                                "parameters": [{ "name": "error_rate", "value": "0.01" }]
+                            }
+                        ],
+                        "backup": { "remoteBackupEnabled": false }
+                    }
+                ],
+                "links": []
+            },
+            "links": []
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = FixedDatabaseHandler::new(client);
+    let result = handler.list(123, None, None).await.unwrap();
+
+    let db = result
+        .subscription
+        .and_then(|s| s.databases.into_iter().next())
+        .expect("response should include the database");
+    let modules = db.modules.expect("modules should deserialize");
+    assert_eq!(modules.len(), 2);
+    assert_eq!(modules[0].name, "RedisTimeSeries");
+    // Empty array parameters.
+    assert_eq!(modules[0].parameters, Some(json!([])));
+    // Populated array parameters round-trip as a JSON array.
+    assert_eq!(
+        modules[1].parameters,
+        Some(json!([{ "name": "error_rate", "value": "0.01" }]))
+    );
+}


### PR DESCRIPTION
Closes #119.

## Problem

`DatabaseModuleSpec.parameters` was typed `Option<HashMap<String, Value>>` — matching the OpenAPI spec, which models it as an object (the create-*request* shape). But the live API returns `parameters` as a **JSON array** on database *reads*, so `fixed_databases().list()` / `.get_by_id()` (and the equivalent Pro-path calls) failed to deserialize every real database that has modules:

```
Failed to deserialize field 'subscription.databases[0].modules[0].parameters':
invalid type: sequence, expected a map
```

Mock tests never caught it because the fixtures omitted `modules` entirely.

## Fix

Retype `parameters` as `Option<serde_json::Value>` in all three duplicated `DatabaseModuleSpec` definitions (`fixed/databases`, `flexible/databases`, `flexible/subscriptions`). `Value` is the only type that tolerates both wire shapes — the request object and the response array — and matches existing house style for shape-varying fields (e.g. `ProcessorResponse::resource`).

This is a small public-type change; `release-plz`'s `semver_check` will surface the appropriate bump.

## Test

Added `test_fixed_database_modules_parameters_array_deserializes`, mirroring the real `GET /fixed/subscriptions/{id}/databases` response: modules with both empty (`[]`) and populated array `parameters`, plus the nested `security`/`clustering`/`backup` objects the API actually sends.

## Verification

- Reproduced live: the failing `list()` call now succeeds against a real Essentials database with 4 modules.
- `cargo fmt`, `cargo clippy --workspace --all-targets --all-features` clean.
- `cargo test --workspace --all-features`: 399 passed, 10 ignored.

## Scope note

This fixes the hard *deserialize failure*. The same response also carries module metadata (`id`/`capabilityName`/`version`/`description`) and nested `security`/`clustering`/`backup` objects that the flat `FixedDatabase` model still drops silently — tracked separately in #121.