### PR TITLE
test(live): expand read sweep to Pro tier + connectivity, pinned to test resources

### DIFF
--- a/tests/live_integration.rs
+++ b/tests/live_integration.rs
@@ -25,7 +25,7 @@
 //! so they are safe to run against a shared or billable account. IDs are
 //! discovered dynamically, so the suite is not tied to one specific account.
 
-use redis_cloud::CloudClient;
+use redis_cloud::{CloudClient, CloudError};
 
 /// Build a client from environment credentials, supporting both the documented
 /// variable names and the redisctl convention. Returns `None` when no
@@ -47,6 +47,30 @@ fn client() -> Option<CloudClient> {
     )
 }
 
+/// Dedicated test-resource IDs, read from the `REDIS_CLOUD_TEST_*` env vars
+/// (see the gitignored `.env`). These point at subscriptions created solely for
+/// validation, so deeper per-resource reads (and, later, non-destructive
+/// writes) target known-safe resources instead of discovering arbitrary ones.
+struct TestResources {
+    pro_sub: i32,
+    pro_db: i32,
+    essentials_sub: i32,
+    essentials_db: i32,
+}
+
+fn env_i32(key: &str) -> Option<i32> {
+    std::env::var(key).ok()?.parse().ok()
+}
+
+fn test_resources() -> Option<TestResources> {
+    Some(TestResources {
+        pro_sub: env_i32("REDIS_CLOUD_TEST_PRO_SUB_ID")?,
+        pro_db: env_i32("REDIS_CLOUD_TEST_PRO_DB_ID")?,
+        essentials_sub: env_i32("REDIS_CLOUD_TEST_ESSENTIALS_SUB_ID")?,
+        essentials_db: env_i32("REDIS_CLOUD_TEST_ESSENTIALS_DB_ID")?,
+    })
+}
+
 /// Define a `#[ignore]`d live test that receives a built `CloudClient`, or
 /// skips with a notice when credentials are absent.
 macro_rules! live_test {
@@ -57,6 +81,25 @@ macro_rules! live_test {
             let Some($client) = client() else {
                 eprintln!(
                     "SKIP {}: set REDIS_CLOUD_API_KEY/REDIS_CLOUD_API_SECRET to run",
+                    stringify!($name)
+                );
+                return;
+            };
+            $body
+        }
+    };
+}
+
+/// Like [`live_test!`], but also requires the dedicated test-resource IDs.
+/// Skips when either credentials or the `REDIS_CLOUD_TEST_*` vars are absent.
+macro_rules! live_test_pinned {
+    ($name:ident, $client:ident, $res:ident, $body:block) => {
+        #[tokio::test]
+        #[ignore = "requires live credentials + REDIS_CLOUD_TEST_* resource ids; run with --ignored"]
+        async fn $name() {
+            let (Some($client), Some($res)) = (client(), test_resources()) else {
+                eprintln!(
+                    "SKIP {}: needs credentials and REDIS_CLOUD_TEST_* resource ids",
                     stringify!($name)
                 );
                 return;
@@ -233,4 +276,123 @@ live_test!(live_tasks_list, c, {
         .get_all_tasks()
         .await
         .expect("tasks get_all_tasks should deserialize");
+});
+
+// ---------------------------------------------------------------------------
+// Pro subscription (pinned to REDIS_CLOUD_TEST_PRO_SUB_ID)
+// ---------------------------------------------------------------------------
+
+live_test_pinned!(live_pro_subscription_reads, c, res, {
+    let sub = res.pro_sub;
+    c.subscriptions()
+        .get_subscription_by_id(sub)
+        .await
+        .expect("get_subscription_by_id should deserialize");
+    c.subscriptions()
+        .get_cidr_allowlist(sub)
+        .await
+        .expect("get_cidr_allowlist should deserialize");
+    c.subscriptions()
+        .get_subscription_maintenance_windows(sub)
+        .await
+        .expect("get_subscription_maintenance_windows should deserialize");
+    c.subscriptions()
+        .get_subscription_pricing(sub)
+        .await
+        .expect("get_subscription_pricing should deserialize");
+    c.subscriptions()
+        .get_redis_versions(Some(sub))
+        .await
+        .expect("get_redis_versions should deserialize");
+});
+
+// ---------------------------------------------------------------------------
+// Pro databases (pinned)
+// ---------------------------------------------------------------------------
+
+live_test_pinned!(live_pro_database_reads, c, res, {
+    let (sub, db) = (res.pro_sub, res.pro_db);
+    c.databases()
+        .list(sub)
+        .await
+        .expect("databases list should deserialize");
+    c.databases()
+        .get_subscription_database_by_id(sub, db)
+        .await
+        .expect("get_subscription_database_by_id should deserialize");
+    c.databases()
+        .get_database_backup_status(sub, db, None)
+        .await
+        .expect("get_database_backup_status should deserialize");
+    c.databases()
+        .get_subscription_database_certificate(sub, db)
+        .await
+        .expect("get_subscription_database_certificate should deserialize");
+    c.databases()
+        .get_slow_log(sub, db, None)
+        .await
+        .expect("get_slow_log should deserialize");
+    c.databases()
+        .get_tags(sub, db)
+        .await
+        .expect("get_tags should deserialize");
+    // The spec documents GET .../traffic, but the live API 404s it for a
+    // normally-running database (traffic state is only meaningful once stopped).
+    // Tolerate the 404; fail only on a deserialize or other unexpected error.
+    match c.databases().get_traffic(sub, db).await {
+        Ok(_) | Err(CloudError::NotFound { .. }) => {}
+        Err(e) => panic!("get_traffic returned an unexpected error: {e}"),
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Connectivity (pinned Pro sub) — typically unconfigured, so a clean NotFound
+// is acceptable; only a deserialize/other error fails.
+// ---------------------------------------------------------------------------
+
+live_test_pinned!(live_connectivity_reads, c, res, {
+    let sub = res.pro_sub;
+    macro_rules! ok_or_not_found {
+        ($call:expr, $what:literal) => {
+            match $call.await {
+                Ok(_) | Err(CloudError::NotFound { .. }) => {}
+                Err(e) => panic!(concat!($what, " returned an unexpected error: {}"), e),
+            }
+        };
+    }
+    ok_or_not_found!(c.vpc_peering().get(sub), "vpc_peering.get");
+    ok_or_not_found!(
+        c.transit_gateway().get_attachments(sub),
+        "transit_gateway.get_attachments"
+    );
+    ok_or_not_found!(c.psc().get_service(sub), "psc.get_service");
+    ok_or_not_found!(c.private_link().get(sub), "private_link.get");
+});
+
+// ---------------------------------------------------------------------------
+// Essentials database deep reads (pinned)
+// ---------------------------------------------------------------------------
+
+live_test_pinned!(live_essentials_database_reads, c, res, {
+    let (sub, db) = (res.essentials_sub, res.essentials_db);
+    c.fixed_databases()
+        .get_by_id(sub, db)
+        .await
+        .expect("fixed get_by_id should deserialize (see #119)");
+    c.fixed_databases()
+        .get_backup_status(sub, db)
+        .await
+        .expect("fixed get_backup_status should deserialize");
+    c.fixed_databases()
+        .get_tags(sub, db)
+        .await
+        .expect("fixed get_tags should deserialize");
+    c.fixed_databases()
+        .get_slow_log(sub, db)
+        .await
+        .expect("fixed get_slow_log should deserialize");
+    match c.fixed_databases().get_traffic(sub, db).await {
+        Ok(_) | Err(CloudError::NotFound { .. }) => {}
+        Err(e) => panic!("fixed get_traffic returned an unexpected error: {e}"),
+    }
 });


### PR DESCRIPTION
Builds on #125. Now that dedicated test subscriptions exist (a Pro and an Essentials sub created for validation), extends the live integration suite beyond the account-agnostic reads to cover the surface that was dark before — the Pro tier and connectivity.

## Added live tests (all `#[ignore]`d, read-only)

- **Pro subscription**: `get_subscription_by_id`, `get_cidr_allowlist`, `get_subscription_maintenance_windows`, `get_subscription_pricing`, `get_redis_versions`
- **Pro databases**: `list`, `get_subscription_database_by_id`, `get_database_backup_status`, `get_subscription_database_certificate`, `get_slow_log`, `get_tags`, `get_traffic`
- **Connectivity**: vpc peering, transit gateway, psc, private link
- **Essentials databases (deep)**: backup status, tags, slow log, traffic

These deeper reads are **pinned to the `REDIS_CLOUD_TEST_*` resource ids** (from the gitignored `.env`) rather than discovered — so they target known-safe resources and lay the groundwork for guarded non-destructive writes later. They skip cleanly when those vars (or credentials) are absent.

`get_traffic` is documented in the spec but the live API **404s it** for a normally-running database (traffic state is only meaningful once stopped), so those assertions tolerate `NotFound` and fail only on a deserialize or other unexpected error.

## Result of the full read sweep

Ran the complete read surface across **both tiers + connectivity** against the real account. Post #119/#120/#122, **everything deserializes cleanly — no new bugs.** The earlier fixes are confirmed across the Pro path too.

## Verification

- 18 live tests pass against the real account (`cargo test --test live_integration -- --ignored`).
- `cargo test --workspace --all-features`: 404 passed, 28 ignored.
- `cargo fmt`, `cargo clippy --workspace --all-targets --all-features` clean.