### PR TITLE
test: live integration harness + hand-authored response fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ Thumbs.db
 .env
 .env.local
 
+# Locally-captured Cloud API fixtures (see scripts/generate-cloud-fixtures.sh).
+# Never commit these — they can contain real account data. Committed fixtures
+# are hand-authored under tests/fixtures/cloud/samples/.
+tests/fixtures/cloud/captured/
+
 # Test coverage
 tarpaulin-report.html
 cobertura.xml

--- a/scripts/generate-cloud-fixtures.sh
+++ b/scripts/generate-cloud-fixtures.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Capture Redis Cloud API responses locally, for INSPECTION when investigating
+# real-vs-model drift. Output goes to tests/fixtures/cloud/captured/, which is
+# .gitignored — these captures are NOT meant to be committed.
+#
+# The committed, CI-runnable fixtures live in tests/fixtures/cloud/samples/ and
+# are HAND-AUTHORED with synthetic data (see tests/cloud_fixture_validation.rs).
+# That is deliberate: the sanitizer below is a best-effort denylist, and a real
+# run proved it leaks sensitive fields the API returns but the denylist doesn't
+# know about (e.g. AWS access key ids, account ids under unexpected keys). Never
+# trust it for data that gets committed to a public repo.
+#
+# Usage (read-only; never creates/modifies/deletes anything):
+#   export REDIS_CLOUD_API_KEY=...      # or REDIS_CLOUD_API_ACCOUNT_KEY
+#   export REDIS_CLOUD_API_SECRET=...   # or REDIS_CLOUD_API_USER_KEY
+#   ./scripts/generate-cloud-fixtures.sh
+#
+# Requires: curl, jq.
+
+set -euo pipefail
+
+API_KEY="${REDIS_CLOUD_API_KEY:-${REDIS_CLOUD_API_ACCOUNT_KEY:-}}"
+API_SECRET="${REDIS_CLOUD_API_SECRET:-${REDIS_CLOUD_API_USER_KEY:-}}"
+BASE_URL="${REDIS_CLOUD_BASE_URL:-https://api.redislabs.com/v1}"
+
+if [[ -z "$API_KEY" || -z "$API_SECRET" ]]; then
+  echo "error: set REDIS_CLOUD_API_KEY and REDIS_CLOUD_API_SECRET" >&2
+  exit 1
+fi
+command -v jq >/dev/null || { echo "error: jq is required" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/../tests/fixtures/cloud/captured"
+mkdir -p "$OUT_DIR"
+
+# Recursive sanitizer. Scrubs identifying values by key name while preserving
+# structural and enum-like values (status, provider, protocol, version, …) so
+# the fixtures still exercise real serde paths.
+#
+# - numeric identifiers -> deterministic fakes
+# - identifying strings -> placeholders
+# - HATEOAS hrefs        -> a templated URL (they embed account/sub/db ids)
+read -r -d '' SANITIZE <<'JQ' || true
+def scrub:
+  walk(
+    if type == "object" then
+      with_entries(
+        (.key) as $k
+        | if ($k | IN("id","account","accountId","subscriptionId","databaseId","paymentMethodId",
+                      "resourceId","additionalResourceId","userAccountId","bdbId","planId"))
+            and (.value | type == "number")
+          then .value = 12345
+        elif $k == "creditCardEndsWith"
+          then .value = (if (.value | type == "number") then 1234 else "1234" end)
+        elif $k | IN("name","nameOnCard","accountName","accountMarketplaceId",
+                     "email","resourceName","serverCert","password","planName","role",
+                     "accessKeyId","accessSecretKey","secretKey","awsUserArn",
+                     "awsConsoleRoleArn","awsAccountId","gcpServiceAccountId")
+          then .value = (if (.value | type == "string") then "example" else .value end)
+        elif $k | IN("publicEndpoint","privateEndpoint","public","private")
+          then .value = (if (.value | type == "string")
+                         then "redis-12345.example.cloud.redislabs.com:12345" else .value end)
+        elif $k | IN("httpSourceIp")
+          then .value = "203.0.113.10"
+        elif $k | IN("allowedSourceIps","sourceIps")
+          then .value = (if (.value | type == "array") then ["0.0.0.0/0"] else .value end)
+        elif $k == "href"
+          then .value = "https://api.redislabs.com/v1/redacted"
+        else .
+        end
+      )
+    else .
+    end
+  );
+scrub
+JQ
+
+fetch() {
+  # fetch <relative-path> <fixture-name>
+  local path="$1" name="$2"
+  echo "  GET $path -> $name.json"
+  curl -fsS "$BASE_URL$path" \
+    -H "x-api-key: $API_KEY" -H "x-api-secret-key: $API_SECRET" \
+    | jq "$SANITIZE" > "$OUT_DIR/$name.json"
+}
+
+echo "Capturing fixtures into $OUT_DIR"
+
+fetch "/"                  account
+fetch "/payment-methods"   payment_methods
+fetch "/data-persistence"  data_persistence
+fetch "/database-modules"  database_modules
+fetch "/regions"           regions
+fetch "/subscriptions"     subscriptions
+fetch "/fixed/subscriptions" fixed_subscriptions
+fetch "/acl/redisRules"    acl_redis_rules
+fetch "/acl/roles"         acl_roles
+fetch "/acl/users"         acl_users
+fetch "/users"             users
+fetch "/cloud-accounts"    cloud_accounts
+fetch "/tasks"             tasks
+
+# Drill into the first Essentials subscription for the rich database shape.
+FIRST_SUB="$(curl -fsS "$BASE_URL/fixed/subscriptions" \
+  -H "x-api-key: $API_KEY" -H "x-api-secret-key: $API_SECRET" \
+  | jq -r '.subscriptions[0].id // empty')"
+
+if [[ -n "$FIRST_SUB" ]]; then
+  fetch "/fixed/subscriptions/$FIRST_SUB"            fixed_subscription
+  fetch "/fixed/subscriptions/$FIRST_SUB/databases"  fixed_databases
+else
+  echo "  (no Essentials subscription found; skipping single-sub + databases fixtures)"
+fi
+
+echo "Done. Files in $OUT_DIR are .gitignored and for local inspection only."
+echo "Do NOT commit them — the committed fixtures are hand-authored under"
+echo "tests/fixtures/cloud/samples/."

--- a/tests/cloud_fixture_validation.rs
+++ b/tests/cloud_fixture_validation.rs
@@ -1,0 +1,91 @@
+//! Deserialization tests against hand-authored fixtures that reproduce real
+//! Redis Cloud response shapes.
+//!
+//! Unlike the inline wiremock mocks (which are written to match our models, so
+//! they agree with our bugs), these fixtures encode the shapes the live API
+//! actually returns — captured by inspecting a real account, then re-authored
+//! with synthetic values so they are safe to commit and run in CI without
+//! credentials. They guard the type-fidelity regressions found via live
+//! testing: #118, #119, #120.
+//!
+//! The fixtures live in `tests/fixtures/cloud/samples/`. To refresh against a
+//! live account for comparison, see `scripts/generate-cloud-fixtures.sh`
+//! (output is gitignored and must not be committed).
+
+use redis_cloud::account::PaymentMethods;
+use redis_cloud::fixed_databases::AccountFixedSubscriptionDatabases;
+use redis_cloud::fixed_subscriptions::FixedSubscription;
+use redis_cloud::types::{TaskStateUpdate, TaskStatus};
+
+// #119: modules[].parameters is an array on the wire (empty or objects), and a
+// scientific-notation float appears in networkMonthlyUsageInByte. The whole
+// response must deserialize.
+#[test]
+fn fixed_databases_response_deserializes() {
+    let raw = include_str!("fixtures/cloud/samples/fixed_databases.json");
+    let resp: AccountFixedSubscriptionDatabases =
+        serde_json::from_str(raw).expect("fixed databases fixture should deserialize");
+
+    let db = resp
+        .subscription
+        .and_then(|s| s.databases.into_iter().next())
+        .expect("fixture should contain a database");
+
+    // Scientific-notation float field parses as f64.
+    assert_eq!(db.network_monthly_usage_in_byte, Some(1.83615528E+10));
+
+    let modules = db.modules.expect("modules should deserialize");
+    assert_eq!(modules.len(), 2);
+    // Empty array parameters.
+    assert_eq!(modules[0].parameters, Some(serde_json::json!([])));
+    // Populated array parameters round-trip as a JSON array (#119).
+    assert_eq!(
+        modules[1].parameters,
+        Some(serde_json::json!([{ "name": "error_rate", "value": "0.01" }]))
+    );
+}
+
+// #120: creditCardEndsWith is a JSON number; the number-or-string deserializer
+// must accept it and stringify it.
+#[test]
+fn payment_methods_response_deserializes() {
+    let raw = include_str!("fixtures/cloud/samples/payment_methods.json");
+    let resp: PaymentMethods =
+        serde_json::from_str(raw).expect("payment methods fixture should deserialize");
+
+    let methods = resp
+        .payment_methods
+        .expect("should contain payment methods");
+    assert_eq!(methods.len(), 1);
+    assert_eq!(methods[0].credit_card_ends_with.as_deref(), Some("1234"));
+}
+
+// #118: the cost-report task nests the id at response.resource.costReportId.
+#[test]
+fn cost_report_task_response_deserializes() {
+    let raw = include_str!("fixtures/cloud/samples/cost_report_task.json");
+    let task: TaskStateUpdate =
+        serde_json::from_str(raw).expect("cost-report task fixture should deserialize");
+
+    assert!(matches!(task.status, Some(TaskStatus::ProcessingCompleted)));
+    let report_id = task
+        .response
+        .and_then(|r| r.resource)
+        .and_then(|res| res.get("costReportId").cloned())
+        .and_then(|v| v.as_str().map(str::to_string))
+        .expect("response.resource.costReportId should be present");
+    assert!(report_id.ends_with(".csv"));
+}
+
+// The Essentials subscription model is field-complete; notably `connections`
+// is a string on the wire ("10000"), not a number.
+#[test]
+fn fixed_subscription_response_deserializes() {
+    let raw = include_str!("fixtures/cloud/samples/fixed_subscription.json");
+    let sub: FixedSubscription =
+        serde_json::from_str(raw).expect("fixed subscription fixture should deserialize");
+
+    assert_eq!(sub.id, Some(111111));
+    assert_eq!(sub.connections.as_deref(), Some("10000"));
+    assert_eq!(sub.database_status.as_deref(), Some("active"));
+}

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -7,47 +7,47 @@
   yet (intentionally deferred). Enforced by `tests/openapi_route_coverage.rs`.
 - `openapi_non_spec_routes.txt` — typed client routes that don't match any spec
   path (known drift). Also enforced by `tests/openapi_route_coverage.rs`.
+- `cloud/samples/*.json` — hand-authored response fixtures that reproduce real
+  API shapes with synthetic data. Validated by
+  `tests/cloud_fixture_validation.rs`.
+- `cloud/captured/` — *gitignored* output of `scripts/generate-cloud-fixtures.sh`
+  (local inspection only; never committed).
 
-Both allowlists are intentional-exception lists: the coverage test fails if a
-new gap appears without an entry, **and** if an entry goes stale (the route got
-covered or the path was fixed). Shrinking them is tracked in #72.
+## Testing layers
 
-## Current Status
+Cloud API responses are exercised at three levels:
 
-Beyond the OpenAPI spec and route-coverage allowlists above, there are no
-captured response fixtures yet.
+1. **Inline wiremock tests** (`tests/*_tests.rs`) — fast, no network, no creds.
+   They catch logic/routing regressions but not real-vs-model drift, because
+   the mocks are written to match our models.
+2. **Hand-authored fixtures** (`cloud/samples/`, validated by
+   `tests/cloud_fixture_validation.rs`) — encode the shapes the live API
+   actually returns (e.g. module `parameters` as an array, numeric
+   `creditCardEndsWith`, the `response.resource.costReportId` task envelope),
+   with synthetic values. Run in normal CI, no credentials. These guard the
+   type-fidelity regressions found via live testing (#118, #119, #120).
+3. **Live integration tests** (`tests/live_integration.rs`) — `#[ignore]`d,
+   read-only, hit a real account. They catch new drift the fixtures can't
+   anticipate.
 
-## Why No Real Fixtures Yet?
-
-Unlike Enterprise API (which uses Docker for testing), Cloud API fixtures require:
-1. A real Cloud account with active resources
-2. Billable subscriptions and databases
-3. Careful sanitization of account data before committing
-
-## Generating Cloud Fixtures
-
-When you have a Cloud account with test resources, you can generate fixtures:
+## Running the live integration tests
 
 ```bash
-export REDIS_CLOUD_API_KEY="your-key"
-export REDIS_CLOUD_SECRET_KEY="your-secret"
-./scripts/generate-cloud-fixtures.sh
+export REDIS_CLOUD_API_KEY=...      # or REDIS_CLOUD_API_ACCOUNT_KEY
+export REDIS_CLOUD_API_SECRET=...   # or REDIS_CLOUD_API_USER_KEY
+cargo test --test live_integration -- --ignored
 ```
 
-**Important**: Review all generated fixtures for sensitive data before committing!
+Read-only (no resource is created, modified, or deleted), so they are safe
+against a shared or billable account. Run them outside any sandbox that blocks
+outbound TLS.
 
-## Current Testing Approach
+## Capturing fixtures for inspection
 
-Cloud API tests currently use wiremock with inline JSON mocks. This approach:
-- ✅ Works well for testing
-- ✅ No infrastructure required
-- ✅ No costs
-- ⚠️  Doesn't catch type mismatches from real API responses
+`scripts/generate-cloud-fixtures.sh` captures live responses into the gitignored
+`cloud/captured/` directory for local comparison when investigating drift.
 
-## Future Work
-
-To get the full benefits of fixture-based testing for Cloud:
-1. Use a test Cloud account with minimal resources
-2. Generate fixtures from real API responses
-3. Sanitize account/subscription IDs
-4. Add validation tests like Enterprise has
+**Do not commit captured fixtures.** Its sanitizer is a best-effort denylist; a
+real run leaked fields it didn't know about (AWS access key ids, account ids
+under unexpected keys). Committed fixtures are hand-authored under
+`cloud/samples/` precisely so repo safety never depends on that denylist.

--- a/tests/fixtures/cloud/samples/cost_report_task.json
+++ b/tests/fixtures/cloud/samples/cost_report_task.json
@@ -1,0 +1,19 @@
+{
+  "taskId": "00000000-0000-0000-0000-000000000000",
+  "commandType": "costReportCreateRequest",
+  "status": "processing-completed",
+  "description": "Request processing completed successfully and its resources are now being provisioned / de-provisioned.",
+  "timestamp": "2026-06-11T18:17:58.06056495Z",
+  "response": {
+    "resource": {
+      "costReportId": "RedisCloudCosts_12345_2026-05-01_2026-05-31_0000000000000.csv"
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "type": "GET",
+      "href": "https://api.redislabs.com/v1/tasks/00000000-0000-0000-0000-000000000000"
+    }
+  ]
+}

--- a/tests/fixtures/cloud/samples/fixed_databases.json
+++ b/tests/fixtures/cloud/samples/fixed_databases.json
@@ -1,0 +1,84 @@
+{
+  "accountId": 12345,
+  "subscription": {
+    "subscriptionId": 111111,
+    "numberOfDatabases": 1,
+    "databases": [
+      {
+        "databaseId": 222222,
+        "name": "example-db",
+        "protocol": "stack",
+        "provider": "AWS",
+        "region": "us-east-1",
+        "redisVersion": "8.2",
+        "redisVersionCompliance": "8.2.1",
+        "respVersion": "resp3",
+        "status": "active",
+        "planMemoryLimit": 12.0,
+        "planDatasetSize": 6.0,
+        "memoryLimitMeasurementUnit": "MB",
+        "memoryUsedInMb": 5270.0,
+        "networkMonthlyUsageInByte": 1.83615528E+10,
+        "memoryStorage": "ram",
+        "redisFlex": false,
+        "supportOSSClusterApi": false,
+        "useExternalEndpointForOSSClusterApi": false,
+        "dataPersistence": "aof-every-1-second",
+        "replication": true,
+        "dataEvictionPolicy": "noeviction",
+        "activatedOn": "2026-01-21T14:46:32Z",
+        "lastModified": "2026-04-07T10:49:56Z",
+        "publicEndpoint": "redis-12345.example.cloud.redislabs.com:12345",
+        "replicaAsSourceEndpoints": {
+          "public": "redis-12345.example.cloud.redislabs.com:12345"
+        },
+        "replicaOf": null,
+        "replica": null,
+        "clustering": {
+          "enabled": false,
+          "regexRules": [
+            { "ordinal": 0, "pattern": ".*\\{(?<tag>.*)\\}.*" },
+            { "ordinal": 1, "pattern": "(?<tag>.*)" }
+          ],
+          "hashingPolicy": "standard"
+        },
+        "security": {
+          "defaultUserEnabled": false,
+          "sslClientAuthentication": false,
+          "tlsClientAuthentication": false,
+          "enableTls": false,
+          "sourceIps": ["0.0.0.0/0"]
+        },
+        "modules": [
+          {
+            "id": 333333,
+            "name": "RedisTimeSeries",
+            "capabilityName": "Time series",
+            "version": "8.2.9",
+            "description": "Time-Series data structure for redis",
+            "parameters": []
+          },
+          {
+            "id": 333334,
+            "name": "RedisBloom",
+            "version": "8.2.13",
+            "parameters": [{ "name": "error_rate", "value": "0.01" }]
+          }
+        ],
+        "alerts": [
+          { "name": "datasets-size", "value": 95, "defaultValue": 80 }
+        ],
+        "backup": { "remoteBackupEnabled": false },
+        "links": []
+      }
+    ],
+    "links": []
+  },
+  "links": [
+    {
+      "rel": "self",
+      "type": "GET",
+      "href": "https://api.redislabs.com/v1/fixed/subscriptions/111111/databases"
+    }
+  ]
+}

--- a/tests/fixtures/cloud/samples/fixed_subscription.json
+++ b/tests/fixtures/cloud/samples/fixed_subscription.json
@@ -1,0 +1,34 @@
+{
+  "id": 111111,
+  "name": "example-subscription",
+  "status": "active",
+  "paymentMethodId": 555,
+  "paymentMethodType": "credit-card",
+  "planId": 21547,
+  "planName": "Single-Zone_Persistence_12GB",
+  "size": 12.0,
+  "sizeMeasurementUnit": "GB",
+  "provider": "AWS",
+  "region": "us-east-1",
+  "price": 198,
+  "pricePeriod": "Month",
+  "priceCurrency": "USD",
+  "maximumDatabases": 1,
+  "availability": "Single-zone",
+  "connections": "10000",
+  "cidrAllowRules": 32,
+  "supportDataPersistence": true,
+  "supportInstantAndDailyBackups": true,
+  "supportReplication": true,
+  "supportClustering": false,
+  "customerSupport": "Standard",
+  "creationDate": "2026-01-21T14:46:32Z",
+  "databaseStatus": "active",
+  "links": [
+    {
+      "href": "https://api.redislabs.com/v1/fixed/subscriptions/111111",
+      "type": "GET",
+      "rel": "self"
+    }
+  ]
+}

--- a/tests/fixtures/cloud/samples/payment_methods.json
+++ b/tests/fixtures/cloud/samples/payment_methods.json
@@ -1,0 +1,21 @@
+{
+  "accountId": 12345,
+  "paymentMethods": [
+    {
+      "id": 555,
+      "type": "Mastercard",
+      "creditCardEndsWith": 1234,
+      "nameOnCard": "Example Cardholder",
+      "expirationMonth": 2,
+      "expirationYear": 2030,
+      "links": []
+    }
+  ],
+  "links": [
+    {
+      "rel": "self",
+      "type": "GET",
+      "href": "https://api.redislabs.com/v1/payment-methods"
+    }
+  ]
+}

--- a/tests/live_integration.rs
+++ b/tests/live_integration.rs
@@ -1,0 +1,236 @@
+//! Live, read-only integration tests against a real Redis Cloud account.
+//!
+//! Every test here is `#[ignore]`d, so a plain `cargo test` never touches the
+//! network. Run them explicitly, with credentials, and outside any sandbox
+//! that blocks outbound TLS:
+//!
+//! ```bash
+//! REDIS_CLOUD_API_KEY=... REDIS_CLOUD_API_SECRET=... \
+//!   cargo test --test live_integration -- --ignored
+//! ```
+//!
+//! The credential helper also accepts the redisctl variable names
+//! (`REDIS_CLOUD_API_ACCOUNT_KEY` / `REDIS_CLOUD_API_USER_KEY`).
+//!
+//! ## What these cover
+//!
+//! These exercise the **read** surface and assert that real API responses
+//! deserialize into the typed models. That is the class of drift wiremock
+//! tests cannot catch — the mocks are written to match our models, so they
+//! agree with our bugs. #119 (module `parameters` array-vs-map) and #120
+//! (`creditCardEndsWith` number-vs-string) both shipped because no real
+//! response was ever parsed in CI.
+//!
+//! They are strictly read-only: no resource is created, modified, or deleted,
+//! so they are safe to run against a shared or billable account. IDs are
+//! discovered dynamically, so the suite is not tied to one specific account.
+
+use redis_cloud::CloudClient;
+
+/// Build a client from environment credentials, supporting both the documented
+/// variable names and the redisctl convention. Returns `None` when no
+/// credentials are present so an explicit `--ignored` run on a machine without
+/// them skips loudly rather than failing.
+fn client() -> Option<CloudClient> {
+    let key = std::env::var("REDIS_CLOUD_API_KEY")
+        .or_else(|_| std::env::var("REDIS_CLOUD_API_ACCOUNT_KEY"))
+        .ok()?;
+    let secret = std::env::var("REDIS_CLOUD_API_SECRET")
+        .or_else(|_| std::env::var("REDIS_CLOUD_API_USER_KEY"))
+        .ok()?;
+    Some(
+        CloudClient::builder()
+            .api_key(key)
+            .api_secret(secret)
+            .build()
+            .expect("client should build from credentials"),
+    )
+}
+
+/// Define a `#[ignore]`d live test that receives a built `CloudClient`, or
+/// skips with a notice when credentials are absent.
+macro_rules! live_test {
+    ($name:ident, $client:ident, $body:block) => {
+        #[tokio::test]
+        #[ignore = "requires live Redis Cloud credentials; run with --ignored"]
+        async fn $name() {
+            let Some($client) = client() else {
+                eprintln!(
+                    "SKIP {}: set REDIS_CLOUD_API_KEY/REDIS_CLOUD_API_SECRET to run",
+                    stringify!($name)
+                );
+                return;
+            };
+            $body
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// account
+// ---------------------------------------------------------------------------
+
+live_test!(live_account_get_current, c, {
+    let account = c
+        .account()
+        .get_current_account()
+        .await
+        .expect("get_current_account should deserialize");
+    assert!(
+        account.account.is_some() || account.links.is_some(),
+        "account response should carry an account or links"
+    );
+});
+
+live_test!(live_account_data_persistence_options, c, {
+    c.account()
+        .get_data_persistence_options()
+        .await
+        .expect("get_data_persistence_options should deserialize");
+});
+
+live_test!(live_account_supported_database_modules, c, {
+    c.account()
+        .get_supported_database_modules()
+        .await
+        .expect("get_supported_database_modules should deserialize");
+});
+
+live_test!(live_account_supported_regions, c, {
+    c.account()
+        .get_supported_regions(None)
+        .await
+        .expect("get_supported_regions should deserialize");
+});
+
+// Regression guard for #120: `creditCardEndsWith` is a number on the wire.
+live_test!(live_account_payment_methods, c, {
+    c.account()
+        .get_account_payment_methods()
+        .await
+        .expect("get_account_payment_methods should deserialize (see #120)");
+});
+
+// ---------------------------------------------------------------------------
+// subscriptions (Pro) — may legitimately be empty
+// ---------------------------------------------------------------------------
+
+live_test!(live_subscriptions_list, c, {
+    c.subscriptions()
+        .list()
+        .await
+        .expect("subscriptions list should deserialize");
+});
+
+// ---------------------------------------------------------------------------
+// fixed subscriptions (Essentials) — list, then drill into the first one
+// ---------------------------------------------------------------------------
+
+live_test!(live_fixed_subscriptions_flow, c, {
+    let subs = c
+        .fixed_subscriptions()
+        .list()
+        .await
+        .expect("fixed_subscriptions list should deserialize");
+
+    let Some(first) = subs.subscriptions.as_ref().and_then(|s| s.first()) else {
+        eprintln!("SKIP drill-down: no Essentials subscriptions on this account");
+        return;
+    };
+    let sub_id = first.id.expect("subscription should have an id");
+
+    c.fixed_subscriptions()
+        .get_by_id(sub_id)
+        .await
+        .expect("fixed_subscriptions get_by_id should deserialize");
+    c.fixed_subscriptions()
+        .get_redis_versions(sub_id)
+        .await
+        .expect("get_redis_versions should deserialize");
+});
+
+// Regression guard for #119: real Essentials databases carry modules whose
+// `parameters` is an array. Discovers a subscription + database dynamically.
+live_test!(live_fixed_databases_flow, c, {
+    let subs = c
+        .fixed_subscriptions()
+        .list()
+        .await
+        .expect("fixed_subscriptions list should deserialize");
+    let Some(sub_id) = subs
+        .subscriptions
+        .as_ref()
+        .and_then(|s| s.first())
+        .and_then(|s| s.id)
+    else {
+        eprintln!("SKIP: no Essentials subscriptions on this account");
+        return;
+    };
+
+    let dbs = c
+        .fixed_databases()
+        .list(sub_id, None, None)
+        .await
+        .expect("fixed_databases list should deserialize (see #119)");
+
+    if let Some(db_id) = dbs
+        .subscription
+        .and_then(|s| s.databases.into_iter().next())
+        .and_then(|d| d.database_id)
+    {
+        c.fixed_databases()
+            .get_by_id(sub_id, db_id)
+            .await
+            .expect("fixed_databases get_by_id should deserialize (see #119)");
+    }
+});
+
+// ---------------------------------------------------------------------------
+// acl
+// ---------------------------------------------------------------------------
+
+live_test!(live_acl_redis_rules, c, {
+    c.acl()
+        .get_all_redis_rules()
+        .await
+        .expect("acl get_all_redis_rules should deserialize");
+});
+
+live_test!(live_acl_roles, c, {
+    c.acl()
+        .get_roles()
+        .await
+        .expect("acl get_roles should deserialize");
+});
+
+live_test!(live_acl_users, c, {
+    c.acl()
+        .get_all_acl_users()
+        .await
+        .expect("acl get_all_acl_users should deserialize");
+});
+
+// ---------------------------------------------------------------------------
+// users / cloud accounts / tasks
+// ---------------------------------------------------------------------------
+
+live_test!(live_users_list, c, {
+    c.users()
+        .get_all_users()
+        .await
+        .expect("users get_all_users should deserialize");
+});
+
+live_test!(live_cloud_accounts_list, c, {
+    c.cloud_accounts()
+        .get_cloud_accounts()
+        .await
+        .expect("cloud_accounts get_cloud_accounts should deserialize");
+});
+
+live_test!(live_tasks_list, c, {
+    c.tasks()
+        .get_all_tasks()
+        .await
+        .expect("tasks get_all_tasks should deserialize");
+});


### PR DESCRIPTION
Adds a real-API testing layer to catch the type-fidelity drift that wiremock mocks structurally cannot — the mocks are written to match our models, so they agree with our bugs. That blind spot is how #118, #119, and #120 all shipped in v0.10.0.

## What's in here

**1. Live integration tests — `tests/live_integration.rs`**
Read-only, `#[ignore]`d tests across every account-level read domain (account, subscriptions, fixed subs/dbs, acl, users, cloud accounts, tasks). They build a client from env, discover IDs dynamically (not tied to one account), and assert real responses deserialize. Two of them (`live_fixed_databases_flow`, `live_account_payment_methods`) directly guard the #119/#120 regressions.

```bash
REDIS_CLOUD_API_KEY=... REDIS_CLOUD_API_SECRET=... \
  cargo test --test live_integration -- --ignored
```

Accepts the redisctl variable names (`REDIS_CLOUD_API_ACCOUNT_KEY` / `_USER_KEY`) too. Strictly read-only — safe against a shared/billable account.

**2. Hand-authored fixtures — `tests/fixtures/cloud/samples/*.json` + `tests/cloud_fixture_validation.rs`**
Reproduce the shapes the live API actually returns — module `parameters` arrays, numeric `creditCardEndsWith`, the `response.resource.costReportId` task envelope, scientific-notation floats, string `connections` — with **synthetic values**. Run in normal CI, no credentials.

**3. Capture tool — `scripts/generate-cloud-fixtures.sh`**
Local-only. Captures live responses into the **gitignored** `cloud/captured/` dir for inspection. **Not committed**, by design: a real run proved its best-effort denylist sanitizer leaks fields it doesn't anticipate (AWS access key ids, account ids under unexpected keys). Committed fixtures are hand-authored precisely so repo safety never depends on that denylist.

## Not included (deliberate)

No CI wiring yet — the live tests stay `#[ignore]`d and local until we decide how/whether to run them automatically against the shared account.

## Verification

- All 14 live tests pass against a real account.
- `cargo test --workspace --all-features`: 404 passed, 24 ignored.
- `cargo fmt`, `cargo clippy --workspace --all-targets --all-features` clean.
- Leak-scanned every committed file for real account identifiers — clean.