### PR TITLE
chore(spec): refresh bundled cloud_openapi.json from upstream

### DIFF
--- a/tests/fixtures/cloud_openapi.json
+++ b/tests/fixtures/cloud_openapi.json
@@ -7128,7 +7128,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BdbVersionUpgradeStatus"
+                  "$ref": "#/components/schemas/DatabaseVersionUpgradeStatus"
                 }
               }
             }
@@ -7933,7 +7933,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BdbVersionUpgradeStatus"
+                  "$ref": "#/components/schemas/DatabaseVersionUpgradeStatus"
                 }
               }
             }
@@ -10088,7 +10088,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BdbAvailableVersionsResponse"
+                  "$ref": "#/components/schemas/DatabaseAvailableVersionsResponse"
                 }
               }
             }
@@ -10700,7 +10700,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BdbAvailableVersionsResponse"
+                  "$ref": "#/components/schemas/DatabaseAvailableVersionsResponse"
                 }
               }
             }
@@ -11239,31 +11239,6 @@
         },
         "description": "User update request"
       },
-      "BdbVersionUpgradeStatus": {
-        "type": "object",
-        "properties": {
-          "databaseId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "targetRedisVersion": {
-            "type": "string"
-          },
-          "progress": {
-            "type": "number",
-            "format": "double"
-          },
-          "upgradeStatus": {
-            "type": "string",
-            "enum": [
-              "in-progress",
-              "in-progress-recovery-pending",
-              "done",
-              "failed"
-            ]
-          }
-        }
-      },
       "PaymentMethods": {
         "type": "object",
         "properties": {
@@ -11520,12 +11495,12 @@
           },
           "paymentMethodId": {
             "type": "integer",
-            "description": "Optional. The payment method ID you'd like to use for this subscription. Must be a valid payment method ID for this account. Use GET /payment-methods to get all payment methods for your account. This value is optional if \u2018paymentMethod\u2019 is \u2018marketplace\u2019, but required if 'paymentMethod' is 'credit-card'.",
+            "description": "Optional. The payment method ID you'd like to use for this subscription. Must be a valid payment method ID for this account. Use GET /payment-methods to get all payment methods for your account. This value is optional if ‘paymentMethod’ is ‘marketplace’, but required if 'paymentMethod' is 'credit-card'.",
             "format": "int32"
           },
           "paymentMethod": {
             "type": "string",
-            "description": "Optional. The payment method for the subscription. If set to \u2018credit-card\u2019 , \u2018paymentMethodId\u2019 must be defined.",
+            "description": "Optional. The payment method for the subscription. If set to ‘credit-card’ , ‘paymentMethodId’ must be defined.",
             "enum": [
               "credit-card",
               "marketplace"
@@ -11804,7 +11779,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb.If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
+            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb.If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -12080,7 +12055,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "(Pay-as-you-go subscriptions only) Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb. If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
+            "description": "(Pay-as-you-go subscriptions only) Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb. If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -12261,7 +12236,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb.If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
+            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb.If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -13419,6 +13394,17 @@
           }
         }
       },
