### PR TITLE
test(compliance): phase 3 — non-destructive writes; matrix fully classified

### DIFF
--- a/tests/compliance.rs
+++ b/tests/compliance.rs
@@ -30,11 +30,19 @@
 //!
 //! ## Tiers
 //!
-//! All reads (T1 — every GET) are covered: each is `Pass`, `Drift`,
-//! `KnownDiff` (e.g. an endpoint the API 404s/500s), or `Skip` (needs
-//! Active-Active / configured connectivity, or a non-JSON body). The remaining
-//! `Uncovered` operations are the write surface — non-destructive writes (T2)
-//! and the deliberate destructive lifecycle (T3) are added incrementally.
+//! The matrix is fully classified — every one of the 155 operations has a
+//! status, no `Uncovered`:
+//!
+//! - **T1 reads** (every GET): `Pass` / `Drift` / `KnownDiff` (an endpoint the
+//!   API 404s/500s) / `Skip` (needs Active-Active or configured connectivity,
+//!   or a non-JSON body).
+//! - **T2 non-destructive writes**: reversible, self-cleaning lifecycles —
+//!   database tags (Pro + Essentials), an ACL redis-rule, and subscription
+//!   renames — validating request serialization and response shape.
+//! - **T4 destructive / mutating writes** (create/delete of subscriptions,
+//!   databases, cloud accounts; flush; import; upgrade; …) and
+//!   connectivity/Active-Active writes are `Skip`ped pending the deliberate,
+//!   guarded destructive pass.
 
 #![allow(clippy::type_complexity)]
 
@@ -219,6 +227,67 @@ async fn discover(
     extract(&c.get_raw(list_path).await.ok()?)
 }
 
