### PR TITLE
fix(subscriptions)!: capture subscriptionPricing + nested cloudDetails on reads (#128)

### DIFF
--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -611,6 +611,14 @@ pub struct CloudDetail {
     /// Regions configured for this cloud provider
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regions: Option<Vec<SubscriptionRegion>>,
+
+    /// Resource tags applied to the subscription's cloud resources.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_tags: Option<Vec<Tag>>,
+
+    /// HATEOAS links.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
 }
 
 /// Region details in a subscription response
@@ -638,8 +646,12 @@ pub struct SubscriptionRegion {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionNetworking {
-    /// Deployment CIDR
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Deployment CIDR.
+    ///
+    /// Wire field is `deploymentCIDR` (capital CIDR), so an explicit rename is
+    /// needed — `rename_all = "camelCase"` would produce `deploymentCidr` and
+    /// silently drop the real value (same casing pitfall as #108/#121).
+    #[serde(rename = "deploymentCIDR", skip_serializing_if = "Option::is_none")]
     pub deployment_cidr: Option<String>,
 
     /// VPC ID
@@ -649,6 +661,10 @@ pub struct SubscriptionNetworking {
     /// Subnet ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subnet_id: Option<String>,
+
+    /// Security group ID associated with the deployment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security_group_id: Option<String>,
 }
 
 /// `RedisLabs` Subscription information
@@ -703,9 +719,15 @@ pub struct Subscription {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud_details: Option<Vec<CloudDetail>>,
 
-    /// Pricing details for the subscription
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pricing: Option<Vec<SubscriptionPricing>>,
+    /// Pricing details for the subscription.
+    ///
+    /// Wire field is `subscriptionPricing`; the field was previously named
+    /// `pricing` (serialized as `pricing`) and silently dropped the real value.
+    #[serde(
+        rename = "subscriptionPricing",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub subscription_pricing: Option<Vec<SubscriptionPricing>>,
 
     /// Redis version for databases created in this subscription (deprecated)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/cloud_fixture_validation.rs
+++ b/tests/cloud_fixture_validation.rs
@@ -16,6 +16,7 @@ use redis_cloud::account::PaymentMethods;
 use redis_cloud::databases::Database;
 use redis_cloud::fixed_databases::AccountFixedSubscriptionDatabases;
 use redis_cloud::fixed_subscriptions::FixedSubscription;
+use redis_cloud::subscriptions::AccountSubscriptions;
 use redis_cloud::types::{TaskStateUpdate, TaskStatus};
 
 // #119: modules[].parameters is an array on the wire (empty or objects), and a
@@ -135,4 +136,44 @@ fn fixed_subscription_response_deserializes() {
     assert_eq!(sub.id, Some(111111));
     assert_eq!(sub.connections.as_deref(), Some("10000"));
     assert_eq!(sub.database_status.as_deref(), Some("active"));
+}
+
+// #128: the Pro subscription read dropped subscriptionPricing and the nested
+// cloudDetails networking/tags/links (incl. the deploymentCIDR casing). All
+// must now be captured.
+#[test]
+fn pro_subscriptions_response_deserializes() {
+    let raw = include_str!("fixtures/cloud/samples/pro_subscriptions.json");
+    let resp: AccountSubscriptions =
+        serde_json::from_str(raw).expect("pro subscriptions fixture should deserialize");
+
+    let sub = resp
+        .subscriptions
+        .and_then(|s| s.into_iter().next())
+        .expect("fixture should contain a subscription");
+
+    // subscriptionPricing (was dropped because the field mapped to `pricing`).
+    let pricing = sub
+        .subscription_pricing
+        .expect("subscriptionPricing should deserialize (see #128)");
+    assert_eq!(pricing.len(), 2);
+    assert_eq!(pricing[0].r#type.as_deref(), Some("MinimumPrice"));
+
+    let cloud = sub
+        .cloud_details
+        .and_then(|c| c.into_iter().next())
+        .expect("cloudDetails should deserialize");
+    // resourceTags + links on cloudDetails (were unmodeled).
+    assert!(cloud.resource_tags.is_some());
+    assert!(cloud.links.is_some());
+
+    let net = cloud
+        .regions
+        .and_then(|r| r.into_iter().next())
+        .and_then(|r| r.networking)
+        .and_then(|n| n.into_iter().next())
+        .expect("networking should deserialize");
+    // deploymentCIDR casing (was dropped) + securityGroupId (was unmodeled).
+    assert_eq!(net.deployment_cidr.as_deref(), Some("192.168.0.0/26"));
+    assert!(net.security_group_id.is_some());
 }

--- a/tests/fixtures/cloud/samples/pro_subscriptions.json
+++ b/tests/fixtures/cloud/samples/pro_subscriptions.json
@@ -1,0 +1,59 @@
+{
+  "accountId": 12345,
+  "subscriptions": [
+    {
+      "id": 111111,
+      "name": "example-pro-subscription",
+      "status": "active",
+      "paymentMethodId": 555,
+      "paymentMethodType": "credit-card",
+      "memoryStorage": "ram",
+      "numberOfDatabases": 1,
+      "deploymentType": "single-region",
+      "cloudDetails": [
+        {
+          "provider": "AWS",
+          "cloudAccountId": 1,
+          "totalSizeInGb": 6.0,
+          "regions": [
+            {
+              "region": "us-east-1",
+              "networking": [
+                {
+                  "deploymentCIDR": "192.168.0.0/26",
+                  "subnetId": "subnet-0example",
+                  "securityGroupId": "sg-0example"
+                }
+              ],
+              "preferredAvailabilityZones": ["use1-az1"],
+              "multipleAvailabilityZones": false
+            }
+          ],
+          "resourceTags": [],
+          "links": []
+        }
+      ],
+      "subscriptionPricing": [
+        {
+          "type": "MinimumPrice",
+          "quantity": 1,
+          "quantityMeasurement": "subscription",
+          "pricePerUnit": 0.274,
+          "priceCurrency": "USD",
+          "pricePeriod": "hour"
+        },
+        {
+          "type": "Shards",
+          "typeDetails": "micro",
+          "quantity": 6,
+          "quantityMeasurement": "shards",
+          "pricePerUnit": 0.043,
+          "priceCurrency": "USD",
+          "pricePeriod": "hour"
+        }
+      ],
+      "links": []
+    }
+  ],
+  "links": []
+}

--- a/tests/live_integration.rs
+++ b/tests/live_integration.rs
@@ -284,10 +284,20 @@ live_test!(live_tasks_list, c, {
 
 live_test_pinned!(live_pro_subscription_reads, c, res, {
     let sub = res.pro_sub;
-    c.subscriptions()
+    let subscription = c
+        .subscriptions()
         .get_subscription_by_id(sub)
         .await
         .expect("get_subscription_by_id should deserialize");
+    // #128: subscriptionPricing and nested cloudDetails must be captured.
+    assert!(
+        subscription.subscription_pricing.is_some(),
+        "subscriptionPricing should be populated (see #128)"
+    );
+    assert!(
+        subscription.cloud_details.is_some(),
+        "cloudDetails should be populated"
+    );
     c.subscriptions()
         .get_cidr_allowlist(sub)
         .await

--- a/tests/subscriptions_tests.rs
+++ b/tests/subscriptions_tests.rs
@@ -187,7 +187,31 @@ async fn test_get_subscription_by_id() {
             "id": 123,
             "name": "Production",
             "status": "active",
-            "paymentMethodType": "credit-card"
+            "paymentMethodType": "credit-card",
+            "numberOfDatabases": 1,
+            "cloudDetails": [{
+                "provider": "AWS",
+                "cloudAccountId": 1,
+                "totalSizeInGb": 6.0,
+                "regions": [{
+                    "region": "us-east-1",
+                    "networking": [{
+                        "deploymentCIDR": "192.168.0.0/26",
+                        "subnetId": "subnet-0example",
+                        "securityGroupId": "sg-0example"
+                    }]
+                }],
+                "resourceTags": [],
+                "links": []
+            }],
+            "subscriptionPricing": [{
+                "type": "Shards",
+                "quantity": 6,
+                "quantityMeasurement": "shards",
+                "pricePerUnit": 0.043,
+                "priceCurrency": "USD",
+                "pricePeriod": "hour"
+            }]
         })))
         .mount(&mock_server)
         .await;
@@ -204,6 +228,22 @@ async fn test_get_subscription_by_id() {
 
     assert_eq!(result.id, Some(123));
     assert_eq!(result.name, Some("Production".to_string()));
+    // #128: subscriptionPricing and the nested cloudDetails networking/tags are
+    // captured from the real response shape.
+    let pricing = result
+        .subscription_pricing
+        .expect("subscriptionPricing should deserialize (see #128)");
+    assert_eq!(pricing[0].r#type.as_deref(), Some("Shards"));
+    let net = result
+        .cloud_details
+        .and_then(|c| c.into_iter().next())
+        .and_then(|c| c.regions)
+        .and_then(|r| r.into_iter().next())
+        .and_then(|r| r.networking)
+        .and_then(|n| n.into_iter().next())
+        .expect("networking should deserialize");
+    assert_eq!(net.deployment_cidr.as_deref(), Some("192.168.0.0/26"));
+    assert!(net.security_group_id.is_some());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #128.

## Problem

A round-trip drift check (deserialize a real `GET /subscriptions` response → re-serialize → diff keys) against a live Pro subscription found fields the `Subscription` model silently dropped:

- **`subscriptionPricing`** — the field was named `pricing` (serialized as `pricing`), not the wire's `subscriptionPricing`. The whole pricing array was dropped.
- **`cloudDetails[].regions[].networking[].deploymentCIDR`** — `deployment_cidr` camelCased to `deploymentCidr`, but the wire field is `deploymentCIDR` (capital CIDR). The #108/#121 casing pitfall, again.
- **`securityGroupId`** — not modeled in `SubscriptionNetworking`.
- **`cloudDetails[].resourceTags`** and **`cloudDetails[].links`** — not modeled in `CloudDetail`.

## Fix

- Rename `Subscription.pricing` → `subscription_pricing` (maps to `subscriptionPricing`).
- `SubscriptionNetworking`: add `#[serde(rename = "deploymentCIDR")]`; add `security_group_id`.
- `CloudDetail`: add `resource_tags` and `links`.

(`SubscriptionPricing` already had the `type` field.)

## ⚠️ Breaking

`Subscription.pricing` → `subscription_pricing`. It never populated on reads (wrong wire name) and nothing referenced it — the `/pricing` endpoint uses the separate `SubscriptionPricings` type. `release-plz` `semver_check` will flag the bump.

## Validation

- **Fixtures (CI):** new `pro_subscriptions.json` + parse test assert pricing and the nested networking/tags/links deserialize.
- **Live (real account):** the pinned Pro subscription test asserts `subscriptionPricing` + `cloudDetails` are captured.
- **Wiremock:** updated `test_get_subscription_by_id` to the real nested shape.
- A drift sweep over **every other read domain** (account, acl, users, cloud_accounts, fixed subscriptions, regions, modules, payment methods) round-tripped **clean** — this was the only remaining silent-drop domain.
- `cargo fmt`, `clippy --workspace --all-targets` clean; `cargo test --workspace`: 406 passed, 28 ignored.