+      "DatabaseAvailableVersionsResponse": {
+        "type": "object",
+        "properties": {
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TargetVersion"
+            }
+          }
+        }
+      },
       "CloudAccount": {
         "type": "object",
         "properties": {
@@ -13537,7 +13523,7 @@
           },
           "paymentMethod": {
             "type": "string",
-            "description": "Optional. The payment method for the subscription. If set to \u2018credit-card\u2019 , \u2018paymentMethodId\u2019 must be defined.",
+            "description": "Optional. The payment method for the subscription. If set to ‘credit-card’ , ‘paymentMethodId’ must be defined.",
             "enum": [
               "credit-card",
               "marketplace"
@@ -13545,7 +13531,7 @@
           },
           "paymentMethodId": {
             "type": "integer",
-            "description": "Optional. The payment method ID you'd like to use for this subscription. Must be a valid payment method ID for this account. Use GET /payment-methods to get a list of payment methods for your account. This value is optional if \u2018paymentMethod\u2019 is \u2018marketplace\u2019, but required if 'paymentMethod' is 'credit-card'.",
+            "description": "Optional. The payment method ID you'd like to use for this subscription. Must be a valid payment method ID for this account. Use GET /payment-methods to get a list of payment methods for your account. This value is optional if ‘paymentMethod’ is ‘marketplace’, but required if 'paymentMethod' is 'credit-card'.",
             "format": "int32"
           },
           "commandType": {
@@ -14907,7 +14893,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "(Pay-as-you-go subscriptions only) Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb. If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
+            "description": "(Pay-as-you-go subscriptions only) Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb. If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -15947,17 +15933,6 @@
         },
         "description": "Database tag"
       },
-      "BdbAvailableVersionsResponse": {
-        "type": "object",
-        "properties": {
-          "targets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TargetVersion"
-            }
-          }
-        }
-      },
       "SubscriptionSpec": {
         "required": [
           "regions"
@@ -16021,6 +15996,31 @@
         },
         "description": "Essentials database backup request message"
       },
