### PR TITLE
fix(databases)!: capture nested security/clustering/backup on reads (#121)

### DIFF
--- a/src/fixed/databases.rs
+++ b/src/fixed/databases.rs
@@ -338,6 +338,71 @@ pub struct DatabaseAlertSpec {
     pub value: i32,
 }
 
+/// Security configuration returned within a [`FixedDatabase`] read response
+/// (nested `security` object).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixedDatabaseSecurity {
+    /// Whether the default Redis user is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_user_enabled: Option<bool>,
+
+    /// Whether SSL client authentication is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssl_client_authentication: Option<bool>,
+
+    /// Whether TLS client authentication is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls_client_authentication: Option<bool>,
+
+    /// Whether TLS is enabled for connections.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_tls: Option<bool>,
+
+    /// Source IP addresses / CIDR blocks allowed to connect.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ips: Option<Vec<String>>,
+}
+
+/// A single regex rule within a fixed database's clustering policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixedDatabaseRegexRule {
+    /// Order of this rule.
+    pub ordinal: i32,
+
+    /// Regex pattern.
+    pub pattern: String,
+}
+
+/// Clustering configuration returned within a [`FixedDatabase`] read response
+/// (nested `clustering` object).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixedDatabaseClustering {
+    /// Whether clustering is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+
+    /// Regex rules for the custom hashing policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub regex_rules: Option<Vec<FixedDatabaseRegexRule>>,
+
+    /// Hashing policy (e.g. `"standard"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hashing_policy: Option<String>,
+}
+
+/// Backup configuration returned within a [`FixedDatabase`] read response
+/// (nested `backup` object).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixedDatabaseBackup {
+    /// Whether remote backup is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_backup_enabled: Option<bool>,
+}
+
 /// `FixedDatabase`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -415,11 +480,17 @@ pub struct FixedDatabase {
     pub redis_flex: Option<bool>,
 
     /// Whether Redis OSS Cluster API support is enabled.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "supportOSSClusterApi",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub support_oss_cluster_api: Option<bool>,
 
     /// Whether the external endpoint is used for OSS Cluster API.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "useExternalEndpointForOSSClusterApi",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub use_external_endpoint_for_oss_cluster_api: Option<bool>,
 
     /// Data persistence type (e.g. `"none"`, `"aof-every-1-second"`, `"snapshot-every-1-hour"`).