+/// Classify the raw result of a (non-destructive, reversible) write: `Ok` means
+/// the API accepted the request body; the response is then round-tripped into
+/// `T` to validate the response shape. `Err` is a `Fail` (rejected request or
+/// deserialize error).
+async fn record_write<T: DeserializeOwned + Serialize>(
+    m: &mut Matrix,
+    method: &str,
+    spec_path: &str,
+    result: Result<Value, redis_cloud::CloudError>,
+) {
+    let status = match result {
+        Ok(raw) => match roundtrip::<T>(&raw) {
+            Ok(dropped) if dropped.is_empty() => Status::Pass,
+            Ok(dropped) => Status::Drift { dropped },
+            Err(e) => {
+                eprintln!("  [FAIL detail] {method} {spec_path}: {e}");
+                Status::Fail
+            }
+        },
+        Err(e) => {
+            eprintln!("  [FAIL detail] {method} {spec_path}: {e}");
+            Status::Fail
+        }
+    };
+    m.insert(key(method, spec_path), status);
+}
+
+/// Auto-classify every write operation not explicitly wired above as a `Skip`,
+/// with a reason: connectivity/Active-Active ops need resources we don't have;
+/// everything else is a mutating/destructive op deferred to the systematic
+/// write pass. Keeps the matrix fully classified (no `Uncovered` writes).
+fn classify_remaining_writes(m: &mut Matrix) {
+    let conn = [
+        "peering",
+        "private-link",
+        "private-service-connect",
+        "transitGateway",
+        "/regions",
+    ];
+    for (method, path) in spec_operations() {
+        if method == "GET" {
+            continue;
+        }
+        let k = key(&method, &path);
+        if m.contains_key(&k) {
+            continue;
+        }
+        let reason = if conn.iter().any(|p| path.contains(p)) {
+            "needs Active-Active / configured connectivity"
+        } else {
+            "mutating/destructive — deferred to the systematic write pass (T4)"
+        };
+        m.insert(
+            k,
+            Status::Skip {
+                reason: reason.to_string(),
+            },
+        );
+    }
+}
+
 /// [`check_tolerating`] specialized to a tolerated `NotFound` (the common case).
 async fn check_known_404<T: DeserializeOwned + Serialize>(
     m: &mut Matrix,
@@ -384,7 +453,7 @@ async fn api_compliance() {
         AccountSubscriptions, Subscription, SubscriptionMaintenanceWindows, SubscriptionPricings,
     };
     use redis_cloud::types::{
-        CloudTags, DatabaseTrafficStateResponse, TaskStateUpdate, TasksStateUpdate,
+        CloudTag, CloudTags, DatabaseTrafficStateResponse, TaskStateUpdate, TasksStateUpdate,
     };
     use redis_cloud::users::AccountUsers;
 
@@ -875,7 +944,248 @@ async fn api_compliance() {
         "binary (CSV) download, not JSON — covered by the live cost-report test",
     );
 
-    // Fill the rest of the surface with Uncovered (and catch any typo'd path).
+    // -- T2: non-destructive write lifecycles (reversible, self-cleaning) --
+
+    // Database tags (Pro): create -> update one -> overwrite all -> delete.
+    {
+        let base = format!("/subscriptions/{ps}/databases/{pd}/tags");
+        let _ = c.delete_raw(&format!("{base}/rcrs-compliance")).await; // pre-clean
+        let r = c
+            .post_raw(
+                &base,
+                serde_json::json!({"key": "rcrs-compliance", "value": "v1"}),
+            )
+            .await;
+        record_write::<CloudTag>(
+            &mut m,
+            "POST",
+            "/subscriptions/{subscriptionId}/databases/{databaseId}/tags",
+            r,
+        )
+        .await;
+        let r = c
+            .put_raw(
+                &format!("{base}/rcrs-compliance"),
+                serde_json::json!({"value": "v2"}),
+            )
+            .await;
+        record_write::<CloudTag>(
+            &mut m,
+            "PUT",
+            "/subscriptions/{subscriptionId}/databases/{databaseId}/tags/{tagKey}",
+            r,
+        )
+        .await;
+        let r = c
+            .put_raw(
+                &base,
+                serde_json::json!({"tags": [{"key": "rcrs-compliance", "value": "v3"}]}),
+            )
+            .await;
+        record_write::<CloudTags>(
+            &mut m,
+            "PUT",
+            "/subscriptions/{subscriptionId}/databases/{databaseId}/tags",
+            r,
+        )
+        .await;
+        let r = c.delete_raw(&format!("{base}/rcrs-compliance")).await;
+        record_write::<Value>(
+            &mut m,
+            "DELETE",
+            "/subscriptions/{subscriptionId}/databases/{databaseId}/tags/{tagKey}",
+            r,
+        )
+        .await;
+    }
+
+    // Database tags (Essentials): same lifecycle.
+    {
+        let base = format!("/fixed/subscriptions/{es}/databases/{ed}/tags");
+        let _ = c.delete_raw(&format!("{base}/rcrs-compliance")).await;
+        let r = c
+            .post_raw(
+                &base,
+                serde_json::json!({"key": "rcrs-compliance", "value": "v1"}),
+            )
+            .await;
+        record_write::<CloudTag>(
+            &mut m,
+            "POST",
+            "/fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags",
+            r,
+        )
+        .await;
+        let r = c
+            .put_raw(
+                &format!("{base}/rcrs-compliance"),
+                serde_json::json!({"value": "v2"}),
+            )
+            .await;
+        record_write::<CloudTag>(
+            &mut m,
+            "PUT",
+            "/fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags/{tagKey}",
+            r,
+        )
+        .await;
+        let r = c
+            .put_raw(
+                &base,
+                serde_json::json!({"tags": [{"key": "rcrs-compliance", "value": "v3"}]}),
+            )
+            .await;
+        record_write::<CloudTags>(
+            &mut m,
+            "PUT",
+            "/fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags",
+            r,
+        )
+        .await;
+        let r = c.delete_raw(&format!("{base}/rcrs-compliance")).await;
+        record_write::<Value>(
+            &mut m,
+            "DELETE",
+            "/fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags/{tagKey}",
+            r,
+        )
+        .await;
+    }
+
+    // ACL redis rule (account-global): create -> update -> delete.
+    {
+        const RULE: &str = "rcrs-compliance-rule";
+        let find = |v: &Value| -> Option<String> {
+            v["redisRules"]
+                .as_array()?
+                .iter()
+                .find(|x| x["name"].as_str() == Some(RULE))
+                .and_then(|x| x["id"].as_i64())
+                .map(|n| n.to_string())
+        };
+        // pre-clean a stray rule from an interrupted prior run
+        if let Some(id) = discover(&c, "/acl/redisRules", find).await {
+            let _ = c.delete_raw(&format!("/acl/redisRules/{id}")).await;
+        }
+        let r = c
+            .post_raw(
+                "/acl/redisRules",
+                serde_json::json!({"name": RULE, "redisRule": "+@read ~*"}),
+            )
+            .await;
+        record_write::<TaskStateUpdate>(&mut m, "POST", "/acl/redisRules", r).await;
+        // poll for the created rule id (creation is async)
+        let mut id = None;
+        for _ in 0..15 {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            if let Some(found) = discover(&c, "/acl/redisRules", find).await {
+                id = Some(found);
+                break;
+            }
+        }
+        if let Some(id) = id {
+            let r = c
+                .put_raw(
+                    &format!("/acl/redisRules/{id}"),
+                    serde_json::json!({"name": RULE, "redisRule": "+@read +@write ~*"}),
+                )
+                .await;
+            record_write::<TaskStateUpdate>(&mut m, "PUT", "/acl/redisRules/{aclRedisRuleId}", r)
+                .await;
+            let r = c.delete_raw(&format!("/acl/redisRules/{id}")).await;
+            record_write::<TaskStateUpdate>(
+                &mut m,
+                "DELETE",
+                "/acl/redisRules/{aclRedisRuleId}",
+                r,
+            )
+            .await;
+            // The delete is async; wait until the rule is actually gone so we
+            // don't leave a stray account-global rule behind.
+            for _ in 0..15 {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                if discover(&c, "/acl/redisRules", find).await.is_none() {
+                    break;
+                }
+            }
+        } else {
+            skip(
+                &mut m,
+                "PUT",
+                "/acl/redisRules/{aclRedisRuleId}",
+                "created rule did not appear in time",
+            );
+            skip(
+                &mut m,
+                "DELETE",
+                "/acl/redisRules/{aclRedisRuleId}",
+                "created rule did not appear in time",
+            );
+        }
+    }
+
+    // Subscription update (Pro): rename, then restore.
+    if let Some(orig) = c
+        .get_raw(&format!("/subscriptions/{ps}"))
+        .await
+        .ok()
+        .and_then(|v| v["name"].as_str().map(String::from))
+    {
+        let r = c
+            .put_raw(
+                &format!("/subscriptions/{ps}"),
+                serde_json::json!({"name": format!("{orig}-rcrs-compliance")}),
+            )
+            .await;
+        record_write::<TaskStateUpdate>(&mut m, "PUT", "/subscriptions/{subscriptionId}", r).await;
+        let _ = c
+            .put_raw(
+                &format!("/subscriptions/{ps}"),
+                serde_json::json!({"name": orig}),
+            )
+            .await; // restore
+    } else {
+        skip(
+            &mut m,
+            "PUT",
+            "/subscriptions/{subscriptionId}",
+            "could not read current name to rename/restore",
+        );
+    }
+
+    // Subscription update (Essentials): rename, then restore.
+    if let Some(orig) = c
+        .get_raw(&format!("/fixed/subscriptions/{es}"))
+        .await
+        .ok()
+        .and_then(|v| v["name"].as_str().map(String::from))
+    {
+        let r = c
+            .put_raw(
+                &format!("/fixed/subscriptions/{es}"),
+                serde_json::json!({"name": format!("{orig}-rcrs-compliance")}),
+            )
+            .await;
+        record_write::<TaskStateUpdate>(&mut m, "PUT", "/fixed/subscriptions/{subscriptionId}", r)
+            .await;
+        let _ = c
+            .put_raw(
+                &format!("/fixed/subscriptions/{es}"),
+                serde_json::json!({"name": orig}),
+            )
+            .await; // restore
+    } else {
+        skip(
+            &mut m,
+            "PUT",
+            "/fixed/subscriptions/{subscriptionId}",
+            "could not read current name to rename/restore",
+        );
+    }
+
+    // Classify every remaining (unwired) write as Skip, then fill reads with
+    // Uncovered (and catch any typo'd path).
+    classify_remaining_writes(&mut m);
     reconcile_with_spec(&mut m);
     print_report(&m);
 

--- a/tests/fixtures/compliance_baseline.json
+++ b/tests/fixtures/compliance_baseline.json
@@ -1,75 +1,96 @@
 {
   "DELETE /acl/redisRules/{aclRedisRuleId}": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "DELETE /acl/roles/{aclRoleId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "DELETE /acl/users/{aclUserId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "DELETE /cloud-accounts/{cloudAccountId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "DELETE /fixed/subscriptions/{subscriptionId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "DELETE /fixed/subscriptions/{subscriptionId}/databases/{databaseId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "DELETE /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags/{tagKey}": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "DELETE /subscriptions/{subscriptionId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "DELETE /subscriptions/{subscriptionId}/databases/{databaseId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "DELETE /subscriptions/{subscriptionId}/databases/{databaseId}/tags/{tagKey}": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "DELETE /subscriptions/{subscriptionId}/peerings/{peeringId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/private-link": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/private-link/principals": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/private-service-connect": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/private-service-connect/{pscServiceId}/endpoints/{endpointId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/regions": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/regions/peerings/{peeringId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/regions/{regionId}/private-link": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/regions/{regionId}/private-link/principals": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/regions/{regionId}/private-service-connect": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/regions/{regionId}/private-service-connect/{pscServiceId}/endpoints/{endpointId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/regions/{regionId}/transitGateways/{TgwId}/attachment": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /subscriptions/{subscriptionId}/transitGateways/{TgwId}/attachment": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "DELETE /users/{userId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "GET /": {
     "status": "pass"
@@ -336,189 +357,241 @@
     "status": "pass"
   },
   "POST /acl/redisRules": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "POST /acl/roles": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /acl/users": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /cloud-accounts": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /cost-report": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /fixed/subscriptions": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /fixed/subscriptions/{subscriptionId}/databases": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/backup": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/import": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "POST /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/traffic/resume": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/upgrade": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /subscriptions": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /subscriptions/{subscriptionId}/databases": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /subscriptions/{subscriptionId}/databases/{databaseId}/backup": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /subscriptions/{subscriptionId}/databases/{databaseId}/import": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /subscriptions/{subscriptionId}/databases/{databaseId}/tags": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "POST /subscriptions/{subscriptionId}/databases/{databaseId}/traffic/resume": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /subscriptions/{subscriptionId}/databases/{databaseId}/upgrade": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "POST /subscriptions/{subscriptionId}/peerings": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/private-link": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/private-link/connections/disassociate": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/private-link/principals": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/private-service-connect": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/private-service-connect/{pscServiceId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/regions": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/regions/peerings": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/regions/{regionId}/private-link": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/regions/{regionId}/private-link/connections/disassociate": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/regions/{regionId}/private-link/principals": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/regions/{regionId}/private-service-connect": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/regions/{regionId}/private-service-connect/{pscServiceId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/regions/{regionId}/transitGateways/{TgwId}/attachment": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "POST /subscriptions/{subscriptionId}/transitGateways/{TgwId}/attachment": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /acl/redisRules/{aclRedisRuleId}": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "PUT /acl/roles/{aclRoleId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "PUT /acl/users/{aclUserId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "PUT /cloud-accounts/{cloudAccountId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "PUT /fixed/subscriptions/{subscriptionId}": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "PUT /fixed/subscriptions/{subscriptionId}/databases/{databaseId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "PUT /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "PUT /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/tags/{tagKey}": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "PUT /subscriptions/{subscriptionId}": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "PUT /subscriptions/{subscriptionId}/cidr": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "PUT /subscriptions/{subscriptionId}/databases/{databaseId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "PUT /subscriptions/{subscriptionId}/databases/{databaseId}/flush": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "PUT /subscriptions/{subscriptionId}/databases/{databaseId}/regions": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /subscriptions/{subscriptionId}/databases/{databaseId}/tags": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "PUT /subscriptions/{subscriptionId}/databases/{databaseId}/tags/{tagKey}": {
-    "status": "uncovered"
+    "status": "pass"
   },
   "PUT /subscriptions/{subscriptionId}/maintenance-windows": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "PUT /subscriptions/{subscriptionId}/peerings/{peeringId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /subscriptions/{subscriptionId}/private-service-connect/{pscServiceId}/endpoints/{endpointId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /subscriptions/{subscriptionId}/regions/peerings/{peeringId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /subscriptions/{subscriptionId}/regions/{regionId}/private-service-connect/{pscServiceId}/endpoints/{endpointId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /subscriptions/{subscriptionId}/regions/{regionId}/transitGateways/invitations/{tgwInvitationId}/accept": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /subscriptions/{subscriptionId}/regions/{regionId}/transitGateways/invitations/{tgwInvitationId}/reject": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /subscriptions/{subscriptionId}/regions/{regionId}/transitGateways/{TgwId}/attachment": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /subscriptions/{subscriptionId}/resource-tags": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   },
   "PUT /subscriptions/{subscriptionId}/transitGateways/invitations/{tgwInvitationId}/accept": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /subscriptions/{subscriptionId}/transitGateways/invitations/{tgwInvitationId}/reject": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /subscriptions/{subscriptionId}/transitGateways/{TgwId}/attachment": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "needs Active-Active / configured connectivity"
   },
   "PUT /users/{userId}": {
-    "status": "uncovered"
+    "status": "skip",
+    "reason": "mutating/destructive — deferred to the systematic write pass (T4)"
   }
 }


### PR DESCRIPTION
Wires reversible, self-cleaning **write** lifecycles into the compliance harness and auto-classifies the remaining writes — so **all 155 operations now have a status (zero `Uncovered`)**.

## Write lifecycles (T2 — validates request serialization + response shape)
- **Database tags** (Pro + Essentials): `POST` create → `PUT` update-one → `PUT` overwrite-all → `DELETE` (delete doubles as cleanup; pre-cleans stray tags)
- **ACL redis rule**: `POST` → poll for id → `PUT` → `DELETE`, then poll until the async delete completes (no account-global rule left behind)
- **Subscription rename** (Pro + Essentials): `PUT` rename → restore

`record_write` classifies a write: `Ok(resp)` round-trips into the response type (Pass/Drift), `Err` is a Fail (rejected request / deserialize error). `classify_remaining_writes` marks every unwired write as `Skip` — connectivity/Active-Active as needs-setup, the rest as mutating/destructive deferred to the guarded **T4** pass.

## Re-blessed baseline (live)
```
155 operations: PASS=56 DRIFT=8 FAIL=0 KNOWN-DIFF=6 SKIP=85 UNCOVERED=0
```
The 13 non-destructive write ops **all PASS** — no client bugs in request serialization or response handling. Resources are restored and cleaned up after each run (verified: subscription names restored, no stray tags or ACL rules).

## State of the harness
The compliance matrix is now complete across reads + non-destructive writes. What's left is **T4** — the deliberate, guarded destructive lifecycle (create/delete subscriptions & databases) — and the existing **#140** drift backlog (8 tracked field drops) for the batch fix.

`fmt` + `clippy` clean; gate passes against the re-blessed baseline.