### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/redis-developer/redis-cloud-rs/compare/v0.10.0...v0.11.0) - 2026-06-16
+
+### Added
+
+- *(scripts)* add OpenAPI spec-drift check against upstream ([#132](https://github.com/redis-developer/redis-cloud-rs/pull/132))
+
+### Fixed
+
+- *(models)* batch-fix compliance drift — capture dropped response fields ([#140](https://github.com/redis-developer/redis-cloud-rs/pull/140)) ([#143](https://github.com/redis-developer/redis-cloud-rs/pull/143))
+- *(subscriptions)* [**breaking**] make Pro update_subscription actually update ([#133](https://github.com/redis-developer/redis-cloud-rs/pull/133)) ([#134](https://github.com/redis-developer/redis-cloud-rs/pull/134))
+- *(tags)* capture inline tags array in CloudTags + validate tag write path ([#130](https://github.com/redis-developer/redis-cloud-rs/pull/130)) ([#131](https://github.com/redis-developer/redis-cloud-rs/pull/131))
+- *(subscriptions)* [**breaking**] capture subscriptionPricing + nested cloudDetails on reads ([#128](https://github.com/redis-developer/redis-cloud-rs/pull/128)) ([#129](https://github.com/redis-developer/redis-cloud-rs/pull/129))
+- *(databases)* [**breaking**] capture nested security/clustering/backup on reads ([#121](https://github.com/redis-developer/redis-cloud-rs/pull/121)) ([#127](https://github.com/redis-developer/redis-cloud-rs/pull/127))
+- *(account)* accept numeric `creditCardEndsWith` in payment methods ([#123](https://github.com/redis-developer/redis-cloud-rs/pull/123))
+- *(databases)* accept array-shaped module `parameters` on reads ([#122](https://github.com/redis-developer/redis-cloud-rs/pull/122))
+
+### Other
+
+- *(compliance)* phase 3 — non-destructive writes; matrix fully classified ([#142](https://github.com/redis-developer/redis-cloud-rs/pull/142))
+- *(compliance)* phase 2 — cover the full read surface ([#141](https://github.com/redis-developer/redis-cloud-rs/pull/141))
+- *(compliance)* add API compliance harness (phase 1: reads) ([#139](https://github.com/redis-developer/redis-cloud-rs/pull/139))
+- *(cost-report)* validate generate->poll->download flow live ([#138](https://github.com/redis-developer/redis-cloud-rs/pull/138))
+- *(spec)* refresh bundled cloud_openapi.json from upstream ([#137](https://github.com/redis-developer/redis-cloud-rs/pull/137))
+- *(acl)* validate reversible ACL redis-rule write lifecycle (live) ([#136](https://github.com/redis-developer/redis-cloud-rs/pull/136))
+- *(databases)* assert update_database serializes the request body ([#135](https://github.com/redis-developer/redis-cloud-rs/pull/135))
+- *(live)* expand read sweep to Pro tier + connectivity, pinned to test resources ([#126](https://github.com/redis-developer/redis-cloud-rs/pull/126))
+- add live integration harness + hand-authored response fixtures ([#125](https://github.com/redis-developer/redis-cloud-rs/pull/125))
+- *(examples)* fix cost-report id extraction and output filename ([#118](https://github.com/redis-developer/redis-cloud-rs/pull/118))
+
 ## [0.10.0](https://github.com/redis-developer/redis-cloud-rs/compare/v0.9.5...v0.10.0) - 2026-06-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)

### ⚠ `redis-cloud` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FixedDatabase.replica_as_source_endpoints in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:560
  field FixedDatabase.security in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:567
  field FixedDatabase.clustering in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:578
  field FixedDatabase.replica_as_source_endpoints in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:560
  field FixedDatabase.security in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:567
  field FixedDatabase.clustering in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:578
  field DatabaseModuleSpec.id in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:475
  field DatabaseModuleSpec.capability_name in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:479
  field DatabaseModuleSpec.version in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:483
  field DatabaseModuleSpec.description in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:487
  field DatabaseModuleSpec.id in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:475
  field DatabaseModuleSpec.capability_name in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:479
  field DatabaseModuleSpec.version in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:483
  field DatabaseModuleSpec.description in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:487
  field Subscription.subscription_pricing in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/subscriptions.rs:722
  field Subscription.subscription_pricing in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/subscriptions.rs:722
  field CloudTags.tags in /tmp/.tmptNAAFu/redis-cloud-rs/src/types.rs:265
  field CloudTags.tags in /tmp/.tmptNAAFu/redis-cloud-rs/src/types.rs:265
  field CloudTags.tags in /tmp/.tmptNAAFu/redis-cloud-rs/src/types.rs:265
  field CloudTags.tags in /tmp/.tmptNAAFu/redis-cloud-rs/src/types.rs:265
  field CloudTags.tags in /tmp/.tmptNAAFu/redis-cloud-rs/src/types.rs:265
  field FixedSubscriptionsPlans.plans in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/subscriptions.rs:77
  field FixedSubscriptionsPlans.plans in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/subscriptions.rs:77
  field DatabaseModuleSpec.id in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:299
  field DatabaseModuleSpec.capability_name in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:303
  field DatabaseModuleSpec.version in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:307
  field DatabaseModuleSpec.description in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:311
  field DatabaseModuleSpec.id in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:299
  field DatabaseModuleSpec.capability_name in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:303
  field DatabaseModuleSpec.version in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:307
  field DatabaseModuleSpec.description in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:311
  field SubscriptionNetworking.security_group_id in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/subscriptions.rs:659
  field SubscriptionNetworking.security_group_id in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/subscriptions.rs:659
  field CloudDetail.resource_tags in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/subscriptions.rs:609
  field CloudDetail.links in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/subscriptions.rs:613
  field CloudDetail.resource_tags in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/subscriptions.rs:609
  field CloudDetail.links in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/subscriptions.rs:613
  field DatabaseAlertSpec.id in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:993
  field DatabaseAlertSpec.default_value in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:997
  field DatabaseAlertSpec.id in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:993
  field DatabaseAlertSpec.default_value in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:997
  field Database.replica_as_source_endpoints in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:838
  field Database.security in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:879
  field Database.clustering in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:885
  field Database.backup in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:890
  field Database.replica_as_source_endpoints in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:838
  field Database.security in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:879
  field Database.clustering in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:885
  field Database.backup in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/databases.rs:890
  field DatabaseAlertSpec.id in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:360
  field DatabaseAlertSpec.default_value in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:364
  field DatabaseAlertSpec.id in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:360
  field DatabaseAlertSpec.default_value in /tmp/.tmptNAAFu/redis-cloud-rs/src/fixed/databases.rs:364
  field SubscriptionUpdateRequest.public_endpoint_access in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/subscriptions.rs:104
  field SubscriptionUpdateRequest.public_endpoint_access in /tmp/.tmptNAAFu/redis-cloud-rs/src/flexible/subscriptions.rs:104

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct redis_cloud::flexible::subscriptions::BaseSubscriptionUpdateRequest, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/subscriptions.rs:69
  struct redis_cloud::subscriptions::BaseSubscriptionUpdateRequest, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/subscriptions.rs:69

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field enable_default_user of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:454
  field enable_tls of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:458
  field password of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:462
  field source_ips of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:466
  field ssl_client_authentication of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:470
  field tls_client_authentication of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:474
  field clustering_enabled of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:482
  field regex_rules of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:486
  field hashing_policy of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:490
  field enable_default_user of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:454
  field enable_tls of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:458
  field password of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:462
  field source_ips of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:466
  field ssl_client_authentication of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:470
  field tls_client_authentication of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:474
  field clustering_enabled of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:482
  field regex_rules of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:486
  field hashing_policy of struct FixedDatabase, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/fixed/databases.rs:490
  field enable_tls of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:831
  field remote_backup of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:851
  field source_ip of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:855
  field password of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:867
  field enable_default_user of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:903
  field number_of_shards of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:923
  field regex_rules of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:927
  field ssl_client_authentication of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:931
  field tls_client_authentication of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:935
  field enable_tls of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:831
  field remote_backup of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:851
  field source_ip of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:855
  field password of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:867
  field enable_default_user of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:903
  field number_of_shards of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:923
  field regex_rules of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:927
  field ssl_client_authentication of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:931
  field tls_client_authentication of struct Database, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/databases.rs:935
  field pricing of struct Subscription, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/subscriptions.rs:703
  field pricing of struct Subscription, previously in file /tmp/.tmpkVxRsj/redis-cloud/src/flexible/subscriptions.rs:703
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/redis-developer/redis-cloud-rs/compare/v0.10.0...v0.11.0) - 2026-06-16

### Added

- *(scripts)* add OpenAPI spec-drift check against upstream ([#132](https://github.com/redis-developer/redis-cloud-rs/pull/132))

### Fixed

- *(models)* batch-fix compliance drift — capture dropped response fields ([#140](https://github.com/redis-developer/redis-cloud-rs/pull/140)) ([#143](https://github.com/redis-developer/redis-cloud-rs/pull/143))
- *(subscriptions)* [**breaking**] make Pro update_subscription actually update ([#133](https://github.com/redis-developer/redis-cloud-rs/pull/133)) ([#134](https://github.com/redis-developer/redis-cloud-rs/pull/134))
- *(tags)* capture inline tags array in CloudTags + validate tag write path ([#130](https://github.com/redis-developer/redis-cloud-rs/pull/130)) ([#131](https://github.com/redis-developer/redis-cloud-rs/pull/131))
- *(subscriptions)* [**breaking**] capture subscriptionPricing + nested cloudDetails on reads ([#128](https://github.com/redis-developer/redis-cloud-rs/pull/128)) ([#129](https://github.com/redis-developer/redis-cloud-rs/pull/129))
- *(databases)* [**breaking**] capture nested security/clustering/backup on reads ([#121](https://github.com/redis-developer/redis-cloud-rs/pull/121)) ([#127](https://github.com/redis-developer/redis-cloud-rs/pull/127))
- *(account)* accept numeric `creditCardEndsWith` in payment methods ([#123](https://github.com/redis-developer/redis-cloud-rs/pull/123))
- *(databases)* accept array-shaped module `parameters` on reads ([#122](https://github.com/redis-developer/redis-cloud-rs/pull/122))

### Other

- *(compliance)* phase 3 — non-destructive writes; matrix fully classified ([#142](https://github.com/redis-developer/redis-cloud-rs/pull/142))
- *(compliance)* phase 2 — cover the full read surface ([#141](https://github.com/redis-developer/redis-cloud-rs/pull/141))
- *(compliance)* add API compliance harness (phase 1: reads) ([#139](https://github.com/redis-developer/redis-cloud-rs/pull/139))
- *(cost-report)* validate generate->poll->download flow live ([#138](https://github.com/redis-developer/redis-cloud-rs/pull/138))
- *(spec)* refresh bundled cloud_openapi.json from upstream ([#137](https://github.com/redis-developer/redis-cloud-rs/pull/137))
- *(acl)* validate reversible ACL redis-rule write lifecycle (live) ([#136](https://github.com/redis-developer/redis-cloud-rs/pull/136))
- *(databases)* assert update_database serializes the request body ([#135](https://github.com/redis-developer/redis-cloud-rs/pull/135))
- *(live)* expand read sweep to Pro tier + connectivity, pinned to test resources ([#126](https://github.com/redis-developer/redis-cloud-rs/pull/126))
- add live integration harness + hand-authored response fixtures ([#125](https://github.com/redis-developer/redis-cloud-rs/pull/125))
- *(examples)* fix cost-report id extraction and output filename ([#118](https://github.com/redis-developer/redis-cloud-rs/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).