### PR TITLE
fix(tags): capture inline tags array in CloudTags + validate tag write path (#130)

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -249,14 +249,20 @@ pub struct CloudTag {
 
 /// Collection wrapper returned by the database tags listing endpoints.
 ///
-/// Matches the `CloudTags` schema, which is a HATEOAS envelope carrying the
-/// owning account ID and links rather than an inline tag array.
+/// The OpenAPI `CloudTags` schema describes only `accountId`/`links`, but the
+/// live `GET .../tags` response includes an inline `tags` array when the
+/// database has tags — so the array is captured here too (see #130).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CloudTags {
     /// Account ID owning the tags.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_id: Option<i32>,
+
+    /// Tags on the database. Present (possibly empty) on real responses; the
+    /// OpenAPI schema omits it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<CloudTag>>,
 
     /// HATEOAS links.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/databases_tests.rs
+++ b/tests/databases_tests.rs
@@ -1265,3 +1265,48 @@ async fn test_resume_database_traffic() {
     // Empty 204 body must deserialize cleanly into `()`.
     handler.resume_traffic(123, 456).await.unwrap();
 }
+
+// #130: the live GET tags response carries an inline `tags` array that the
+// CloudTags model used to drop. Mirror the real shape and assert it's captured.
+#[tokio::test]
+async fn test_get_tags_captures_inline_tags() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/subscriptions/123/databases/456/tags"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "accountId": 456,
+            "tags": [
+                {
+                    "key": "env",
+                    "value": "test",
+                    "createdAt": "2026-06-12T14:36:24.487Z",
+                    "updatedAt": "2026-06-12T14:36:24.487Z",
+                    "links": []
+                }
+            ],
+            "links": []
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key".to_string())
+        .api_secret("test-secret".to_string())
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = DatabaseHandler::new(client);
+    let result = handler.get_tags(123, 456).await.unwrap();
+
+    assert_eq!(result.account_id, Some(456));
+    let tags = result
+        .tags
+        .expect("tags array should be captured (see #130)");
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].key.as_deref(), Some("env"));
+    assert_eq!(tags[0].value.as_deref(), Some("test"));
+}

--- a/tests/live_integration.rs
+++ b/tests/live_integration.rs
@@ -425,3 +425,91 @@ live_test_pinned!(live_essentials_database_reads, c, res, {
         Err(e) => panic!("fixed get_traffic returned an unexpected error: {e}"),
     }
 });
+
+// ---------------------------------------------------------------------------
+// Non-destructive WRITE validation (pinned) — full database-tag lifecycle.
+// Fully reversible and scoped to the pinned test database; cleans up after
+// itself (and pre-cleans in case a prior run was interrupted).
+// ---------------------------------------------------------------------------
+
+live_test_pinned!(live_pro_database_tag_lifecycle, c, res, {
+    use redis_cloud::databases::{DatabaseTagCreateRequest, DatabaseTagUpdateRequest};
+
+    let (sub, db) = (res.pro_sub, res.pro_db);
+    let key = "rcrs-write-test";
+
+    // Pre-clean: drop a stray tag from an interrupted prior run (ignore errors).
+    let _ = c.databases().delete_tag(sub, db, key.to_string()).await;
+
+    // Create.
+    let created = c
+        .databases()
+        .create_tag(
+            sub,
+            db,
+            &DatabaseTagCreateRequest {
+                key: key.to_string(),
+                value: "v1".to_string(),
+                subscription_id: None,
+                database_id: None,
+                command_type: None,
+            },
+        )
+        .await
+        .expect("create_tag should succeed");
+    assert_eq!(created.value.as_deref(), Some("v1"));
+
+    // Read back — the inline tags array must be captured (#130).
+    let tags = c
+        .databases()
+        .get_tags(sub, db)
+        .await
+        .expect("get_tags should deserialize");
+    let found = tags
+        .tags
+        .unwrap_or_default()
+        .into_iter()
+        .find(|t| t.key.as_deref() == Some(key));
+    assert!(
+        found.is_some_and(|t| t.value.as_deref() == Some("v1")),
+        "created tag should appear in get_tags with its value (see #130)"
+    );
+
+    // Update the value (PUT request serialization).
+    let updated = c
+        .databases()
+        .update_tag(
+            sub,
+            db,
+            key.to_string(),
+            &DatabaseTagUpdateRequest {
+                subscription_id: None,
+                database_id: None,
+                key: None,
+                value: "v2".to_string(),
+                command_type: None,
+            },
+        )
+        .await
+        .expect("update_tag should succeed");
+    assert_eq!(updated.value.as_deref(), Some("v2"));
+
+    // Delete (cleanup).
+    c.databases()
+        .delete_tag(sub, db, key.to_string())
+        .await
+        .expect("delete_tag should succeed");
+
+    // Verify gone.
+    let after = c
+        .databases()
+        .get_tags(sub, db)
+        .await
+        .expect("get_tags should deserialize");
+    let still_present = after
+        .tags
+        .unwrap_or_default()
+        .iter()
+        .any(|t| t.key.as_deref() == Some(key));
+    assert!(!still_present, "tag should be gone after delete");
+});


### PR DESCRIPTION
Closes #130. First slice of non-destructive write validation.

## Problem

The live `GET .../tags` response carries an inline `tags` array when a database has tags:

```json
{ "accountId": 12345, "tags": [{ "key": "env", "value": "test", "createdAt": "...", "updatedAt": "...", "links": [] }], "links": [] }
```

…but `CloudTags` was modeled as `{ accountId, links }` (matching the OpenAPI schema, which omits the array). So `databases().get_tags()` and `fixed_databases().get_tags()` silently dropped every tag.

## Fix

Add `tags: Option<Vec<CloudTag>>` to `CloudTags` (additive, **non-breaking**). `CloudTag` already models the per-tag shape.

## How found

Starting non-destructive write validation: created a tag on the pinned Pro test database, then read it back. `create_tag` (→ `CloudTag`) and `delete_tag` (204) were already correct; only the list-response shape was wrong. The earlier read sweep missed it because the DB had zero tags at the time.

## Tests

- **Wiremock (CI):** `test_get_tags_captures_inline_tags` mirrors the real shape and asserts the array is captured.
- **Live (real account):** `live_pro_database_tag_lifecycle` — a fully reversible, pinned tag lifecycle: create → get (asserts the tag round-trips) → update → delete → verify gone. Pre-cleans a stray tag from any interrupted prior run, so it's safe to re-run.

This also establishes the **guarded-write test pattern** (pinned to `REDIS_CLOUD_TEST_*`, self-cleaning) for the rest of the write-path validation.

## Verification
`cargo fmt`, `clippy --workspace --all-targets` clean; `cargo test --workspace`: 407 passed, 29 ignored; 19 live tests pass (incl. the new write lifecycle).