### PR TITLE
fix(subscriptions)!: make Pro update_subscription actually update (#133)

### DIFF
--- a/src/flexible/subscriptions.rs
+++ b/src/flexible/subscriptions.rs
@@ -64,20 +64,6 @@ use typed_builder::TypedBuilder;
 // ============================================================================
 
 /// Subscription update request message
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BaseSubscriptionUpdateRequest {
-    /// Subscription ID being updated. Server-populated from the path.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub subscription_id: Option<i32>,
-
-    /// Read-only on the response; populated by the server with the
-    /// operation type (e.g. `"UPDATE_SUBSCRIPTION"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_type: Option<String>,
-}
-
-/// Subscription update request message
 ///
 /// # Example
 ///
@@ -110,6 +96,12 @@ pub struct SubscriptionUpdateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option, into))]
     pub payment_method: Option<String>,
+
+    /// Optional. Whether the databases in this subscription are reachable on
+    /// their public endpoints.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub public_endpoint_access: Option<bool>,
 
     /// Read-only on the response; populated by the server with the
     /// operation type (e.g. `"UPDATE_SUBSCRIPTION"`).
@@ -1061,7 +1053,7 @@ impl SubscriptionHandler {
     pub async fn update_subscription(
         &self,
         subscription_id: i32,
-        request: &BaseSubscriptionUpdateRequest,
+        request: &SubscriptionUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.client
             .put(&format!("/subscriptions/{subscription_id}"), request)
@@ -1305,7 +1297,7 @@ impl SubscriptionHandler {
     pub async fn update(
         &self,
         subscription_id: i32,
-        request: &BaseSubscriptionUpdateRequest,
+        request: &SubscriptionUpdateRequest,
     ) -> Result<TaskStateUpdate> {
         self.update_subscription(subscription_id, request).await
     }

--- a/tests/live_integration.rs
+++ b/tests/live_integration.rs
@@ -513,3 +513,75 @@ live_test_pinned!(live_pro_database_tag_lifecycle, c, res, {
         .any(|t| t.key.as_deref() == Some(key));
     assert!(!still_present, "tag should be gone after delete");
 });
+
+// Reversible subscription update: rename the pinned test subscription and
+// restore it. Guards #133 — the update request must actually carry `name`
+// (the old request type silently dropped it, making updates no-ops).
+live_test_pinned!(live_pro_subscription_update_name, c, res, {
+    use redis_cloud::subscriptions::SubscriptionUpdateRequest;
+    use std::time::Duration;
+
+    // Poll the subscription name until it reflects `want` (updates are async),
+    // returning the last observed name.
+    async fn wait_for_name(c: &CloudClient, sub: i32, want: &str) -> Option<String> {
+        for _ in 0..30 {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            if let Ok(s) = c.subscriptions().get_subscription_by_id(sub).await
+                && s.name.as_deref() == Some(want)
+            {
+                return s.name;
+            }
+        }
+        c.subscriptions()
+            .get_subscription_by_id(sub)
+            .await
+            .ok()
+            .and_then(|s| s.name)
+    }
+
+    let sub = res.pro_sub;
+    let original = c
+        .subscriptions()
+        .get_subscription_by_id(sub)
+        .await
+        .expect("get_subscription_by_id should deserialize")
+        .name
+        .expect("test subscription should have a name");
+    let temp = format!("{original}-rcrs-upd-test");
+
+    // Rename to a temp value.
+    c.subscriptions()
+        .update_subscription(
+            sub,
+            &SubscriptionUpdateRequest::builder()
+                .name(temp.clone())
+                .build(),
+        )
+        .await
+        .expect("update_subscription (rename) should succeed");
+    let after = wait_for_name(&c, sub, &temp).await;
+
+    // Restore the original name *before* asserting, so a failed assertion
+    // doesn't leave the subscription renamed.
+    c.subscriptions()
+        .update_subscription(
+            sub,
+            &SubscriptionUpdateRequest::builder()
+                .name(original.clone())
+                .build(),
+        )
+        .await
+        .expect("update_subscription (restore) should succeed");
+    let restored = wait_for_name(&c, sub, &original).await;
+
+    assert_eq!(
+        after.as_deref(),
+        Some(temp.as_str()),
+        "rename should take effect (see #133)"
+    );
+    assert_eq!(
+        restored.as_deref(),
+        Some(original.as_str()),
+        "name should be restored"
+    );
+});

--- a/tests/subscriptions_tests.rs
+++ b/tests/subscriptions_tests.rs
@@ -254,6 +254,9 @@ async fn test_update_subscription() {
         .and(path("/subscriptions/123"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
+        // #133: the request body must actually carry `name` (the old request
+        // type couldn't serialize it, so updates were no-ops).
+        .and(body_json(json!({ "name": "renamed-subscription" })))
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-update-sub",
             "commandType": "UPDATE_SUBSCRIPTION",
@@ -270,10 +273,9 @@ async fn test_update_subscription() {
         .unwrap();
 
     let handler = SubscriptionsHandler::new(client);
-    let request = redis_cloud::subscriptions::BaseSubscriptionUpdateRequest {
-        subscription_id: None,
-        command_type: None,
-    };
+    let request = redis_cloud::subscriptions::SubscriptionUpdateRequest::builder()
+        .name("renamed-subscription")
+        .build();
 
     let result = handler.update_subscription(123, &request).await.unwrap();
     assert_eq!(result.task_id, Some("task-update-sub".to_string()));


### PR DESCRIPTION
Closes #133. Continuing non-destructive write validation (DB/subscription updates).

## Problem

`update_subscription(id, ...)` (and its `update` alias) took `BaseSubscriptionUpdateRequest` — which only has `subscription_id` + `command_type`. So the client could not set a subscription's **name** or **payment method**; the request body was effectively empty.

**Confirmed against the live API:** `PUT /subscriptions/{id}` with `{"name": "..."}` does rename the subscription (verified on the test sub: renamed and restored). So the real API accepts fields the client couldn't send.

A richer `SubscriptionUpdateRequest` (name / paymentMethodId / paymentMethod + a `TypedBuilder`) **already existed but was wired to no handler** — dead code.

## Fix

- Add `public_endpoint_access` to `SubscriptionUpdateRequest` (accepted by the real API and the spec's richer schema).
- Point `update_subscription` / `update` at `SubscriptionUpdateRequest`.
- Remove the now-unused `BaseSubscriptionUpdateRequest`.

## ⚠️ Breaking

Handler signature change + removal of `BaseSubscriptionUpdateRequest` (which was unusable). Isolated to the Pro subscription update — the Essentials sub update (`FixedSubscriptionUpdateRequest`) and both DB update requests already carried these fields.

## Tests

- **Wiremock:** `test_update_subscription` now asserts the serialized request body actually carries `name` (`body_json` matcher) — directly guards the bug.
- **Live:** `live_pro_subscription_update_name` — a reversible rename round-trip pinned to the test subscription (rename → verify → restore), validated against the real account.

## Verification
`cargo fmt`, `clippy --workspace --all-targets` clean; `cargo test --workspace`: 407 passed, 30 ignored; 20 live tests pass (incl. the rename round-trip).