@@ -454,45 +525,23 @@ pub struct FixedDatabase {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dynamic_endpoints: Option<DynamicEndpoints>,
 
-    /// Whether default Redis user is enabled
+    /// Security configuration (TLS, source IPs, authentication).
+    ///
+    /// Returned as a nested `security` object on reads. See
+    /// [`FixedDatabaseSecurity`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_default_user: Option<bool>,
-
-    /// Whether TLS is enabled for connections
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_tls: Option<bool>,
-
-    /// Database password (masked in responses)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub password: Option<String>,
-
-    /// List of source IP addresses or subnet masks allowed to connect
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_ips: Option<Vec<String>>,
-
-    /// Whether SSL client authentication is enabled
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ssl_client_authentication: Option<bool>,
-
-    /// Whether TLS client authentication is enabled
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tls_client_authentication: Option<bool>,
+    pub security: Option<FixedDatabaseSecurity>,
 
     /// Replica of configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replica: Option<ReplicaOfSpec>,
 
-    /// Whether database clustering is enabled
+    /// Clustering configuration (shard hashing).
+    ///
+    /// Returned as a nested `clustering` object on reads. See
+    /// [`FixedDatabaseClustering`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub clustering_enabled: Option<bool>,
-
-    /// Regex rules for custom hashing policy
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub regex_rules: Option<Vec<String>>,
-
-    /// Hashing policy for clustering
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hashing_policy: Option<String>,
+    pub clustering: Option<FixedDatabaseClustering>,
 
     /// Redis modules/capabilities enabled on this database
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -502,9 +551,10 @@ pub struct FixedDatabase {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alerts: Option<Vec<DatabaseAlertSpec>>,
 
-    /// Backup configuration and status
+    /// Backup configuration as returned on reads (nested `backup` object).
+    /// See [`FixedDatabaseBackup`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub backup: Option<DatabaseBackupStatus>,
+    pub backup: Option<FixedDatabaseBackup>,
 
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -489,8 +489,12 @@ pub struct Backup {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_remote_backup: Option<bool>,
 
-    /// Backup time in UTC
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Backup time in UTC.
+    ///
+    /// Wire field is `timeUTC` (capital UTC), so an explicit rename is needed —
+    /// `rename_all = "camelCase"` would produce `timeUtc` and silently drop the
+    /// real value (same casing pitfall as #108).
+    #[serde(rename = "timeUTC", skip_serializing_if = "Option::is_none")]
     pub time_utc: Option<String>,
 
     /// Backup interval (e.g., "every-24-hours", "every-12-hours")
@@ -824,16 +828,36 @@ pub struct Database {
     pub protocol: Option<String>,
 
     /// Support for OSS Cluster API
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "supportOSSClusterApi",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub support_oss_cluster_api: Option<bool>,
 
     /// Use external endpoint for OSS Cluster API
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "useExternalEndpointForOSSClusterApi",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub use_external_endpoint_for_oss_cluster_api: Option<bool>,
 
-    /// Whether TLS is enabled for connections
+    /// Security configuration (TLS, source IPs, authentication).
+    ///
+    /// The API returns these as a nested `security` object on reads. See
+    /// [`Security`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_tls: Option<bool>,
+    pub security: Option<Security>,
+
+    /// Clustering configuration (shard count, hashing policy, regex rules).
+    ///
+    /// Returned as a nested `clustering` object on reads. See [`Clustering`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clustering: Option<Clustering>,
+
+    /// Backup configuration as returned on reads (nested `backup` object).
+    /// See [`Backup`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backup: Option<Backup>,
 
     /// Throughput measurement configuration
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -851,14 +875,6 @@ pub struct Database {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub periodic_backup_path: Option<String>,
 
-    /// Remote backup configuration
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub remote_backup: Option<DatabaseBackupConfig>,
-
-    /// List of source IP addresses or subnet masks allowed to connect
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_ip: Option<Vec<String>>,
-
     /// Client TLS/SSL certificate (deprecated, use `client_tls_certificates`)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_ssl_certificate: Option<String>,
@@ -866,10 +882,6 @@ pub struct Database {
     /// List of client TLS/SSL certificates for mTLS authentication
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_tls_certificates: Option<Vec<DatabaseCertificateSpec>>,
-
-    /// Database password (masked in responses for security)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub password: Option<String>,
 
     /// Memcached SASL username
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -903,10 +915,6 @@ pub struct Database {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replica: Option<ReplicaOfSpec>,
 
-    /// Whether default Redis user is enabled
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_default_user: Option<bool>,
-
     /// Whether this is an Active-Active (CRDB) database
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_active_redis: Option<bool>,
@@ -922,22 +930,6 @@ pub struct Database {
     /// Whether automatic minor version upgrades are enabled
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
-
-    /// Number of shards in the database cluster
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub number_of_shards: Option<i32>,
-
-    /// Regex rules for custom hashing policy
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub regex_rules: Option<Vec<RegexRule>>,
-
-    /// Whether SSL client authentication is enabled
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ssl_client_authentication: Option<bool>,
-
-    /// Whether TLS client authentication is enabled
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tls_client_authentication: Option<bool>,
 
     /// Timestamp when the database was activated.
     ///

--- a/tests/cloud_fixture_validation.rs
+++ b/tests/cloud_fixture_validation.rs
@@ -13,6 +13,7 @@
 //! (output is gitignored and must not be committed).
 
 use redis_cloud::account::PaymentMethods;
+use redis_cloud::databases::Database;
 use redis_cloud::fixed_databases::AccountFixedSubscriptionDatabases;
 use redis_cloud::fixed_subscriptions::FixedSubscription;
 use redis_cloud::types::{TaskStateUpdate, TaskStatus};
@@ -43,6 +44,52 @@ fn fixed_databases_response_deserializes() {
         modules[1].parameters,
         Some(serde_json::json!([{ "name": "error_rate", "value": "0.01" }]))
     );
+
+    // #121: the nested security/clustering/backup objects are now captured
+    // instead of silently dropped.
+    let security = db
+        .security
+        .expect("security object should deserialize (see #121)");
+    assert_eq!(security.source_ips, Some(vec!["0.0.0.0/0".to_string()]));
+    assert_eq!(security.enable_tls, Some(false));
+    assert_eq!(security.default_user_enabled, Some(false));
+
+    let clustering = db.clustering.expect("clustering object should deserialize");
+    assert_eq!(clustering.enabled, Some(false));
+    assert_eq!(clustering.regex_rules.as_ref().map(Vec::len), Some(2));
+    assert_eq!(clustering.hashing_policy.as_deref(), Some("standard"));
+
+    let backup = db.backup.expect("backup object should deserialize");
+    assert_eq!(backup.remote_backup_enabled, Some(false));
+}
+
+// #121 (Pro path): the flexible Database model nests security/clustering/backup
+// the same way, plus OSS-cased fields. All must be captured.
+#[test]
+fn pro_database_response_deserializes() {
+    let raw = include_str!("fixtures/cloud/samples/pro_database.json");
+    let db: Database = serde_json::from_str(raw).expect("pro database fixture should deserialize");
+
+    assert_eq!(db.database_id, 222333);
+    // OSS-cased fields land (rename to supportOSSClusterApi / ...OSSClusterApi).
+    assert_eq!(db.support_oss_cluster_api, Some(false));
+    assert_eq!(db.use_external_endpoint_for_oss_cluster_api, Some(false));
+
+    let security = db
+        .security
+        .expect("security object should deserialize (see #121)");
+    assert_eq!(security.source_ips, Some(vec!["0.0.0.0/0".to_string()]));
+    assert_eq!(security.enable_default_user, Some(true));
+    assert_eq!(security.enable_tls, Some(false));
+
+    let clustering = db.clustering.expect("clustering object should deserialize");
+    assert_eq!(clustering.number_of_shards, Some(1));
+    assert_eq!(clustering.regex_rules.as_ref().map(Vec::len), Some(2));
+
+    let backup = db.backup.expect("backup object should deserialize");
+    assert_eq!(backup.enable_remote_backup, Some(false));
+    assert_eq!(backup.interval.as_deref(), Some("every-12-hours"));
+    assert_eq!(backup.time_utc.as_deref(), Some("14:00"));
 }
 
 // #120: creditCardEndsWith is a JSON number; the number-or-string deserializer

--- a/tests/databases_tests.rs
+++ b/tests/databases_tests.rs
@@ -142,6 +142,25 @@ async fn test_get_database_by_id() {
             "privateEndpoint": "redis-12345.c1.us-east-1.redislabs.com:16379",
             "publicEndpoint": "redis-12345-ext.c1.us-east-1.redislabs.com:16379",
             "protocol": "redis",
+            "supportOSSClusterApi": false,
+            "useExternalEndpointForOSSClusterApi": false,
+            "security": {
+                "enableDefaultUser": true,
+                "enableTls": false,
+                "sourceIps": ["0.0.0.0/0"],
+                "tlsClientAuthentication": false
+            },
+            "clustering": {
+                "numberOfShards": 1,
+                "hashingPolicy": "standard",
+                "regexRules": [{ "ordinal": 0, "pattern": ".*" }]
+            },
+            "backup": {
+                "enableRemoteBackup": false,
+                "interval": "every-12-hours",
+                "timeUTC": "14:00",
+                "destination": "s3://example/backups"
+            },
             "activatedOn": "2024-01-01T00:00:00Z",
             "lastModified": "2024-01-01T12:00:00Z"
         })))
@@ -183,6 +202,20 @@ async fn test_get_database_by_id() {
         result.activated_on,
         Some("2024-01-01T00:00:00Z".to_string())
     );
+    // #121: OSS-cased fields and the nested security/clustering/backup objects
+    // are captured from the real response shape rather than silently dropped.
+    assert_eq!(result.support_oss_cluster_api, Some(false));
+    let security = result
+        .security
+        .expect("security should deserialize (see #121)");
+    assert_eq!(security.source_ips, Some(vec!["0.0.0.0/0".to_string()]));
+    assert_eq!(security.enable_default_user, Some(true));
+    let clustering = result.clustering.expect("clustering should deserialize");
+    assert_eq!(clustering.number_of_shards, Some(1));
+    let backup = result.backup.expect("backup should deserialize");
+    assert_eq!(backup.enable_remote_backup, Some(false));
+    // Same timeUTC casing pitfall as #108 — must be captured.
+    assert_eq!(backup.time_utc.as_deref(), Some("14:00"));
 }
 
 #[tokio::test]

--- a/tests/fixed_databases_tests.rs
+++ b/tests/fixed_databases_tests.rs
@@ -653,4 +653,12 @@ async fn test_fixed_database_modules_parameters_array_deserializes() {
         modules[1].parameters,
         Some(json!([{ "name": "error_rate", "value": "0.01" }]))
     );
+
+    // #121: the nested security/clustering/backup objects are now captured.
+    let security = db.security.expect("security should deserialize (see #121)");
+    assert_eq!(security.source_ips, Some(vec!["0.0.0.0/0".to_string()]));
+    assert_eq!(security.enable_tls, Some(false));
+    let clustering = db.clustering.expect("clustering should deserialize");
+    assert_eq!(clustering.enabled, Some(false));
+    assert_eq!(clustering.regex_rules.as_ref().map(Vec::len), Some(1));
 }

--- a/tests/fixtures/cloud/samples/pro_database.json
+++ b/tests/fixtures/cloud/samples/pro_database.json
@@ -1,0 +1,54 @@
+{
+  "databaseId": 222333,
+  "name": "example-pro-db",
+  "protocol": "redis",
+  "provider": "AWS",
+  "region": "us-east-1",
+  "status": "active",
+  "memoryLimitInGb": 6.0,
+  "datasetSizeInGb": 3.0,
+  "memoryUsedInMb": 6.3,
+  "redisVersion": "8.4",
+  "redisVersionCompliance": "8.4.0",
+  "respVersion": "resp3",
+  "publicEndpoint": "redis-12345.example.cloud.redislabs.com:12345",
+  "privateEndpoint": "redis-12345.internal.example.cloud.redislabs.com:12345",
+  "dataPersistence": "aof-every-1-second",
+  "dataEvictionPolicy": "noeviction",
+  "replication": true,
+  "supportOSSClusterApi": false,
+  "useExternalEndpointForOSSClusterApi": false,
+  "autoMinorVersionUpgrade": true,
+  "queryPerformanceFactor": "standard",
+  "memoryStorage": "ram",
+  "security": {
+    "enableDefaultUser": true,
+    "enableTls": false,
+    "password": "example-password",
+    "sourceIps": ["0.0.0.0/0"],
+    "tlsClientAuthentication": false
+  },
+  "clustering": {
+    "numberOfShards": 1,
+    "hashingPolicy": "standard",
+    "regexRules": [
+      { "ordinal": 0, "pattern": ".*\\{(?<tag>.*)\\}.*" },
+      { "ordinal": 1, "pattern": "(?<tag>.*)" }
+    ]
+  },
+  "modules": [],
+  "throughputMeasurement": { "by": "operations-per-second", "value": 3000 },
+  "alerts": [
+    { "id": 1, "name": "dataset-size", "value": 80, "defaultValue": 80 }
+  ],
+  "backup": {
+    "destination": "s3://example-bucket/backups",
+    "enableRemoteBackup": false,
+    "interval": "every-12-hours",
+    "timeUTC": "14:00"
+  },
+  "replicaOf": null,
+  "activatedOn": "2026-06-11T18:00:00Z",
+  "lastModified": "2026-06-11T18:30:00Z",
+  "links": []
+}

--- a/tests/live_integration.rs
+++ b/tests/live_integration.rs
@@ -316,10 +316,20 @@ live_test_pinned!(live_pro_database_reads, c, res, {
         .list(sub)
         .await
         .expect("databases list should deserialize");
-    c.databases()
+    let database = c
+        .databases()
         .get_subscription_database_by_id(sub, db)
         .await
         .expect("get_subscription_database_by_id should deserialize");
+    // #121: the nested security object (with its source-IP allowlist) must be
+    // captured from the real response, not silently dropped.
+    let security = database
+        .security
+        .expect("Pro database response should include a security object (see #121)");
+    assert!(
+        security.source_ips.is_some(),
+        "security.sourceIps should be populated"
+    );
     c.databases()
         .get_database_backup_status(sub, db, None)
         .await
@@ -375,10 +385,19 @@ live_test_pinned!(live_connectivity_reads, c, res, {
 
 live_test_pinned!(live_essentials_database_reads, c, res, {
     let (sub, db) = (res.essentials_sub, res.essentials_db);
-    c.fixed_databases()
+    let database = c
+        .fixed_databases()
         .get_by_id(sub, db)
         .await
         .expect("fixed get_by_id should deserialize (see #119)");
+    // #121: nested security object captured from the real Essentials response.
+    let security = database
+        .security
+        .expect("Essentials database response should include a security object (see #121)");
+    assert!(
+        security.source_ips.is_some(),
+        "security.sourceIps should be populated"
+    );
     c.fixed_databases()
         .get_backup_status(sub, db)
         .await


### PR DESCRIPTION
Closes #121.

## Problem

Both database response models **flattened** config that the live API returns **nested**, so every database read silently dropped it — across *both* tiers. Confirmed against live Pro + Essentials databases: `security.sourceIps` (the IP allowlist), TLS flags, `clustering.numberOfShards`/`regexRules`, and the `backup` object all came back empty despite being present on the wire. This is silent loss of security-relevant data on the most common read.

## Fix

**`flexible::Database` (Pro):** wire in the `Security`, `Clustering`, and `Backup` response structs — which already existed in the module but were never used by the response model — as nested `security`/`clustering`/`backup` fields. Remove the flat duplicates (`enable_tls`, `source_ip`, `ssl_client_authentication`, `tls_client_authentication`, `enable_default_user`, `password`, `number_of_shards`, `regex_rules`, `remote_backup`). Add explicit `supportOSSClusterApi` / `useExternalEndpointForOSSClusterApi` renames (`rename_all = "camelCase"` produced `...OssClusterApi`, dropping them).

**`fixed::FixedDatabase` (Essentials):** add tier-specific nested structs (`FixedDatabaseSecurity` with `defaultUserEnabled`, `FixedDatabaseClustering`, `FixedDatabaseBackup` with `remoteBackupEnabled` — the field names differ from Pro) and wire them in; remove the flat duplicates; fix OSS casing.

**`Backup.time_utc`:** add `rename = "timeUTC"` — `camelCase` produced `timeUtc` and dropped the real value (the #108 pitfall again). Surfaced by the new Pro fixture parse test.

Both are **response-only** models (separate `*CreateRequest`/`*UpdateRequest` types carry the request fields), so request serialization is unaffected.

## ⚠️ Breaking

Removes flat fields from `Database` and `FixedDatabase` that **never populated on reads anyway**. Read them via the nested objects now (`db.security.source_ips`, `db.clustering.number_of_shards`, `db.backup.enable_remote_backup`, …). `release-plz`'s `semver_check` will flag the bump. Zero `src/` references to the removed fields; only the two DB test files touched them.

## Validation

- **Fixtures (CI, no creds):** new `pro_database.json` + parse tests assert the nested objects and OSS fields deserialize; the Essentials fixture test now asserts the nested fields too.
- **Live (real account):** the pinned Pro + Essentials live tests now assert `security.sourceIps` is captured — verified against the real account.
- **Wiremock:** updated the primary Pro `get-by-id` and Essentials list mocks to the real nested shapes with nested assertions.
- `cargo fmt`, `cargo clippy --workspace --all-targets --all-features` clean; `cargo test --workspace`: 405 passed, 28 ignored; 18 live tests pass.