### PR TITLE
fix(models): batch-fix compliance drift — capture dropped response fields (#140)

### DIFF
--- a/src/fixed/databases.rs
+++ b/src/fixed/databases.rs
@@ -280,6 +280,7 @@ pub struct FixedDatabaseBackupRequest {
 
 /// Optional. Redis advanced capabilities (also known as modules) to be provisioned in the database. Use GET /database-modules to get a list of available advanced capabilities.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DatabaseModuleSpec {
     /// Redis advanced capability name. Use GET /database-modules for a list of available capabilities.
     pub name: String,
@@ -292,6 +293,22 @@ pub struct DatabaseModuleSpec {
     /// side and failed to deserialize real responses.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<Value>,
+
+    /// Module id (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<i32>,
+
+    /// Human-readable capability name, e.g. `"Search and query"` (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capability_name: Option<String>,
+
+    /// Module version (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// Module description (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Optional. Changes Replica Of (also known as Active-Passive) configuration details.
@@ -330,12 +347,21 @@ pub struct DatabaseBackupStatus {
 
 /// Optional. Changes Redis database alert details.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DatabaseAlertSpec {
     /// Alert type. Available options depend on Plan type. See [Configure alerts](https://redis.io/docs/latest/operate/rc/databases/monitor-performance/#configure-metric-alerts) for more information.
     pub name: String,
 
     /// Value over which an alert will be sent. Default values and range depend on the alert type. See [Configure alerts](https://redis.io/docs/latest/operate/rc/databases/monitor-performance/#configure-metric-alerts) for more information.
     pub value: i32,
+
+    /// Alert id (response only). A composite string such as `"<dbId>-<n>"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// Default threshold value for this alert type (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_value: Option<i32>,
 }
 
 /// Security configuration returned within a [`FixedDatabase`] read response
@@ -362,6 +388,10 @@ pub struct FixedDatabaseSecurity {
     /// Source IP addresses / CIDR blocks allowed to connect.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_ips: Option<Vec<String>>,
+
+    /// Database password (masked in responses).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
 }
 
 /// A single regex rule within a fixed database's clustering policy.
@@ -524,6 +554,10 @@ pub struct FixedDatabase {
     /// Additional dynamic endpoints. See [`DynamicEndpoints`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dynamic_endpoints: Option<DynamicEndpoints>,
+
+    /// Replica-as-source endpoints (`public`/`private`), returned on reads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replica_as_source_endpoints: Option<DynamicEndpoints>,
 
     /// Security configuration (TLS, source IPs, authentication).
     ///

--- a/src/fixed/subscriptions.rs
+++ b/src/fixed/subscriptions.rs
@@ -71,6 +71,11 @@ pub struct RedisVersions {
 /// Redis list of Essentials subscriptions plans
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FixedSubscriptionsPlans {
+    /// The available Essentials plans. The OpenAPI schema omits this array, but
+    /// the live `GET /fixed/plans` responses include it (see #140).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plans: Option<Vec<FixedSubscriptionsPlan>>,
+
     /// HATEOAS links
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Vec<Link>>,
@@ -179,7 +184,10 @@ pub struct FixedSubscriptionsPlan {
     pub maximum_throughput: Option<i32>,
 
     /// Maximum monthly bandwidth, in GB.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    ///
+    /// Wire field is `maximumBandwidthGB` (capital GB); `rename_all = "camelCase"`
+    /// would produce `maximumBandwidthGb` and drop the value (#108 casing pitfall).
+    #[serde(rename = "maximumBandwidthGB", skip_serializing_if = "Option::is_none")]
     pub maximum_bandwidth_gb: Option<i32>,
 
     /// Availability tier (e.g. `"Single-zone"`, `"Multi-zone"`).

--- a/src/flexible/databases.rs
+++ b/src/flexible/databases.rs
@@ -197,7 +197,15 @@ pub struct CrdbFlushRequest {
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseCertificate {
     /// An X.509 PEM (base64) encoded server certificate with new line characters replaced by '\n'.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    ///
+    /// Wire field is `publicCertificatePEMString` (capital PEM), so an explicit
+    /// rename is needed — `rename_all = "camelCase"` would produce
+    /// `publicCertificatePemString` and drop the real value (the #108 casing
+    /// pitfall).
+    #[serde(
+        rename = "publicCertificatePEMString",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub public_certificate_pem_string: Option<String>,
 }
 
@@ -448,6 +456,7 @@ pub struct DatabaseBackupConfig {
 
 /// Optional. Redis advanced capabilities (also known as modules) to be provisioned in the database. Use GET /database-modules to get a list of available advanced capabilities.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DatabaseModuleSpec {
     /// Redis advanced capability name. Use GET /database-modules for a list of available capabilities.
     pub name: String,
@@ -460,6 +469,22 @@ pub struct DatabaseModuleSpec {
     /// side and failed to deserialize real responses.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<Value>,
+
+    /// Module id (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<i32>,
+
+    /// Human-readable capability name, e.g. `"Search and query"` (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capability_name: Option<String>,
+
+    /// Module version (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// Module description (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Optional. Changes Replica Of (also known as Active-Passive) configuration details.
@@ -807,6 +832,11 @@ pub struct Database {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public_endpoint: Option<String>,
 
+    /// Replica-as-source endpoints (`public`/`private`), returned on reads.
+    /// Kept as a [`Value`] (the flexible model has no nested endpoints struct).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replica_as_source_endpoints: Option<Value>,
+
     /// TCP port on which the database is available
     #[serde(skip_serializing_if = "Option::is_none")]
     pub port: Option<i32>,
@@ -950,12 +980,21 @@ pub struct Database {
 
 /// Optional. Changes Redis database alert details.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DatabaseAlertSpec {
     /// Alert type. Available options depend on Plan type. See [Configure alerts](https://redis.io/docs/latest/operate/rc/databases/monitor-performance/#configure-metric-alerts) for more information.
     pub name: String,
 
     /// Value over which an alert will be sent. Default values and range depend on the alert type. See [Configure alerts](https://redis.io/docs/latest/operate/rc/databases/monitor-performance/#configure-metric-alerts) for more information.
     pub value: i32,
+
+    /// Alert id (response only). A composite string such as `"<dbId>-<n>"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// Default threshold value for this alert type (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_value: Option<i32>,
 }
 
 /// Request structure for creating a new Pro database

--- a/tests/cloud_fixture_validation.rs
+++ b/tests/cloud_fixture_validation.rs
@@ -45,6 +45,17 @@ fn fixed_databases_response_deserializes() {
         modules[1].parameters,
         Some(serde_json::json!([{ "name": "error_rate", "value": "0.01" }]))
     );
+    // #140: module response metadata is now captured (was dropped).
+    assert_eq!(modules[0].id, Some(333333));
+    assert_eq!(modules[0].capability_name.as_deref(), Some("Time series"));
+    assert_eq!(modules[0].version.as_deref(), Some("8.2.9"));
+
+    // #140: alert defaultValue is now captured.
+    let alerts = db.alerts.expect("alerts should deserialize");
+    assert_eq!(alerts[0].default_value, Some(80));
+
+    // #140: replicaAsSourceEndpoints is now captured (was dropped).
+    assert!(db.replica_as_source_endpoints.is_some());
 
     // #121: the nested security/clustering/backup objects are now captured
     // instead of silently dropped.

--- a/tests/databases_tests.rs
+++ b/tests/databases_tests.rs
@@ -572,10 +572,18 @@ async fn test_create_database_with_modules() {
             redis_cloud::databases::DatabaseModuleSpec {
                 name: "RediSearch".to_string(),
                 parameters: None,
+                id: None,
+                capability_name: None,
+                version: None,
+                description: None,
             },
             redis_cloud::databases::DatabaseModuleSpec {
                 name: "RedisJSON".to_string(),
                 parameters: None,
+                id: None,
+                capability_name: None,
+                version: None,
+                description: None,
             },
         ]),
         sharding_type: None,
@@ -647,6 +655,8 @@ async fn test_create_database_with_alerts() {
         alerts: Some(vec![redis_cloud::databases::DatabaseAlertSpec {
             name: "dataset-size".to_string(),
             value: 80,
+            id: None,
+            default_value: None,
         }]),
         modules: None,
         sharding_type: None,

--- a/tests/fixed_subscriptions_tests.rs
+++ b/tests/fixed_subscriptions_tests.rs
@@ -14,7 +14,7 @@ async fn test_get_all_fixed_subscriptions_plans() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "plans": [
                 {
-                    "id": "plan-1",
+                    "id": 1,
                     "name": "Cache 250MB",
                     "size": 250,
                     "sizeMeasurementUnit": "MB",
@@ -22,7 +22,7 @@ async fn test_get_all_fixed_subscriptions_plans() {
                     "region": "us-east-1"
                 },
                 {
-                    "id": "plan-2",
+                    "id": 2,
                     "name": "Cache 1GB",
                     "size": 1,
                     "sizeMeasurementUnit": "GB",
@@ -44,9 +44,11 @@ async fn test_get_all_fixed_subscriptions_plans() {
     let handler = FixedSubscriptionsHandler::new(client);
     let result = handler.list_plans(None, None).await.unwrap();
 
-    // Verify the response was successfully parsed
-    // Note: plans data would need typed fields added to FixedSubscriptionsPlans to be accessible
-    assert!(result.links.is_none()); // No links in the mock response
+    // #140: the `plans` array is now captured (was previously dropped).
+    let plans = result.plans.expect("plans should deserialize");
+    assert_eq!(plans.len(), 2);
+    assert_eq!(plans[0].id, Some(1));
+    assert_eq!(plans[0].name.as_deref(), Some("Cache 250MB"));
 }
 
 #[tokio::test]
@@ -64,7 +66,7 @@ async fn test_get_fixed_subscriptions_plans_by_subscription_id() {
             },
             "plans": [
                 {
-                    "id": "plan-1",
+                    "id": 1,
                     "name": "Current Plan",
                     "size": 500,
                     "price": 15
@@ -84,9 +86,10 @@ async fn test_get_fixed_subscriptions_plans_by_subscription_id() {
     let handler = FixedSubscriptionsHandler::new(client);
     let result = handler.get_plans_by_subscription_id(123).await.unwrap();
 
-    // Verify the response was successfully parsed
-    // Note: subscription and plans data would need typed fields to be accessible
-    assert!(result.links.is_none()); // No links in the mock response
+    // #140: the `plans` array is now captured.
+    let plans = result.plans.expect("plans should deserialize");
+    assert_eq!(plans.len(), 1);
+    assert_eq!(plans[0].id, Some(1));
 }
 
 #[tokio::test]

--- a/tests/fixtures/cloud/samples/pro_database.json
+++ b/tests/fixtures/cloud/samples/pro_database.json
@@ -39,7 +39,7 @@
   "modules": [],
   "throughputMeasurement": { "by": "operations-per-second", "value": 3000 },
   "alerts": [
-    { "id": 1, "name": "dataset-size", "value": 80, "defaultValue": 80 }
+    { "id": "222333-1", "name": "dataset-size", "value": 80, "defaultValue": 80 }
   ],
   "backup": {
     "destination": "s3://example-bucket/backups",

--- a/tests/fixtures/compliance_baseline.json
+++ b/tests/fixtures/compliance_baseline.json
@@ -124,22 +124,13 @@
     "status": "pass"
   },
   "GET /fixed/plans": {
-    "status": "drift",
-    "dropped": [
-      "plans"
-    ]
+    "status": "pass"
   },
   "GET /fixed/plans/subscriptions/{subscriptionId}": {
-    "status": "drift",
-    "dropped": [
-      "plans"
-    ]
+    "status": "pass"
   },
   "GET /fixed/plans/{planId}": {
-    "status": "drift",
-    "dropped": [
-      "maximumBandwidthGB"
-    ]
+    "status": "pass"
   },
   "GET /fixed/redis-versions": {
     "status": "known-diff",
@@ -152,27 +143,10 @@
     "status": "pass"
   },
   "GET /fixed/subscriptions/{subscriptionId}/databases": {
-    "status": "drift",
-    "dropped": [
-      "subscription.databases[0].alerts[0].defaultValue",
-      "subscription.databases[0].modules[0].capabilityName",
-      "subscription.databases[0].modules[0].description",
-      "subscription.databases[0].modules[0].id",
-      "subscription.databases[0].modules[0].version",
-      "subscription.databases[0].replicaAsSourceEndpoints"
-    ]
+    "status": "pass"
   },
   "GET /fixed/subscriptions/{subscriptionId}/databases/{databaseId}": {
-    "status": "drift",
-    "dropped": [
-      "alerts[0].defaultValue",
-      "modules[0].capabilityName",
-      "modules[0].description",
-      "modules[0].id",
-      "modules[0].version",
-      "replicaAsSourceEndpoints",
-      "security.password"
-    ]
+    "status": "pass"
   },
   "GET /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/available-target-versions": {
     "status": "pass"
@@ -225,20 +199,10 @@
     "status": "pass"
   },
   "GET /subscriptions/{subscriptionId}/databases": {
-    "status": "drift",
-    "dropped": [
-      "subscription[0].databases[0].alerts[0].defaultValue",
-      "subscription[0].databases[0].alerts[0].id",
-      "subscription[0].databases[0].replicaAsSourceEndpoints"
-    ]
+    "status": "pass"
   },
   "GET /subscriptions/{subscriptionId}/databases/{databaseId}": {
-    "status": "drift",
-    "dropped": [
-      "alerts[0].defaultValue",
-      "alerts[0].id",
-      "replicaAsSourceEndpoints"
-    ]
+    "status": "pass"
   },
   "GET /subscriptions/{subscriptionId}/databases/{databaseId}/available-target-versions": {
     "status": "pass"
@@ -247,10 +211,7 @@
     "status": "pass"
   },
   "GET /subscriptions/{subscriptionId}/databases/{databaseId}/certificate": {
-    "status": "drift",
-    "dropped": [
-      "publicCertificatePEMString"
-    ]
+    "status": "pass"
   },
   "GET /subscriptions/{subscriptionId}/databases/{databaseId}/import": {
     "status": "pass"


### PR DESCRIPTION
Closes #140. Knocks out the full drift backlog the compliance harness accumulated — all **additive** field captures. The 8 baseline `DRIFT`s become `PASS`:
```
compliance matrix: PASS=64  DRIFT=0  FAIL=0  KNOWN-DIFF=6  SKIP=85  UNCOVERED=0
```

## Fixes
- **`DatabaseModuleSpec`** (fixed + flexible): add `id`, `capabilityName`, `version`, `description` (+ `rename_all = camelCase`) — module response metadata was dropped.
- **`DatabaseAlertSpec`** (fixed + flexible): add `id` (a **String** — it's a composite like `"<dbId>-<n>"`, not an int) and `defaultValue`.
- **`FixedDatabaseSecurity`**: add `password`.
- **`FixedDatabase` / `Database`**: add `replicaAsSourceEndpoints`.
- **`DatabaseCertificate`**: casing fix — `publicCertificatePEMString` needs an explicit rename (camelCase produced `publicCertificatePemString` and dropped the cert).
- **`FixedSubscriptionsPlans`**: add the `plans` array — `list_plans()` was returning no plans (CloudTags-class drop).
- **`FixedSubscriptionsPlan`**: casing fix — `maximumBandwidthGB` needs an explicit rename.

## Tests
- Updated the fixed-plans wiremock mocks (they used fake string plan ids that only "worked" while plans were dropped) and now assert the captured `plans`.
- Added CI-level fixture assertions for the new fields (module metadata, alert `defaultValue`, `replicaAsSourceEndpoints`).
- Re-blessed `compliance_baseline.json`.

The find→fix→re-bless loop end to end: the harness flagged the drift, these are the fixes, and the baseline now shows zero drift.

`fmt` + `clippy` clean; 99 workspace tests pass; compliance gate green.