+      "DatabaseVersionUpgradeStatus": {
+        "type": "object",
+        "properties": {
+          "databaseId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "targetRedisVersion": {
+            "type": "string"
+          },
+          "progress": {
+            "type": "number",
+            "format": "double"
+          },
+          "upgradeStatus": {
+            "type": "string",
+            "enum": [
+              "in-progress",
+              "in-progress-recovery-pending",
+              "done",
+              "failed"
+            ]
+          }
+        }
+      },
       "DatabaseModuleSpec": {
         "required": [
           "name"
@@ -16063,7 +16063,7 @@
           },
           "paymentMethod": {
             "type": "string",
-            "description": "Optional. The payment method for the subscription. If set to \u2018credit-card\u2019, \u2018paymentMethodId\u2019 must be defined. Default: 'credit-card'",
+            "description": "Optional. The payment method for the subscription. If set to ‘credit-card’, ‘paymentMethodId’ must be defined. Default: 'credit-card'",
             "enum": [
               "credit-card",
               "marketplace"
@@ -16071,7 +16071,7 @@
           },
           "paymentMethodId": {
             "type": "integer",
-            "description": "Optional. A valid payment method ID for this account. Use GET /payment-methods to get a list of all payment methods for your account. This value is optional if \u2018paymentMethod\u2019 is \u2018marketplace\u2019, but required for all other account types.",
+            "description": "Optional. A valid payment method ID for this account. Use GET /payment-methods to get a list of all payment methods for your account. This value is optional if ‘paymentMethod’ is ‘marketplace’, but required for all other account types.",
             "format": "int32"
           },
           "commandType": {
@@ -16282,7 +16282,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb.If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
+            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb.If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -16430,15 +16430,15 @@
           },
           "multipleAvailabilityZones": {
             "type": "boolean",
-            "description": "Optional. Support deployment on multiple availability zones within the selected region. Default: 'false'",
+            "description": "Optional. Support deployment on multiple availability zones within the selected region. Default for Active-Active: matches the region's multi-AZ capability (true on multi-AZ regions, false on non-multi-AZ regions). Default for Pro / single-region: `false`.",
             "example": false
           },
           "preferredAvailabilityZones": {
             "type": "array",
-            "description": "Optional. List the zone ID(s) for your preferred availability zone(s) for the cloud provider and region. If \u2018multipleAvailabilityZones\u2019 is set to 'true', you must list three availability zones. Otherwise, list one availability zone.",
+            "description": "Optional. List the zone ID(s) for your preferred availability zone(s) for the cloud provider and region. If ‘multipleAvailabilityZones’ is set to 'true', you must list three availability zones. Otherwise, list one availability zone.",
             "items": {
               "type": "string",
-              "description": "Optional. List the zone ID(s) for your preferred availability zone(s) for the cloud provider and region. If \u2018multipleAvailabilityZones\u2019 is set to 'true', you must list three availability zones. Otherwise, list one availability zone."
+              "description": "Optional. List the zone ID(s) for your preferred availability zone(s) for the cloud provider and region. If ‘multipleAvailabilityZones’ is set to 'true', you must list three availability zones. Otherwise, list one availability zone."
             }
           },
           "networking": {
@@ -16522,7 +16522,7 @@
             "minimum": 0.1,
             "exclusiveMinimum": false,
             "type": "number",
-            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If \u2018replication\u2019 is 'true', the database\u2019s total memory will be twice as large as the datasetSizeInGb. If \u2018replication\u2019 is false, the database\u2019s total memory will be the datasetSizeInGb value.",
+            "description": "Optional. The maximum amount of data in the dataset for this database in GB. You cannot set both datasetSizeInGb and totalMemoryInGb. If ‘replication’ is 'true', the database’s total memory will be twice as large as the datasetSizeInGb. If ‘replication’ is false, the database’s total memory will be the datasetSizeInGb value.",
             "format": "double",
             "example": 1
           },
@@ -16835,6 +16835,8 @@
               "SUBSCRIPTION_INVALID_REGION_NAME",
               "SUBSCRIPTION_INVALID_REGION_ID",
               "SUBSCRIPTION_BAD_PREFERRED_AZ_SIZE",
+              "SUBSCRIPTION_REGION_DOES_NOT_SUPPORT_MULTI_AZ",
+              "SUBSCRIPTION_AA_NON_MAZ_REGION_NOT_SUPPORTED",
               "SUBSCRIPTION_PREFERRED_AZ_INVALID_VALUE",
               "SUBSCRIPTION_PREFERRED_AZ_MUST_BE_DEFINED_ONCE",
               "SUBSCRIPTION_PREFERRED_AZ_IS_DISABLED",
@@ -17833,7 +17835,7 @@
           },
           "paymentMethod": {
             "type": "string",
-            "description": "Optional. The payment method for the subscription. If set to \u2018credit-card\u2019, \u2018paymentMethodId\u2019 must be defined. Default: 'credit-card'",
+            "description": "Optional. The payment method for the subscription. If set to ‘credit-card’, ‘paymentMethodId’ must be defined. Default: 'credit-card'",
             "enum": [
               "credit-card",
               "marketplace"
@@ -17841,7 +17843,7 @@
           },
           "paymentMethodId": {
             "type": "integer",
-            "description": "Optional. A valid payment method ID for this account. Use GET /payment-methods to get a list of all payment methods for your account. This value is optional if \u2018paymentMethod\u2019 is \u2018marketplace\u2019, but required for all other account types.",
+            "description": "Optional. A valid payment method ID for this account. Use GET /payment-methods to get a list of all payment methods for your account. This value is optional if ‘paymentMethod’ is ‘marketplace’, but required for all other account types.",
             "format": "int32"
           },
           "memoryStorage": {


### PR DESCRIPTION
Clears the drift `scripts/check-spec-drift.sh` reported (added in #132).

Re-fetched the bundled spec from upstream via `check-spec-drift.sh --update`. The only semantic change is **two schema renames** (operations unchanged, 155/155):

- `BdbAvailableVersionsResponse` → `DatabaseAvailableVersionsResponse`
- `BdbVersionUpgradeStatus` → `DatabaseVersionUpgradeStatus`

The rest of the ~118-line diff is one-time `jq` formatting normalization (the file wasn't previously jq-canonical; future refreshes will be clean).

- Route coverage unaffected (no routes added/removed).
- The matching Rust response types keep their names — renaming them to match upstream is a separate, cosmetic breaking change left for an explicit decision.
- `openapi_route_coverage` + `openapi_validation` pass; `check-spec-drift.sh` now reports **no drift**.