### PR TITLE
fix(account): accept numeric `creditCardEndsWith` in payment methods

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -237,6 +237,28 @@ pub struct PaymentMethods {
     pub links: Option<Vec<Link>>,
 }
 
+/// Deserialize a field the API may send as either a JSON number or a string
+/// into an `Option<String>`.
+///
+/// Used for `creditCardEndsWith`, which the OpenAPI schema documents as a
+/// string but the live API returns as a number (see #120). A `null` or absent
+/// field yields `None`; a number is stringified; a string is kept verbatim.
+fn deserialize_opt_string_or_number<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match serde_json::Value::deserialize(deserializer)? {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::String(s) => Ok(Some(s)),
+        serde_json::Value::Number(n) => Ok(Some(n.to_string())),
+        other => Err(serde::de::Error::custom(format!(
+            "expected a string or number for creditCardEndsWith, got {other}"
+        ))),
+    }
+}
+
 /// Payment method information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -249,12 +271,19 @@ pub struct PaymentMethod {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
 
-    /// Last digits of the credit card as a masked string.
+    /// Last digits of the credit card.
     ///
-    /// Typed as `Option<String>` because the OpenAPI example shows a string
-    /// value and real responses can include leading zeros (`"0042"`) or
-    /// non-numeric formatting that would be lost or fail to parse as `i32`.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Kept as `Option<String>`, but deserialized with a number-or-string
+    /// helper: the OpenAPI schema documents a string, yet the live API returns
+    /// `creditCardEndsWith` as a JSON number. Accepting both keeps the public
+    /// type stable while tolerating the real response (a plain `String` failed
+    /// to deserialize — see #120). A string is preserved as-is, so a value with
+    /// leading zeros (`"0042"`) is not lost if the API ever sends one.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_opt_string_or_number",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub credit_card_ends_with: Option<String>,
 
     /// Name on the card

--- a/tests/account_tests.rs
+++ b/tests/account_tests.rs
@@ -227,6 +227,51 @@ async fn test_get_account_payment_methods() {
     assert_eq!(methods[0].credit_card_ends_with.as_deref(), Some("0042"));
 }
 
+// Regression for #120: the live API returns `creditCardEndsWith` as a JSON
+// number, not a string. The previous `Option<String>` typing failed to
+// deserialize it; the number-or-string helper now accepts both, stringifying
+// the number.
+#[tokio::test]
+async fn test_get_account_payment_methods_numeric_card_tail() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/payment-methods"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "accountId": 123,
+            "paymentMethods": [
+                {
+                    "id": 555,
+                    "type": "Mastercard",
+                    "creditCardEndsWith": 3825,
+                    "expirationMonth": 2,
+                    "expirationYear": 2028
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = AccountHandler::new(client);
+    let result = handler.get_account_payment_methods().await.unwrap();
+
+    let methods = result
+        .payment_methods
+        .expect("response should include paymentMethods");
+    assert_eq!(methods.len(), 1);
+    // Numeric card tail deserializes, stringified.
+    assert_eq!(methods[0].credit_card_ends_with.as_deref(), Some("3825"));
+}
+
 #[tokio::test]
 async fn test_get_account_system_logs() {
     let mock_server = MockServer::start().await;


### PR DESCRIPTION
Closes #120.

## Problem

`PaymentMethod.credit_card_ends_with` was typed `Option<String>` — matching the OpenAPI schema, which documents it as a string. But the live API returns `creditCardEndsWith` as a **JSON number**, so `account().get_account_payment_methods()` failed to deserialize on any account with a payment method on file:

```
Failed to deserialize field 'paymentMethods[0].creditCardEndsWith':
invalid type: integer `NNNN`, expected a string
```

## Fix

Add a number-or-string `deserialize_with` helper and apply it to the field. The public type stays `Option<String>` (non-breaking):

- a number is stringified (`3825` → `"3825"`)
- a string is preserved verbatim — so the leading-zero case guarded by #77 (`"0042"`) still round-trips

This keeps the field robust to either wire shape the API might send.

## Test

Added `test_get_account_payment_methods_numeric_card_tail` (numeric `creditCardEndsWith`) alongside the existing string-based `test_get_account_payment_methods`.

## Verification

- Reproduced live: `get_account_payment_methods()` previously errored against the real account; it now deserializes successfully.
- `cargo fmt`, `cargo clippy --workspace --all-targets --all-features` clean.
- `cargo test --test account_tests`: 18 passed.