### PR TITLE
test(databases): assert update_database serializes the request body

### DIFF
--- a/tests/databases_tests.rs
+++ b/tests/databases_tests.rs
@@ -226,6 +226,13 @@ async fn test_update_database() {
         .and(path("/subscriptions/123/databases/456"))
         .and(header("x-api-key", "test-key"))
         .and(header("x-api-secret-key", "test-secret"))
+        // The request body must actually serialize the update fields (guards
+        // the request-serialization class; confirmed live for DB renames).
+        .and(body_json(json!({
+            "name": "updated-database",
+            "memoryLimitInGb": 4.0,
+            "dataEvictionPolicy": "volatile-lru"
+        })))
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
             "taskId": "task-update-db-456",
             "commandType": "UPDATE_DATABASE",


### PR DESCRIPTION
Small guard completing the DB/subscription update validation.

Adds a `body_json` matcher to `test_update_database` so it verifies the update request actually carries `name`/`memoryLimitInGb`/`dataEvictionPolicy` — the request-serialization class (cf. #133, where the *subscription* update couldn't serialize its fields at all).

Confirmed live during write validation: `PUT /subscriptions/{s}/databases/{d}` with `{name}` renames the database — `DatabaseUpdateRequest` is complete and serializes correctly (no bug). Operational note discovered: the API rejects a second update until the database returns to `active` (`DATABASE_NOT_ACTIVE` 403), which makes a live round-trip slow/flaky — so this fast wiremock guard covers the serialization instead of a live test.

`cargo fmt`, `clippy --workspace --all-targets` clean; databases_tests: 26 passed.